### PR TITLE
feat: v0.11 — security hardening, nav polish, REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 0.11 — Security Hardening, Nav Polish, and REST API
+
+### Milestone 1 — Security Hardening
+
+#### Login rate limiting (`login.php`, `lib.php`, `migrations.php`)
+- New `login_attempts` table (migration `0.11`) tracks failed login attempts per IP with a timestamp
+- Logins from an IP are blocked for a configurable window after too many consecutive failures
+- New `lib.php` functions: `login_rate_limited()`, `record_login_failure()`, `clear_login_failures()`, `purge_old_login_attempts()`
+- Successful login clears the failure counter for that IP
+- Stale attempt records are purged opportunistically on each login page load
+- Blocked attempts are recorded in the audit log as `auth.login_blocked`
+- Configurable via `config.php`: `login_max_attempts` (default 5), `login_lockout_seconds` (default 900)
+
+#### Session idle timeout (`lib.php`)
+- `require_login()` now checks `$_SESSION['last_active']` and logs users out after a configurable inactivity period
+- `login_user()` seeds `last_active` at login time; `require_login()` refreshes it on every authenticated page load
+- Expired sessions redirect to `login.php?timeout=1` with an informational message
+- Configurable via `config.php`: `session_idle_seconds` (default 1800 / 30 min)
+
+---
+
+### Milestone 2 — Nav & UX Polish
+
+#### Admin dropdown menu (`lib.php`, `assets/app.css`, `assets/app.js`)
+- Admin-only nav links (Sites, Users, API Keys, Import CSV) are grouped under a single **⚙ Admin ▾** dropdown
+- Dropdown opens on click and closes when clicking outside, reducing visual clutter for non-admin users
+
+#### Single theme toggle (`lib.php`, `assets/app.js`)
+- Replaced the two separate Theme/System buttons with a single **cycle button**: System → Light → Dark → System
+- Button label updates dynamically to show the current mode (🖥 System / ☀ Light / 🌙 Dark)
+- Legacy `ipamToggleTheme` and `ipamClearTheme` JS functions retained for backward compatibility
+
+---
+
+### Milestone 3 — REST API
+
+#### Read-only JSON API (`api.php`)
+- New stateless endpoint with no session dependency; authenticated via API key
+- API key passed as `Authorization: Bearer <key>` header or `?api_key=` query parameter (header preferred)
+- `last_used_at` timestamp updated on each successful API request
+- Resources:
+  - `GET api.php?resource=subnets` — list all subnets (with site name)
+  - `GET api.php?resource=subnets&id=N` — single subnet by ID
+  - `GET api.php?resource=addresses` — paginated address list; filterable by `subnet_id`, `status`; `page`/`limit` params (max 500 per page)
+  - `GET api.php?resource=sites` — list all sites
+
+#### API key management (`api_keys.php`, `migrations.php`)
+- New `api_keys` table (migration `0.11`): `name`, `key_hash` (SHA-256), `created_at`, `last_used_at`, `is_active`, `created_by`
+- Admin-only `api_keys.php` UI: generate keys (raw key shown once), deactivate, re-activate, delete
+- Key generation uses `random_bytes(32)` encoded as 64-character hex; only the SHA-256 hash is persisted
+- All key lifecycle events (create, deactivate, activate, delete) are written to the audit log
+
+---
+
 ## 0.10 — Exports, Import Safety, Overlap Detection, and Dashboard
 
 ### Milestone 1 — Export Foundation

--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -1,0 +1,196 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Simple-PHP-IPAM — Read-only REST API
+ *
+ * Authentication: pass your API key via the Authorization header
+ *   Authorization: Bearer <key>
+ * or as a query parameter (less secure, avoid in logs):
+ *   ?api_key=<key>
+ *
+ * Resources:
+ *   GET api.php?resource=subnets            — list all subnets
+ *   GET api.php?resource=subnets&id=N       — single subnet
+ *   GET api.php?resource=addresses          — list addresses (paginated)
+ *     optional: &subnet_id=N  &status=used|reserved|free
+ *     optional: &page=N  &limit=N (max 500, default 100)
+ *   GET api.php?resource=sites              — list all sites
+ */
+
+// No session; stateless API request
+$config = require __DIR__ . '/config.php';
+require __DIR__ . '/lib.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('X-Content-Type-Options: nosniff');
+
+$db = ipam_db((string)$config['db_path']);
+ipam_db_init($db);
+
+// ---- API key authentication ----
+
+$rawKey = '';
+$authHeader = (string)($_SERVER['HTTP_AUTHORIZATION'] ?? '');
+if (preg_match('/^Bearer\s+(\S+)$/i', $authHeader, $m)) {
+    $rawKey = $m[1];
+} elseif (!empty($_GET['api_key'])) {
+    $rawKey = (string)$_GET['api_key'];
+}
+
+if ($rawKey === '') {
+    http_response_code(401);
+    echo json_encode(['error' => 'API key required. Pass via Authorization: Bearer <key> header.']);
+    exit;
+}
+
+$keyHash = hash('sha256', $rawKey);
+$st = $db->prepare("SELECT id, name FROM api_keys WHERE key_hash = :h AND is_active = 1");
+$st->execute([':h' => $keyHash]);
+$apiKey = $st->fetch();
+
+if (!$apiKey) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Invalid or inactive API key.']);
+    exit;
+}
+
+$db->prepare("UPDATE api_keys SET last_used_at = datetime('now') WHERE id = :id")
+   ->execute([':id' => (int)$apiKey['id']]);
+
+// ---- Route ----
+
+$resource = strtolower(trim((string)($_GET['resource'] ?? '')));
+
+match ($resource) {
+    'subnets'   => api_subnets($db),
+    'addresses' => api_addresses($db),
+    'sites'     => api_sites($db),
+    default     => api_error(404, 'Unknown resource. Valid resources: subnets, addresses, sites'),
+};
+
+// ---- Helpers ----
+
+function api_json(mixed $data): never
+{
+    echo json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function api_error(int $code, string $message): never
+{
+    http_response_code($code);
+    api_json(['error' => $message]);
+}
+
+// ---- Resource handlers ----
+
+function api_subnets(PDO $db): never
+{
+    $baseSql = "SELECT s.id, s.cidr, s.ip_version, s.network, s.prefix,
+                       s.description, s.created_at, si.name AS site
+                FROM subnets s
+                LEFT JOIN sites si ON si.id = s.site_id";
+
+    if (isset($_GET['id'])) {
+        $id = (int)$_GET['id'];
+        $st = $db->prepare($baseSql . " WHERE s.id = :id");
+        $st->execute([':id' => $id]);
+        $row = $st->fetch();
+        if (!$row) api_error(404, 'Subnet not found.');
+        api_json(fmt_subnet($row));
+    }
+
+    $st = $db->query($baseSql . " ORDER BY s.ip_version, s.network_bin");
+    api_json(['subnets' => array_map('fmt_subnet', $st->fetchAll())]);
+}
+
+function fmt_subnet(array $r): array
+{
+    return [
+        'id'          => (int)$r['id'],
+        'cidr'        => $r['cidr'],
+        'ip_version'  => (int)$r['ip_version'],
+        'network'     => $r['network'],
+        'prefix'      => (int)$r['prefix'],
+        'description' => (string)$r['description'],
+        'site'        => $r['site'],
+        'created_at'  => $r['created_at'],
+    ];
+}
+
+function api_addresses(PDO $db): never
+{
+    $where  = [];
+    $params = [];
+
+    if (isset($_GET['subnet_id'])) {
+        $where[] = 'a.subnet_id = :sid';
+        $params[':sid'] = (int)$_GET['subnet_id'];
+    }
+    if (isset($_GET['status'])) {
+        $s = strtolower(trim((string)$_GET['status']));
+        if (in_array($s, ['used', 'reserved', 'free'], true)) {
+            $where[]         = 'a.status = :st';
+            $params[':st']   = $s;
+        }
+    }
+
+    $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+    $page   = max(1, (int)($_GET['page']  ?? 1));
+    $limit  = max(1, min(500, (int)($_GET['limit'] ?? 100)));
+    $offset = ($page - 1) * $limit;
+
+    $cntSt = $db->prepare("SELECT COUNT(*) AS c FROM addresses a $whereSql");
+    $cntSt->execute($params);
+    $total = (int)$cntSt->fetch()['c'];
+
+    $sql = "SELECT a.id, a.subnet_id, a.ip, a.hostname, a.owner,
+                   a.status, a.description, a.created_at
+            FROM addresses a $whereSql
+            ORDER BY a.ip_bin
+            LIMIT :lim OFFSET :off";
+
+    $st = $db->prepare($sql);
+    $st->bindValue(':lim', $limit, PDO::PARAM_INT);
+    $st->bindValue(':off', $offset, PDO::PARAM_INT);
+    foreach ($params as $k => $v) {
+        $st->bindValue($k, $v);
+    }
+    $st->execute();
+
+    $rows = array_map(function(array $r): array {
+        return [
+            'id'          => (int)$r['id'],
+            'subnet_id'   => (int)$r['subnet_id'],
+            'ip'          => $r['ip'],
+            'hostname'    => (string)$r['hostname'],
+            'owner'       => (string)$r['owner'],
+            'status'      => $r['status'],
+            'description' => (string)$r['description'],
+            'created_at'  => $r['created_at'],
+        ];
+    }, $st->fetchAll());
+
+    api_json([
+        'total'     => $total,
+        'page'      => $page,
+        'limit'     => $limit,
+        'addresses' => $rows,
+    ]);
+}
+
+function api_sites(PDO $db): never
+{
+    $st = $db->query("SELECT id, name, description, created_at FROM sites ORDER BY name");
+    $rows = array_map(function(array $r): array {
+        return [
+            'id'          => (int)$r['id'],
+            'name'        => $r['name'],
+            'description' => (string)$r['description'],
+            'created_at'  => $r['created_at'],
+        ];
+    }, $st->fetchAll());
+    api_json(['sites' => $rows]);
+}

--- a/Simple-PHP-IPAM/api_keys.php
+++ b/Simple-PHP-IPAM/api_keys.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+require_role('admin');
+if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
+
+$u = current_user();
+$newKey = null; // raw key shown once after creation
+
+// ---- Actions ----
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = (string)($_POST['action'] ?? '');
+
+    if ($action === 'create') {
+        $name = trim((string)($_POST['name'] ?? ''));
+        if ($name === '') {
+            $formError = 'Key name is required.';
+        } else {
+            // Generate a 32-byte random key, encode as hex (64 chars)
+            $rawKey  = bin2hex(random_bytes(32));
+            $keyHash = hash('sha256', $rawKey);
+            $st = $db->prepare("INSERT INTO api_keys (name, key_hash, created_by) VALUES (:n,:h,:by)");
+            $st->execute([':n' => $name, ':h' => $keyHash, ':by' => $u['username']]);
+            audit($db, 'api_key.create', 'api_key', (int)$db->lastInsertId(), 'name=' . $name);
+            $newKey = $rawKey; // shown once only
+        }
+    }
+
+    if ($action === 'deactivate') {
+        $kid = (int)($_POST['key_id'] ?? 0);
+        $db->prepare("UPDATE api_keys SET is_active = 0 WHERE id = :id")
+           ->execute([':id' => $kid]);
+        audit($db, 'api_key.deactivate', 'api_key', $kid, '');
+        header('Location: api_keys.php');
+        exit;
+    }
+
+    if ($action === 'activate') {
+        $kid = (int)($_POST['key_id'] ?? 0);
+        $db->prepare("UPDATE api_keys SET is_active = 1 WHERE id = :id")
+           ->execute([':id' => $kid]);
+        audit($db, 'api_key.activate', 'api_key', $kid, '');
+        header('Location: api_keys.php');
+        exit;
+    }
+
+    if ($action === 'delete') {
+        $kid = (int)($_POST['key_id'] ?? 0);
+        $db->prepare("DELETE FROM api_keys WHERE id = :id")
+           ->execute([':id' => $kid]);
+        audit($db, 'api_key.delete', 'api_key', $kid, '');
+        header('Location: api_keys.php');
+        exit;
+    }
+}
+
+// ---- List ----
+
+$keys = $db->query("SELECT id, name, created_at, last_used_at, is_active, created_by
+                    FROM api_keys ORDER BY created_at DESC")
+           ->fetchAll();
+
+page_header('API Keys');
+?>
+<h1>API Keys</h1>
+<p class="muted">API keys grant read-only access to the <a href="api.php">REST API</a>.
+  Each key is shown <strong>once</strong> at creation — copy it before navigating away.</p>
+
+<?php if (!empty($newKey)): ?>
+<div class="card" style="border-color:var(--success)">
+  <strong>New API key created — copy it now, it will not be shown again:</strong><br>
+  <code style="word-break:break-all;font-size:1.05rem"><?= e($newKey) ?></code>
+</div>
+<?php endif; ?>
+
+<?php if (!empty($formError)): ?>
+  <p class="danger"><?= e($formError) ?></p>
+<?php endif; ?>
+
+<div class="card">
+  <h2>Create new key</h2>
+  <form method="post" action="api_keys.php">
+    <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+    <input type="hidden" name="action" value="create">
+    <div class="row">
+      <label>Key name / description
+        <input name="name" required placeholder="e.g. Monitoring script" style="min-width:260px">
+      </label>
+      <div style="align-self:flex-end">
+        <button type="submit">Generate key</button>
+      </div>
+    </div>
+  </form>
+</div>
+
+<?php if ($keys): ?>
+<div class="card" style="margin-top:16px">
+  <h2>Existing keys</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Created</th>
+        <th>Created by</th>
+        <th>Last used</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($keys as $k): ?>
+      <tr>
+        <td><?= e((string)$k['name']) ?></td>
+        <td><?= e((string)$k['created_at']) ?></td>
+        <td><?= e((string)$k['created_by']) ?></td>
+        <td><?= $k['last_used_at'] ? e((string)$k['last_used_at']) : '<span class="muted">Never</span>' ?></td>
+        <td>
+          <?php if ((int)$k['is_active']): ?>
+            <span class="success">Active</span>
+          <?php else: ?>
+            <span class="muted">Inactive</span>
+          <?php endif; ?>
+        </td>
+        <td>
+          <div class="actions-inline">
+            <?php if ((int)$k['is_active']): ?>
+              <form method="post" action="api_keys.php" style="display:inline">
+                <input type="hidden" name="csrf"     value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action"   value="deactivate">
+                <input type="hidden" name="key_id"   value="<?= (int)$k['id'] ?>">
+                <button type="submit" class="button-secondary">Deactivate</button>
+              </form>
+            <?php else: ?>
+              <form method="post" action="api_keys.php" style="display:inline">
+                <input type="hidden" name="csrf"     value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action"   value="activate">
+                <input type="hidden" name="key_id"   value="<?= (int)$k['id'] ?>">
+                <button type="submit" class="button-secondary">Activate</button>
+              </form>
+            <?php endif; ?>
+            <form method="post" action="api_keys.php" style="display:inline"
+                  onsubmit="return confirm('Permanently delete this key?')">
+              <input type="hidden" name="csrf"     value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action"   value="delete">
+              <input type="hidden" name="key_id"   value="<?= (int)$k['id'] ?>">
+              <button type="submit" class="button-danger">Delete</button>
+            </form>
+          </div>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+    </tbody>
+  </table>
+</div>
+<?php else: ?>
+  <p class="muted" style="margin-top:16px">No API keys yet.</p>
+<?php endif; ?>
+
+<?php page_footer(); ?>

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -153,6 +153,49 @@ h3{font-size:1.05rem}
   align-items:center;
   flex-wrap:wrap;
 }
+.nav-dropdown{
+  position:relative;
+}
+.nav-dropdown-toggle{
+  padding:9px 13px;
+  border-radius:12px;
+  background:transparent;
+  color:var(--link);
+  border:none;
+  cursor:pointer;
+  font:inherit;
+  line-height:1.2;
+}
+.nav-dropdown-toggle:hover{
+  background:var(--card-2);
+  filter:none;
+}
+.nav-dropdown-menu{
+  display:none;
+  position:absolute;
+  top:calc(100% + 4px);
+  left:0;
+  min-width:160px;
+  background:var(--card);
+  border:1px solid var(--border);
+  border-radius:12px;
+  box-shadow:var(--shadow);
+  z-index:100;
+  padding:6px 0;
+}
+.nav-dropdown.open .nav-dropdown-menu{
+  display:block;
+}
+.nav-dropdown-item{
+  display:block;
+  padding:9px 16px;
+  color:var(--fg);
+  white-space:nowrap;
+}
+.nav-dropdown-item:hover{
+  background:var(--card-2);
+  text-decoration:none;
+}
 
 .card{
   background:var(--card);

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -5,20 +5,56 @@
     document.documentElement.setAttribute("data-theme", saved);
   }
 
-  window.ipamToggleTheme = function(){
-    const cur = document.documentElement.getAttribute("data-theme");
-    let next;
-    if (cur === "dark") next = "light";
-    else if (cur === "light") next = "dark";
-    else {
-      next = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "light" : "dark";
+  function currentTheme() {
+    return document.documentElement.getAttribute("data-theme") || "auto";
+  }
+
+  function applyTheme(t) {
+    if (t === "auto") {
+      document.documentElement.removeAttribute("data-theme");
+      localStorage.removeItem(key);
+    } else {
+      document.documentElement.setAttribute("data-theme", t);
+      localStorage.setItem(key, t);
     }
-    document.documentElement.setAttribute("data-theme", next);
-    localStorage.setItem(key, next);
+  }
+
+  function updateThemeButton() {
+    const btn = document.getElementById("theme-toggle");
+    if (!btn) return;
+    const labels = { auto: "🖥 System", light: "☀ Light", dark: "🌙 Dark" };
+    btn.textContent = labels[currentTheme()] || "🌓 Theme";
+  }
+
+  window.ipamCycleTheme = function() {
+    const order = ["auto", "light", "dark"];
+    const next = order[(order.indexOf(currentTheme()) + 1) % order.length];
+    applyTheme(next);
+    updateThemeButton();
   };
 
-  window.ipamClearTheme = function(){
-    document.documentElement.removeAttribute("data-theme");
-    localStorage.removeItem(key);
-  };
+  // Keep old names in case anything calls them externally
+  window.ipamToggleTheme = window.ipamCycleTheme;
+  window.ipamClearTheme = function() { applyTheme("auto"); updateThemeButton(); };
+
+  document.addEventListener("DOMContentLoaded", function() {
+    updateThemeButton();
+
+    // Dropdown toggle
+    document.addEventListener("click", function(e) {
+      const toggle = e.target.closest(".nav-dropdown-toggle");
+      if (toggle) {
+        const dropdown = toggle.closest(".nav-dropdown");
+        const isOpen = dropdown.classList.contains("open");
+        // Close all first
+        document.querySelectorAll(".nav-dropdown.open")
+                .forEach(function(d) { d.classList.remove("open"); });
+        if (!isOpen) dropdown.classList.add("open");
+        return;
+      }
+      // Click outside closes all
+      document.querySelectorAll(".nav-dropdown.open")
+              .forEach(function(d) { d.classList.remove("open"); });
+    });
+  });
 })();

--- a/Simple-PHP-IPAM/config.php
+++ b/Simple-PHP-IPAM/config.php
@@ -11,6 +11,13 @@ return [
         'password' => 'ChangeMeNow!12345',
     ],
 
+    // Session idle timeout (seconds). Users are logged out after this much inactivity.
+    'session_idle_seconds' => 1800,
+
+    // Login rate limiting: lock out an IP after this many failed attempts within the window.
+    'login_max_attempts'    => 5,
+    'login_lockout_seconds' => 900,
+
     // CSV import max upload size (MB). Allowed range: 5..50
     'import_csv_max_mb' => 5,
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -88,6 +88,13 @@ function require_login(): void
         header('Location: login.php');
         exit;
     }
+    $idle = (int)(($GLOBALS['config'] ?? [])['session_idle_seconds'] ?? 1800);
+    if (isset($_SESSION['last_active']) && (time() - (int)$_SESSION['last_active']) > $idle) {
+        logout_user();
+        header('Location: login.php?timeout=1');
+        exit;
+    }
+    $_SESSION['last_active'] = time();
 }
 
 function current_user(): array
@@ -123,6 +130,36 @@ function login_user(int $uid, string $username, string $role): void
     $_SESSION['uid'] = $uid;
     $_SESSION['username'] = $username;
     $_SESSION['role'] = $role;
+    $_SESSION['last_active'] = time();
+}
+
+/* ---------------- Login rate limiting ---------------- */
+
+function login_rate_limited(PDO $db, string $ip, int $maxAttempts, int $windowSeconds): bool
+{
+    $cutoff = date('Y-m-d H:i:s', time() - $windowSeconds);
+    $st = $db->prepare("SELECT COUNT(*) AS c FROM login_attempts WHERE ip = :ip AND attempted_at >= :cutoff");
+    $st->execute([':ip' => $ip, ':cutoff' => $cutoff]);
+    return (int)$st->fetch()['c'] >= $maxAttempts;
+}
+
+function record_login_failure(PDO $db, string $ip): void
+{
+    $db->prepare("INSERT INTO login_attempts (ip) VALUES (:ip)")
+       ->execute([':ip' => $ip]);
+}
+
+function clear_login_failures(PDO $db, string $ip): void
+{
+    $db->prepare("DELETE FROM login_attempts WHERE ip = :ip")
+       ->execute([':ip' => $ip]);
+}
+
+function purge_old_login_attempts(PDO $db, int $windowSeconds): void
+{
+    $cutoff = date('Y-m-d H:i:s', time() - $windowSeconds);
+    $db->prepare("DELETE FROM login_attempts WHERE attempted_at < :cutoff")
+       ->execute([':cutoff' => $cutoff]);
 }
 
 function logout_user(): void
@@ -756,8 +793,8 @@ function page_header(string $title): void
 
     echo "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>";
     echo "<title>" . e($title) . "</title>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=0.9.1'>";
-    echo "<script defer src='assets/app.js?v=0.9.1'></script>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=0.11'>";
+    echo "<script defer src='assets/app.js?v=0.11'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";
@@ -770,9 +807,14 @@ function page_header(string $title): void
         echo "<a class='nav-pill' href='search.php'>🔎 Search</a>";
         echo "<a class='nav-pill' href='audit.php'>📜 Audit</a>";
         if (($role ?? '') === 'admin') {
-            echo "<a class='nav-pill' href='sites.php'>📍 Sites</a>";
-            echo "<a class='nav-pill' href='users.php'>👤 Users</a>";
-            echo "<a class='nav-pill' href='import_csv.php'>⬆ Import CSV</a>";
+            echo "<div class='nav-dropdown'>";
+            echo "<button type='button' class='nav-pill nav-dropdown-toggle'>⚙ Admin ▾</button>";
+            echo "<div class='nav-dropdown-menu'>";
+            echo "<a class='nav-dropdown-item' href='sites.php'>📍 Sites</a>";
+            echo "<a class='nav-dropdown-item' href='users.php'>👤 Users</a>";
+            echo "<a class='nav-dropdown-item' href='api_keys.php'>🔑 API Keys</a>";
+            echo "<a class='nav-dropdown-item' href='import_csv.php'>⬆ Import CSV</a>";
+            echo "</div></div>";
         }
         echo "<a class='nav-pill' href='change_password.php'>🔐 Password</a>";
         echo "<a class='nav-pill' href='logout.php'>↩ Logout</a>";
@@ -782,8 +824,7 @@ function page_header(string $title): void
     echo "</div>";
 
     echo "<div class='nav-right'>";
-    echo "<button type='button' class='button-secondary' onclick='ipamToggleTheme()'>🌓 Theme</button>";
-    echo "<button type='button' class='button-secondary' onclick='ipamClearTheme()'>🖥 System</button>";
+    echo "<button type='button' class='button-secondary' id='theme-toggle' onclick='ipamCycleTheme()'>🌓 Theme</button>";
     echo "</div>";
 
     echo "</div></div>";

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -5,34 +5,53 @@ require __DIR__ . '/init.php';
 if (is_logged_in()) { header('Location: dashboard.php'); exit; }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
 
+$maxAttempts   = (int)($config['login_max_attempts']   ?? 5);
+$lockoutSeconds = (int)($config['login_lockout_seconds'] ?? 900);
+
 $error = '';
+$timedOut = !empty($_GET['timeout']);
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password = (string)($_POST['password'] ?? '');
+    $ip = client_ip();
 
-    $st = $db->prepare("SELECT id, username, password_hash, role, is_active FROM users WHERE username = :u");
-    $st->execute([':u' => $username]);
-    $user = $st->fetch();
+    // Purge stale attempts opportunistically (keep rows 2× the lockout window)
+    purge_old_login_attempts($db, $lockoutSeconds * 2);
 
-    if ($user && (int)$user['is_active'] === 1 && password_verify($password, $user['password_hash'])) {
-        if (password_needs_rehash($user['password_hash'], PASSWORD_DEFAULT)) {
-            $new = password_hash($password, PASSWORD_DEFAULT);
-            $up = $db->prepare("UPDATE users SET password_hash = :h WHERE id = :id");
-            $up->execute([':h' => $new, ':id' => $user['id']]);
+    if (login_rate_limited($db, $ip, $maxAttempts, $lockoutSeconds)) {
+        $error = 'Too many failed login attempts. Please try again later.';
+        audit($db, 'auth.login_blocked', 'user', null, 'ip=' . $ip);
+    } else {
+        $st = $db->prepare("SELECT id, username, password_hash, role, is_active FROM users WHERE username = :u");
+        $st->execute([':u' => $username]);
+        $user = $st->fetch();
+
+        if ($user && (int)$user['is_active'] === 1 && password_verify($password, $user['password_hash'])) {
+            if (password_needs_rehash($user['password_hash'], PASSWORD_DEFAULT)) {
+                $new = password_hash($password, PASSWORD_DEFAULT);
+                $up = $db->prepare("UPDATE users SET password_hash = :h WHERE id = :id");
+                $up->execute([':h' => $new, ':id' => $user['id']]);
+            }
+            clear_login_failures($db, $ip);
+            login_user((int)$user['id'], (string)$user['username'], (string)$user['role']);
+            audit($db, 'auth.login', 'user', (int)$user['id'], 'login ok');
+            header('Location: dashboard.php');
+            exit;
         }
-        login_user((int)$user['id'], (string)$user['username'], (string)$user['role']);
-        audit($db, 'auth.login', 'user', (int)$user['id'], 'login ok');
-        header('Location: dashboard.php');
-        exit;
-    }
 
-    $error = 'Invalid username or password.';
-    audit($db, 'auth.login_failed', 'user', null, 'username=' . $username);
+        record_login_failure($db, $ip);
+        $error = 'Invalid username or password.';
+        audit($db, 'auth.login_failed', 'user', null, 'username=' . $username);
+    }
 }
 
 page_header('Login');
 ?>
 <h1>Login</h1>
+<?php if ($timedOut && !$error): ?>
+  <p class="warning">Your session expired due to inactivity. Please log in again.</p>
+<?php endif; ?>
 <?php if ($error): ?><p class="danger"><?= e($error) ?></p><?php endif; ?>
 
 <form method="post" action="login.php" autocomplete="off">

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -55,7 +55,7 @@ function ipam_migrations(): array
         },
 
         // 0.9: sites grouping
-        '0.9' => function(PDO $db) {
+        '0.9'  => function(PDO $db) {
             $db->exec("
                 CREATE TABLE IF NOT EXISTS sites (
                   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -73,6 +73,31 @@ function ipam_migrations(): array
             }
 
             $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id)");
+        },
+
+        // 0.11: login rate-limiting + REST API keys
+        '0.11' => function(PDO $db) {
+            $db->exec("
+                CREATE TABLE IF NOT EXISTS login_attempts (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ip           TEXT NOT NULL,
+                    attempted_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            ");
+            $db->exec("CREATE INDEX IF NOT EXISTS idx_login_attempts_ip_time
+                       ON login_attempts(ip, attempted_at)");
+
+            $db->exec("
+                CREATE TABLE IF NOT EXISTS api_keys (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name         TEXT NOT NULL,
+                    key_hash     TEXT NOT NULL UNIQUE,
+                    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+                    last_used_at TEXT,
+                    is_active    INTEGER NOT NULL DEFAULT 1,
+                    created_by   TEXT NOT NULL DEFAULT ''
+                )
+            ");
         },
     ];
 }

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-const IPAM_VERSION = '0.10';
+const IPAM_VERSION = '0.11';


### PR DESCRIPTION
Milestone 1 — Security Hardening:
- Login rate limiting: new login_attempts table (migration 0.11), IP-based lockout after configurable failed attempts (default 5/15 min)
- Session idle timeout: auto-logout after inactivity (default 30 min), with informational message on next login
- New config.php keys: session_idle_seconds, login_max_attempts, login_lockout_seconds

Milestone 2 — Nav & UX Polish:
- Admin links (Sites, Users, API Keys, Import CSV) collapsed into a single ⚙ Admin dropdown menu
- Two theme buttons replaced with one cycle button (System→Light→Dark) with dynamic label

Milestone 3 — REST API:
- New api.php: stateless read-only JSON API (subnets, addresses, sites)
- New api_keys.php: admin UI to create/deactivate/delete API keys
- API keys stored as SHA-256 hashes; raw key shown once at creation
- New api_keys table (migration 0.11)

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3