### PR TITLE
Milestone 3 — Subnet overlap detection

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -305,6 +305,7 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .muted{color:var(--muted)}
 .danger{color:var(--danger)}
 .success{color:var(--success)}
+.warning{color:var(--warn)}
 .badge{
   display:inline-block;
   padding:3px 10px;

--- a/Simple-PHP-IPAM/import_csv.php
+++ b/Simple-PHP-IPAM/import_csv.php
@@ -116,6 +116,7 @@ function analyze_import(PDO $db, array $wiz): array
     foreach ($existingSubnets as $s) $existingByCidr[(string)$s['cidr']] = (int)$s['id'];
 
     $seenCsvKeys = []; // detect duplicate rows in CSV after resolution
+    $overlapCache = []; // cidr => overlap result, avoid redundant DB queries per unique CIDR
     $maxProcessRows = 200000;
 
     while (!feof($fh) && $rowNum < $maxProcessRows) {
@@ -300,6 +301,16 @@ function analyze_import(PDO $db, array $wiz): array
             $entry['display_action'] = 'create_with_subnet';
             $entry['reason'] = 'Will create subnet and address';
             $summary['create']++;
+
+            // Check if the new subnet would nest inside or contain existing subnets
+            $cidrToCheck = (string)$entry['resolved_cidr'];
+            if (!isset($overlapCache[$cidrToCheck])) {
+                $overlapCache[$cidrToCheck] = detect_subnet_overlaps($db, $cidrToCheck);
+            }
+            $ov = $overlapCache[$cidrToCheck];
+            if (!empty($ov['parents']) || !empty($ov['children'])) {
+                $entry['subnet_overlap_warning'] = $ov;
+            }
         } else {
             if ($entry['existed_at_analysis']) {
                 if ($dupMode === 'skip') {
@@ -626,12 +637,23 @@ if ($step === 3) {
           <tbody>
           <?php foreach ($rows as $r): ?>
             <?php $cls = action_class((string)($r['display_action'] ?? $r['final_action'] ?? '')); ?>
+            <?php $ov = $r['subnet_overlap_warning'] ?? null; ?>
             <tr>
               <td><?= e((string)$r['row_num']) ?></td>
               <td><?= e((string)($r['ip'] ?? $r['ip_raw'] ?? '')) ?></td>
               <td><span class="<?= e($cls) ?>"><?= e((string)($r['display_action'] ?? $r['final_action'] ?? '')) ?></span></td>
               <td><?= e((string)($r['resolved_subnet_id'] ?? $r['resolved_cidr'] ?? '')) ?></td>
-              <td><?= e((string)($r['reason'] ?? '')) ?></td>
+              <td>
+                <?= e((string)($r['reason'] ?? '')) ?>
+                <?php if ($ov): ?>
+                  <?php
+                    $ovParts = [];
+                    if (!empty($ov['parents'])) $ovParts[] = 'nested inside: ' . implode(', ', $ov['parents']);
+                    if (!empty($ov['children'])) $ovParts[] = 'parent of: ' . implode(', ', $ov['children']);
+                  ?>
+                  <br><span class="warning">Hierarchy: <?= e(implode('; ', $ovParts)) ?></span>
+                <?php endif; ?>
+              </td>
             </tr>
           <?php endforeach; ?>
           </tbody>

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -685,6 +685,68 @@ function cidr_from_ip_and_prefix(array $normIp, int $prefix): string
     return inet_ntop($netBin) . '/' . $prefix;
 }
 
+/* ---------------- Subnet overlap detection ---------------- */
+
+/**
+ * Detect parent/child relationships for a proposed CIDR against existing subnets.
+ *
+ * In valid CIDR math, two subnets of different prefix lengths either have a strict
+ * parent/child containment relationship or are completely disjoint — partial overlap
+ * is impossible. Exact duplicates are prevented by the DB UNIQUE constraint on cidr.
+ *
+ * Returns:
+ *   'parents'  — existing subnets that contain the proposed CIDR (new is a child)
+ *   'children' — existing subnets that fall inside the proposed CIDR (new is a parent)
+ *
+ * Both are informational warnings; neither case blocks the operation, as hierarchical
+ * nesting is the expected use-case. Pass $excludeId when checking an update so the
+ * subnet being edited is not compared against itself.
+ *
+ * @return array{parents: list<string>, children: list<string>}
+ */
+function detect_subnet_overlaps(PDO $db, string $cidr, ?int $excludeId = null): array
+{
+    $p = parse_cidr($cidr);
+    if (!$p) return ['parents' => [], 'children' => []];
+
+    $ver    = (int)$p['version'];
+    $prefix = (int)$p['prefix'];
+    $netBin = (string)$p['net_bin'];
+
+    $sql    = "SELECT id, cidr, prefix, network_bin FROM subnets WHERE ip_version = :v";
+    $params = [':v' => $ver];
+    if ($excludeId !== null) {
+        $sql .= " AND id != :excl";
+        $params[':excl'] = $excludeId;
+    }
+    $st = $db->prepare($sql);
+    $st->execute($params);
+    $rows = $st->fetchAll();
+
+    $parents  = [];
+    $children = [];
+
+    foreach ($rows as $row) {
+        $rowPrefix = (int)$row['prefix'];
+        $rowNetBin = (string)$row['network_bin'];
+
+        if ($rowPrefix < $prefix) {
+            // Candidate parent: does the existing broader subnet contain our new one?
+            if (hash_equals(apply_prefix_mask($netBin, $rowPrefix), $rowNetBin)) {
+                $parents[] = (string)$row['cidr'];
+            }
+        } elseif ($rowPrefix > $prefix) {
+            // Candidate child: does our new broader subnet contain the existing one?
+            if (hash_equals(apply_prefix_mask($rowNetBin, $prefix), $netBin)) {
+                $children[] = (string)$row['cidr'];
+            }
+        }
+        // Same prefix: exact duplicate — handled by DB UNIQUE constraint on cidr
+    }
+
+    return ['parents' => $parents, 'children' => $children];
+}
+
 /* ---------------- UI helpers ---------------- */
 
 function page_header(string $title): void

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -7,6 +7,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
 
 $err = '';
 $msg = '';
+$warn = '';
+
+// Consume any flash warning left by a create redirect
+if (!empty($_SESSION['ipam_flash_warn'])) {
+    $warn = (string)$_SESSION['ipam_flash_warn'];
+    unset($_SESSION['ipam_flash_warn']);
+}
 
 $st = $db->prepare("SELECT id, name FROM sites ORDER BY name ASC");
 $st->execute();
@@ -32,6 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $err = 'Invalid CIDR. Examples: 192.168.1.0/24 or 2001:db8::/64';
         } else {
             $normalized = $p['network'] . '/' . $p['prefix'];
+            $overlaps = detect_subnet_overlaps($db, $normalized);
             try {
                 $st = $db->prepare("INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id)
                                     VALUES (:cidr,:ver,:net,:nb,:pre,:d,:site)");
@@ -45,6 +53,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     ':site' => $siteId,
                 ]);
                 audit($db, 'subnet.create', 'subnet', (int)$db->lastInsertId(), $normalized);
+                if (!empty($overlaps['parents']) || !empty($overlaps['children'])) {
+                    $_SESSION['ipam_flash_warn'] = subnet_overlap_warning_text($overlaps);
+                }
                 header('Location: subnets.php');
                 exit;
             } catch (PDOException $e) {
@@ -64,6 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $err = 'Invalid CIDR.';
         } else {
             $normalized = $p['network'] . '/' . $p['prefix'];
+            $overlaps = detect_subnet_overlaps($db, $normalized, $id);
             try {
                 $st = $db->prepare("UPDATE subnets
                                     SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site
@@ -80,6 +92,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ]);
                 audit($db, 'subnet.update', 'subnet', $id, $normalized);
                 $msg = 'Subnet updated.';
+                if (!empty($overlaps['parents']) || !empty($overlaps['children'])) {
+                    $warn = subnet_overlap_warning_text($overlaps);
+                }
             } catch (PDOException $e) {
                 $err = 'Could not update subnet (duplicate?).';
             }
@@ -273,6 +288,20 @@ function ipv4_unassigned_summary_local(PDO $db): array
     return $out;
 }
 
+function subnet_overlap_warning_text(array $overlaps): string
+{
+    $parts = [];
+    if (!empty($overlaps['parents'])) {
+        $list = implode(', ', array_map('e', $overlaps['parents']));
+        $parts[] = 'nested inside: ' . $list;
+    }
+    if (!empty($overlaps['children'])) {
+        $list = implode(', ', array_map('e', $overlaps['children']));
+        $parts[] = 'parent of: ' . $list;
+    }
+    return 'Hierarchy notice — this subnet is ' . implode('; and ', $parts) . '. Verify this nesting is intentional.';
+}
+
 $tree = build_subnet_tree_local($list);
 $direct = subnet_direct_counts_local($db);
 $agg = subnet_aggregated_counts_local($tree, $direct);
@@ -392,6 +421,7 @@ page_header('Subnets');
 
 <?php if ($err): ?><p class="danger"><?= e($err) ?></p><?php endif; ?>
 <?php if ($msg): ?><p class="success"><?= e($msg) ?></p><?php endif; ?>
+<?php if ($warn): ?><p class="warning"><?= $warn ?></p><?php endif; ?>
 
 <div class="card" id="add-subnet" style="margin-top:16px">
   <h2>Add subnet</h2>


### PR DESCRIPTION
Add detect_subnet_overlaps() to lib.php to classify existing subnets as parents (contain the new CIDR) or children (fall inside the new CIDR). Because valid CIDR math cannot produce partial overlaps, every detected relationship is a legitimate parent/child hierarchy; operations are never blocked, only annotated with an informational warning.

- lib.php: new detect_subnet_overlaps(db, cidr, excludeId) helper
- subnets.php: run check on create (flash via session) and update (inline); render warning message using new .warning CSS class
- import_csv.php: run check per unique new-subnet CIDR in dry-run analysis, show hierarchy notice in the row report Reason column
- assets/app.css: add .warning utility class (uses existing --warn token)

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3