### PR TITLE
Milestone 4 — Dashboard + Search enhancement

### DIFF
--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -3,31 +3,179 @@ declare(strict_types=1);
 require __DIR__ . '/init.php';
 require_login();
 
+/* --- Summary counts --- */
 $st = $db->prepare("SELECT COUNT(*) AS c FROM subnets");
 $st->execute();
-$subnets = (int)$st->fetch()['c'];
+$totalSubnets = (int)$st->fetch()['c'];
 
 $st = $db->prepare("SELECT COUNT(*) AS c FROM addresses");
 $st->execute();
-$addrs = (int)$st->fetch()['c'];
+$totalAddrs = (int)$st->fetch()['c'];
 
-$st = $db->prepare("SELECT status, COUNT(*) AS c FROM addresses GROUP BY status ORDER BY status");
+$st = $db->prepare("SELECT status, COUNT(*) AS c FROM addresses GROUP BY status");
 $st->execute();
-$byStatus = $st->fetchAll();
+$statusMap = ['used' => 0, 'reserved' => 0, 'free' => 0];
+foreach ($st->fetchAll() as $r) {
+    if (isset($statusMap[$r['status']])) $statusMap[$r['status']] = (int)$r['c'];
+}
+
+/* --- IPv4 / IPv6 subnet split --- */
+$st = $db->prepare("SELECT ip_version, COUNT(*) AS c FROM subnets GROUP BY ip_version");
+$st->execute();
+$verCounts = [4 => 0, 6 => 0];
+foreach ($st->fetchAll() as $r) $verCounts[(int)$r['ip_version']] = (int)$r['c'];
+
+/* --- Top IPv4 subnets by used-address count (/8–/30 only, avoids huge/tiny edge cases) --- */
+$st = $db->prepare("
+    SELECT s.id, s.cidr, s.prefix, s.description,
+           COUNT(a.id) AS used_count
+    FROM subnets s
+    LEFT JOIN addresses a ON a.subnet_id = s.id AND a.status = 'used'
+    WHERE s.ip_version = 4 AND s.prefix BETWEEN 8 AND 30
+    GROUP BY s.id
+    ORDER BY used_count DESC
+    LIMIT 10
+");
+$st->execute();
+$topSubnets = $st->fetchAll();
+
+/* --- Address counts grouped by site --- */
+$st = $db->prepare("
+    SELECT COALESCE(si.name, 'Ungrouped') AS site_name,
+           SUM(CASE WHEN a.status = 'used'     THEN 1 ELSE 0 END) AS used,
+           SUM(CASE WHEN a.status = 'reserved' THEN 1 ELSE 0 END) AS reserved,
+           SUM(CASE WHEN a.status = 'free'     THEN 1 ELSE 0 END) AS free,
+           COUNT(a.id) AS total
+    FROM subnets s
+    LEFT JOIN sites si ON si.id = s.site_id
+    LEFT JOIN addresses a ON a.subnet_id = s.id
+    GROUP BY s.site_id, si.name
+    ORDER BY site_name ASC
+");
+$st->execute();
+$bySite = $st->fetchAll();
+
+/* --- Recent audit events --- */
+$st = $db->prepare("
+    SELECT created_at, username, action, details
+    FROM audit_log
+    ORDER BY id DESC
+    LIMIT 10
+");
+$st->execute();
+$recentAudit = $st->fetchAll();
 
 page_header('Dashboard');
 ?>
-<h1>Dashboard</h1>
-<ul>
-  <li>Subnets: <b><?= e((string)$subnets) ?></b></li>
-  <li>Addresses (rows): <b><?= e((string)$addrs) ?></b></li>
-</ul>
 
-<h2>Address rows by status</h2>
-<ul>
-  <?php foreach ($byStatus as $r): ?>
-    <li><?= e($r['status']) ?>: <b><?= e((string)$r['c']) ?></b></li>
-  <?php endforeach; ?>
-</ul>
+<div class="breadcrumbs">
+  <span>🏠 Dashboard</span>
+</div>
+
+<div class="toolbar">
+  <div>
+    <h1>Dashboard</h1>
+    <div class="muted">System overview</div>
+  </div>
+</div>
+
+<div class="grid cols-3" style="margin-top:16px">
+  <div class="metric"><div class="label">Subnets</div><div class="value"><?= e((string)$totalSubnets) ?></div></div>
+  <div class="metric"><div class="label">Addresses (rows)</div><div class="value"><?= e((string)$totalAddrs) ?></div></div>
+  <div class="metric"><div class="label">Used</div><div class="value status-used"><?= e((string)$statusMap['used']) ?></div></div>
+  <div class="metric"><div class="label">Reserved</div><div class="value status-reserved"><?= e((string)$statusMap['reserved']) ?></div></div>
+  <div class="metric"><div class="label">Free</div><div class="value status-free"><?= e((string)$statusMap['free']) ?></div></div>
+  <div class="metric"><div class="label">IPv4 / IPv6 Subnets</div><div class="value"><?= e((string)$verCounts[4]) ?> / <?= e((string)$verCounts[6]) ?></div></div>
+</div>
+
+<div class="grid cols-2" style="margin-top:16px">
+
+  <div class="card">
+    <h2>Top IPv4 Subnets by Usage</h2>
+    <?php if (!$topSubnets): ?>
+      <div class="empty-state">No IPv4 subnets in /8–/30 range.</div>
+    <?php else: ?>
+      <table>
+        <thead>
+          <tr><th>Subnet</th><th>Description</th><th>Used</th><th>Capacity</th><th>Fill</th></tr>
+        </thead>
+        <tbody>
+        <?php foreach ($topSubnets as $s):
+            $cap  = ipv4_assignable_count((int)$s['prefix']);
+            $used = (int)$s['used_count'];
+            $pct  = $cap > 0 ? min(100, (int)round($used / $cap * 100)) : 0;
+            $bar  = $pct >= 90 ? 'var(--danger)' : ($pct >= 70 ? 'var(--warn)' : 'var(--success)');
+        ?>
+          <tr>
+            <td><a href="addresses.php?subnet_id=<?= (int)$s['id'] ?>"><?= e($s['cidr']) ?></a></td>
+            <td class="muted"><?= e((string)$s['description']) ?></td>
+            <td><?= e((string)$used) ?></td>
+            <td><?= e((string)$cap) ?></td>
+            <td style="min-width:90px">
+              <div style="background:var(--border);border-radius:4px;height:8px;overflow:hidden">
+                <div style="width:<?= $pct ?>%;background:<?= $bar ?>;height:100%"></div>
+              </div>
+              <span class="muted" style="font-size:.85rem"><?= $pct ?>%</span>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    <?php endif; ?>
+    <div style="margin-top:10px"><a class="action-pill" href="subnets.php">🌐 All Subnets</a></div>
+  </div>
+
+  <div class="card">
+    <h2>Addresses by Site</h2>
+    <?php if (!$bySite): ?>
+      <div class="empty-state">No data yet.</div>
+    <?php else: ?>
+      <table>
+        <thead>
+          <tr><th>Site</th><th>Used</th><th>Reserved</th><th>Free</th><th>Total</th></tr>
+        </thead>
+        <tbody>
+        <?php foreach ($bySite as $r): ?>
+          <tr>
+            <td><?= e((string)$r['site_name']) ?></td>
+            <td class="status-used"><?= e((string)$r['used']) ?></td>
+            <td class="status-reserved"><?= e((string)$r['reserved']) ?></td>
+            <td class="status-free"><?= e((string)$r['free']) ?></td>
+            <td><b><?= e((string)$r['total']) ?></b></td>
+          </tr>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    <?php endif; ?>
+    <?php if (current_user()['role'] === 'admin'): ?>
+      <div style="margin-top:10px"><a class="action-pill" href="sites.php">📍 Manage Sites</a></div>
+    <?php endif; ?>
+  </div>
+
+</div>
+
+<div class="card" style="margin-top:16px">
+  <h2>Recent Activity</h2>
+  <?php if (!$recentAudit): ?>
+    <div class="empty-state">No audit events yet.</div>
+  <?php else: ?>
+    <table>
+      <thead>
+        <tr><th>Time</th><th>User</th><th>Action</th><th>Details</th></tr>
+      </thead>
+      <tbody>
+      <?php foreach ($recentAudit as $r): ?>
+        <tr>
+          <td class="muted" style="white-space:nowrap"><?= e((string)$r['created_at']) ?></td>
+          <td><?= e((string)$r['username']) ?></td>
+          <td><?= e((string)$r['action']) ?></td>
+          <td class="muted"><?= e((string)$r['details']) ?></td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+    <div style="margin-top:10px"><a class="action-pill" href="audit.php">📜 Full Audit Log</a></div>
+  <?php endif; ?>
+</div>
 
 <?php page_footer();

--- a/Simple-PHP-IPAM/search.php
+++ b/Simple-PHP-IPAM/search.php
@@ -3,41 +3,61 @@ declare(strict_types=1);
 require __DIR__ . '/init.php';
 require_login();
 
-$q = trim((string)($_GET['q'] ?? ''));
-$status = trim((string)($_GET['status'] ?? ''));
-$subnetId = (int)($_GET['subnet_id'] ?? 0);
+$q          = trim((string)($_GET['q'] ?? ''));
+$status     = trim((string)($_GET['status'] ?? ''));
+$subnetId   = (int)($_GET['subnet_id'] ?? 0);
+$siteId     = (int)($_GET['site_id'] ?? 0);
+$ipVersion  = (int)($_GET['ip_version'] ?? 0);
 
-$page = q_int('page', 1, 1, 1000000);
+$page     = q_int('page', 1, 1, 1000000);
 $pageSize = q_int('page_size', 254, 1, 500);
 
-$allowedStatus = ['' ,'used','reserved','free'];
+$allowedStatus = ['', 'used', 'reserved', 'free'];
 if (!in_array($status, $allowedStatus, true)) $status = '';
+if (!in_array($ipVersion, [0, 4, 6], true)) $ipVersion = 0;
 
-$st = $db->prepare("SELECT id, cidr, ip_version FROM subnets ORDER BY ip_version ASC, cidr ASC");
+/* Fetch sites for filter dropdown */
+$st = $db->prepare("SELECT id, name FROM sites ORDER BY name ASC");
+$st->execute();
+$siteList = $st->fetchAll();
+
+/* Fetch subnets for filter dropdown (include site_id for JS filtering) */
+$st = $db->prepare("SELECT id, cidr, ip_version, site_id FROM subnets ORDER BY ip_version ASC, cidr ASC");
 $st->execute();
 $subnets = $st->fetchAll();
 
-$where = [];
+/* Build WHERE clause — all conditions reference `a` or `s` (subnets already joined) */
+$where  = [];
 $params = [];
 
 if ($q !== '') {
-    $where[] = "(a.ip LIKE :q OR a.hostname LIKE :q OR a.owner LIKE :q OR a.note LIKE :q)";
-    $params[':q'] = '%' . $q . '%';
+    $where[]       = "(a.ip LIKE :q OR a.hostname LIKE :q OR a.owner LIKE :q OR a.note LIKE :q)";
+    $params[':q']  = '%' . $q . '%';
 }
 if ($status !== '') {
-    $where[] = "a.status = :st";
+    $where[]       = "a.status = :st";
     $params[':st'] = $status;
 }
 if ($subnetId > 0) {
-    $where[] = "a.subnet_id = :sid";
+    $where[]        = "a.subnet_id = :sid";
     $params[':sid'] = $subnetId;
+}
+if ($siteId > 0) {
+    $where[]          = "s.site_id = :site_id";
+    $params[':site_id'] = $siteId;
+}
+if ($ipVersion > 0) {
+    $where[]           = "s.ip_version = :ipver";
+    $params[':ipver']  = $ipVersion;
 }
 
 $whereSql = $where ? ("WHERE " . implode(" AND ", $where)) : "";
 
+/* Count query — must JOIN subnets when site/version filters are active */
 $st = $db->prepare("
     SELECT COUNT(*) AS c
     FROM addresses a
+    JOIN subnets s ON s.id = a.subnet_id
     $whereSql
 ");
 $st->execute($params);
@@ -95,24 +115,49 @@ page_header('Search');
 
 <div class="card" style="margin-top:16px">
   <form method="get" action="search.php" class="row">
+
     <label>Query<br>
-      <input name="q" value="<?= e($q) ?>" placeholder="ip/hostname/owner/note">
+      <input name="q" value="<?= e($q) ?>" placeholder="ip / hostname / owner / note">
     </label>
 
     <label>Status<br>
       <select name="status">
         <option value="" <?= $status===''?'selected':'' ?>>(any)</option>
-        <option value="used" <?= $status==='used'?'selected':'' ?>>used</option>
+        <option value="used"     <?= $status==='used'    ?'selected':'' ?>>used</option>
         <option value="reserved" <?= $status==='reserved'?'selected':'' ?>>reserved</option>
-        <option value="free" <?= $status==='free'?'selected':'' ?>>free</option>
+        <option value="free"     <?= $status==='free'    ?'selected':'' ?>>free</option>
       </select>
     </label>
 
+    <label>IP Version<br>
+      <select name="ip_version">
+        <option value="0" <?= $ipVersion===0?'selected':'' ?>>(any)</option>
+        <option value="4" <?= $ipVersion===4?'selected':'' ?>>IPv4</option>
+        <option value="6" <?= $ipVersion===6?'selected':'' ?>>IPv6</option>
+      </select>
+    </label>
+
+    <?php if ($siteList): ?>
+    <label>Site<br>
+      <select name="site_id" id="filter-site">
+        <option value="0">(any site)</option>
+        <?php foreach ($siteList as $site): ?>
+          <option value="<?= (int)$site['id'] ?>" <?= ((int)$site['id']===$siteId)?'selected':'' ?>>
+            <?= e($site['name']) ?>
+          </option>
+        <?php endforeach; ?>
+      </select>
+    </label>
+    <?php endif; ?>
+
     <label>Subnet<br>
-      <select name="subnet_id">
+      <select name="subnet_id" id="filter-subnet">
         <option value="0">(any)</option>
         <?php foreach ($subnets as $s): ?>
-          <option value="<?= (int)$s['id'] ?>" <?= ((int)$s['id']===$subnetId)?'selected':'' ?>>
+          <option value="<?= (int)$s['id'] ?>"
+                  data-site="<?= (int)($s['site_id'] ?? 0) ?>"
+                  data-ver="<?= (int)$s['ip_version'] ?>"
+                  <?= ((int)$s['id']===$subnetId)?'selected':'' ?>>
             <?= e($s['cidr']) ?>
           </option>
         <?php endforeach; ?>
@@ -121,13 +166,17 @@ page_header('Search');
 
     <label>Page size<br>
       <select name="page_size">
-        <?php foreach ([50,100,254,500] as $sz): ?>
+        <?php foreach ([50, 100, 254, 500] as $sz): ?>
           <option value="<?= $sz ?>" <?= $pageSize===$sz?'selected':'' ?>><?= $sz ?></option>
         <?php endforeach; ?>
       </select>
     </label>
 
     <button type="submit">Search</button>
+    <?php if ($q !== '' || $status !== '' || $subnetId > 0 || $siteId > 0 || $ipVersion > 0): ?>
+      <a class="action-pill" href="search.php">Clear filters</a>
+    <?php endif; ?>
+
   </form>
 </div>
 
@@ -181,5 +230,32 @@ page_header('Search');
     </p>
   <?php endif; ?>
 </div>
+
+<script>
+(function () {
+  var siteEl   = document.getElementById('filter-site');
+  var subnetEl = document.getElementById('filter-subnet');
+  if (!siteEl || !subnetEl) return;
+
+  function filterSubnets() {
+    var selectedSite = siteEl.value;
+    var opts = subnetEl.querySelectorAll('option');
+    var currentVal = subnetEl.value;
+    var currentStillVisible = false;
+
+    opts.forEach(function (opt) {
+      if (opt.value === '0') return; // always show "any"
+      var match = selectedSite === '0' || opt.dataset.site === selectedSite;
+      opt.style.display = match ? '' : 'none';
+      if (match && opt.value === currentVal) currentStillVisible = true;
+    });
+
+    if (!currentStillVisible) subnetEl.value = '0';
+  }
+
+  siteEl.addEventListener('change', filterSubnets);
+  filterSubnets(); // apply on page load to respect pre-selected site
+}());
+</script>
 
 <?php page_footer();


### PR DESCRIPTION
dashboard.php: replace minimal 4-line summary with full widget layout
- 6-metric summary row (subnets, addresses, used/reserved/free, IPv4/IPv6 split)
- Top IPv4 subnets by usage with colour-coded fill bar (green/amber/red at 70%/90%)
- Address counts broken down by site in a summary table
- Recent activity panel showing last 10 audit events with link to full audit log

search.php: add site + IP version filters and UX polish
- Site dropdown filters the subnet dropdown client-side via a small JS snippet (data-site attribute on each <option>, no page reload needed)
- IP version filter (any / IPv4 / IPv6) added to WHERE via subnets join
- COUNT query now uses the same JOIN as the results query so site/version filters apply correctly to totals and pagination
- "Clear filters" link appears whenever any filter is active

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3