### PR TITLE
docs: split README into focused docs/ files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,7 @@
 
 A lightweight **IP Address Management (IPAM)** web application built with PHP 8.2+ and SQLite. Designed for small to mid-sized environments that need straightforward subnet and address tracking without the complexity of a full enterprise IPAM platform.
 
----
-
-## Table of Contents
-
-- [Features](#features)
-- [Requirements](#requirements)
-- [Fresh Install](#fresh-install)
-- [Configuration](#configuration)
-- [First Login](#first-login)
-- [Upgrading](#upgrading)
-- [CLI Utilities](#cli-utilities)
-- [File Permissions Reference](#file-permissions-reference)
-- [Security Notes](#security-notes)
-- [Changelog](#changelog)
+No Composer, no npm, no external dependencies — just PHP and a web server.
 
 ---
 
@@ -26,30 +13,29 @@ A lightweight **IP Address Management (IPAM)** web application built with PHP 8.
 - Manage **address records** with hostname, owner, status (`used` / `reserved` / `free`), and notes
 - Subnet **hierarchy view** — parent/child nesting with expand/collapse for both IPv4 and IPv6
 - **Subnet overlap detection** — warns when a new subnet nests inside or contains existing ones
-- IPv4 **unassigned host tracking** — lists assignable IPs that have no address record, with a quick-add form
+- IPv4 **unassigned host tracking** — lists assignable IPs with no address record and a quick-add form
 - Correct IP sorting using packed binary storage (`ip_bin`, `network_bin`)
 
 ### Search & Productivity
-- **Dashboard** — utilization bar chart for top subnets, per-site address breakdown, recent audit activity
+- **Dashboard** — utilization bars for top subnets, per-site address breakdown, recent audit activity
 - **Global search** across IP / hostname / owner / note with filters for status, site, and IP version
 - **Bulk update** — update hostname / owner / status / note across multiple addresses at once, with bulk delete
-- **CSV import wizard** (admin-only) — upload, map columns, dry-run preview, then apply; supports skip / overwrite / fill-empty duplicate modes and can auto-create missing subnets
+- **CSV import wizard** (admin-only) — upload, map columns, dry-run preview, then apply; supports auto-create missing subnets
 
 ### Organisation
-- **Sites** — group subnets by location or network segment; subnets page groups hierarchies by site
+- **Sites** — group subnets by location or network segment
 
 ### Security & Access Control
 - HTTPS enforced at the application layer; secure session cookies (`Secure`, `HttpOnly`, `SameSite=Strict`)
-- CSRF protection on all POST requests
-- Prepared statements everywhere (PDO)
-- Password hashing via `password_hash()` / `password_verify()`
+- **Login rate limiting** — IP-based lockout after repeated failed attempts
+- **Session idle timeout** — automatic logout after configurable inactivity period
+- CSRF protection on all POST requests; PDO prepared statements throughout
 - **RBAC roles:** `admin` (full access + user management) and `readonly`
-- Hardened `.htaccess` — blocks direct access to SQLite DB files, build artefacts, and internal PHP files
-- **Append-only audit log** enforced with SQLite triggers (rows cannot be updated or deleted)
+- Append-only audit log enforced with SQLite triggers
 
-### Auditing & History
-- Audit log viewer with CSV export (admin)
-- Per-address change history — captures who changed what, when, and from/to values for create / update / delete / bulk / import events
+### REST API
+- Read-only JSON API (`api.php`) authenticated with API keys
+- Resources: subnets, addresses (paginated + filterable), sites
 
 ---
 
@@ -59,262 +45,33 @@ A lightweight **IP Address Management (IPAM)** web application built with PHP 8.
 |---|---|
 | **PHP** | 8.2 or later (8.3 recommended) |
 | **PHP extensions** | `pdo`, `pdo_sqlite`, `openssl` |
-| **Web server** | Apache or LiteSpeed (`.htaccess` support required); Nginx requires manual translation of `.htaccess` rules |
+| **Web server** | Apache or LiteSpeed (`.htaccess` required); Nginx needs manual rule translation |
 | **SQLite** | 3.x via PDO SQLite |
-| **HTTPS** | Required — the app redirects all HTTP traffic to HTTPS |
-| **Writable `data/` dir** | The web server user needs read/write access to `data/` (and `data/tmp/` for CSV import) |
-
-### `upgrade.sh` dependencies (optional)
-`bash`, `rsync`, `tar`, `stat`, `find`, `chmod`, `sort`, `sed`, `head`, `rm`
-Optional: `php` CLI (for automatic DB migrations), `chown` (for ownership alignment).
+| **HTTPS** | Required — HTTP is redirected to HTTPS |
+| **Writable `data/` dir** | Web server user needs read/write access to `data/` |
 
 ---
 
-## Fresh Install
+## Quick start
 
-### 1. Download a release
+1. Download and extract a [release](../../releases), or clone this repo
+2. Point your web server document root at the `Simple-PHP-IPAM/` directory
+3. Edit `config.php` — **change the default admin password**
+4. Open the site in a browser; you will be redirected to the login page
 
-Download the latest release archive from the [Releases](../../releases) page and extract it, or clone this repository:
-
-```bash
-# Option A — download a release bundle
-tar -xzf ipam-0.10.tar.gz -C /var/www/
-
-# Option B — clone the repository
-git clone https://github.com/seanmousseau/Simple-PHP-IPAM.git /var/www/ipam
-```
-
-The application files live inside the `Simple-PHP-IPAM/` subdirectory of the repo. Point your web server document root at that directory.
-
-### 2. Set file permissions
-
-```bash
-# Replace www-data with your web server user (e.g. apache, nginx, _www on macOS)
-chown -R www-data:www-data /var/www/ipam
-find /var/www/ipam -type f -name '*.php' -exec chmod 0644 {} \;
-find /var/www/ipam -type d -exec chmod 0755 {} \;
-
-# Restrict the data directory
-chmod 0700 /var/www/ipam/data
-```
-
-The `data/` directory and the SQLite database file are created automatically on first request. If they already exist:
-
-```bash
-chmod 0700 /var/www/ipam/data
-chmod 0600 /var/www/ipam/data/ipam.sqlite
-```
-
-### 3. Configure the application
-
-Copy or edit `config.php` — see [Configuration](#configuration) below. At minimum, **change the default admin password** before the site receives any traffic.
-
-### 4. Configure your web server
-
-#### Apache (virtual host example)
-
-```apache
-<VirtualHost *:443>
-    ServerName ipam.example.com
-    DocumentRoot /var/www/ipam
-
-    SSLEngine on
-    SSLCertificateFile    /etc/ssl/certs/ipam.crt
-    SSLCertificateKeyFile /etc/ssl/private/ipam.key
-
-    <Directory /var/www/ipam>
-        AllowOverride All
-        Require all granted
-    </Directory>
-</VirtualHost>
-
-# Redirect HTTP → HTTPS
-<VirtualHost *:80>
-    ServerName ipam.example.com
-    Redirect permanent / https://ipam.example.com/
-</VirtualHost>
-```
-
-Ensure `mod_rewrite` and `mod_headers` are enabled:
-
-```bash
-a2enmod rewrite headers
-systemctl reload apache2
-```
-
-#### Nginx
-
-Nginx does not process `.htaccess` files. You must replicate the rules manually. Key rules to translate from `.htaccess`:
-- Deny access to `data/` and `*.sqlite` / `*.db` files
-- Deny access to `*.sh`, `*.sql`, `*.json`, `*.tar.gz`, `*.zip`, `*.bundle.txt`, `SHA256SUMS`
-- Pass all `.php` requests through PHP-FPM
-
-### 5. Verify the install
-
-Open `https://ipam.example.com/` in a browser. You should be redirected to the login page. Log in with the bootstrap admin credentials from `config.php` and immediately change the password under **Password** in the navigation.
+See the [Installation guide](docs/install.md) for full web server configuration examples (Apache, Nginx), file permission setup, and first-login steps.
 
 ---
 
-## Configuration
+## Documentation
 
-All settings are in `config.php`. This file is preserved automatically during upgrades.
-
-```php
-return [
-    // Path to the SQLite database file.
-    // The directory must be writable by the web server user.
-    'db_path' => __DIR__ . '/data/ipam.sqlite',
-
-    // Session cookie name.
-    'session_name' => 'IPAMSESSID',
-
-    // Set to true only if the app sits behind a trusted reverse proxy
-    // that sets X-Forwarded-Proto. Leave false if accessed directly.
-    'proxy_trust' => false,
-
-    // Bootstrap admin account — created on first run if no users exist.
-    // CHANGE THIS PASSWORD before exposing the site.
-    'bootstrap_admin' => [
-        'username' => 'admin',
-        'password' => 'ChangeMeNow!12345',
-    ],
-
-    // Maximum CSV upload size for the import wizard (MB). Range: 5–50.
-    'import_csv_max_mb' => 5,
-
-    // How long (seconds) to keep uploaded CSV temp files before cleanup.
-    'tmp_cleanup_ttl_seconds' => 86400,
-
-    // Lazy housekeeping: runs on normal site access at most once per interval.
-    'housekeeping' => [
-        'enabled' => true,
-        'interval_seconds' => 86400, // once per day
-    ],
-];
-```
-
-### Behind a reverse proxy
-
-If HTTPS is terminated at a load balancer or reverse proxy that forwards `X-Forwarded-Proto: https`, set `'proxy_trust' => true`. Only do this if you control the proxy and it reliably sets this header — trusting it on a public-facing server without a proxy is a security risk.
-
----
-
-## First Login
-
-1. Navigate to your install URL. You will be redirected to the login page.
-2. Log in with the credentials set in `config.php` under `bootstrap_admin` (default: `admin` / `ChangeMeNow!12345`).
-3. **Immediately change the password** — go to **Password** in the top navigation.
-4. Optionally create additional users under **Users** (admin-only).
-
-> The bootstrap admin account is only created if no users exist in the database. Once any user account exists, changes to `bootstrap_admin` in `config.php` have no effect.
-
----
-
-## Upgrading
-
-Upgrades are handled by `upgrade.sh`, included in each release bundle. The script:
-
-- Creates a timestamped backup of your current install (including the SQLite DB and WAL files)
-- Syncs new application files into the target directory
-- Preserves `config.php` and the entire `data/` directory
-- Fixes file permissions
-- Runs database migrations automatically (if the `php` CLI is available)
-- Removes upgrade artefacts from the webroot
-
-### Steps
-
-```bash
-# 1. Extract the new release bundle alongside your current install
-tar -xzf ipam-0.10.tar.gz -C /tmp/
-
-# 2. Run upgrade.sh from the extracted bundle, pointing it at your current install
-bash /tmp/Simple-PHP-IPAM/upgrade.sh /var/www/ipam
-```
-
-The script will confirm the version transition before proceeding. To skip the confirmation prompt (e.g. in a deployment script):
-
-```bash
-bash /tmp/Simple-PHP-IPAM/upgrade.sh --yes /var/www/ipam
-```
-
-### Options
-
-| Flag | Description |
+| Guide | Description |
 |---|---|
-| `--yes` | Non-interactive — skip confirmation prompts |
-| `--force` | Allow reinstalling the same version |
-| `--force-downgrade` | Allow downgrading (not recommended — may break the DB) |
-
-### Environment variables
-
-| Variable | Default | Description |
-|---|---|---|
-| `CLEANUP_ARTIFACTS` | `1` | Remove build/upgrade artefacts from the target webroot after success |
-| `REMOVE_UPGRADE_SH_FROM_TARGET` | `1` | Also remove `upgrade.sh` from the target webroot |
-
-### What the backup looks like
-
-```
-/var/www/ipam.backup.20260326-143000/   ← timestamped copy
-    data/
-        ipam.sqlite
-        ipam.sqlite-wal   ← if present
-        ipam.sqlite-shm   ← if present
-    ... (all other app files)
-```
-
-If the migration step fails, `upgrade.sh` automatically restores from the backup and exits with code `10`.
-
----
-
-## CLI Utilities
-
-These scripts are run from the application directory using the PHP CLI.
-
-### Run database migrations manually
-
-```bash
-cd /var/www/ipam
-php migrate.php
-```
-
-Applies any pending schema migrations. Migrations are also run automatically on each web request (via `ipam_db_init()`) and during upgrades, so this is only needed for manual or scripted deployments.
-
-### Clean up stale CSV temp files
-
-```bash
-cd /var/www/ipam
-php tmp_cleanup.php
-```
-
-Deletes uploaded CSV files and import plan files in `data/tmp/` that are older than `tmp_cleanup_ttl_seconds` (default: 24 hours). This also runs automatically via lazy housekeeping on normal site access.
-
----
-
-## File Permissions Reference
-
-| Path | Recommended permissions | Notes |
-|---|---|---|
-| Application files (`*.php`, `*.sql`, etc.) | `0644` | Web server reads; world-readable is fine |
-| Directories (except `data/`) | `0755` | Standard web directory permissions |
-| `data/` | `0700` | Web server user only — keeps DB out of reach of other users |
-| `data/ipam.sqlite` | `0600` | Web server user only |
-| `data/ipam.sqlite-wal` / `-shm` | `0600` | Created automatically by SQLite WAL mode |
-| `data/tmp/` | `0700` | Created automatically; holds CSV uploads |
-| `config.php` | `0640` | Web server readable, not world-readable |
-| `upgrade.sh` | `0755` | Executable; removed from webroot by default after upgrade |
-
----
-
-## Security Notes
-
-- **HTTPS is required.** The application redirects all HTTP traffic to HTTPS and sets `Secure` on session cookies. Do not run this on plain HTTP in production.
-- **Change the default password** before the site receives any traffic.
-- The `data/` directory and SQLite database are protected by `.htaccess` rules (Apache/LiteSpeed). On Nginx you must replicate these rules manually.
-- The audit log is **append-only** — SQLite triggers prevent any UPDATE or DELETE on `audit_log` rows.
-- All POST endpoints are protected by **CSRF tokens**.
-- All database queries use **PDO prepared statements**.
-- User passwords are stored using `password_hash()` with `PASSWORD_DEFAULT` (bcrypt).
+| [Installation](docs/install.md) | Requirements, web server setup, file permissions, first login |
+| [Configuration](docs/configuration.md) | All `config.php` settings explained |
+| [Upgrading](docs/upgrading.md) | Using `upgrade.sh`, CLI migration utilities |
+| [Security](docs/security.md) | HTTPS, rate limiting, session hardening, audit log, API keys |
+| [REST API](docs/api.md) | API authentication, endpoints, pagination, examples |
 
 ---
 
@@ -322,23 +79,20 @@ Deletes uploaded CSV files and import plan files in `data/tmp/` that are older t
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
+### What's new in 0.11
+
+**Security Hardening** — Login rate limiting (IP-based lockout, configurable attempts/window), session idle timeout with redirect on expiry, new `login_max_attempts` / `login_lockout_seconds` / `session_idle_seconds` config keys.
+
+**Nav & UX Polish** — Admin links (Sites, Users, API Keys, Import CSV) collapsed into a single ⚙ Admin dropdown. Two theme buttons replaced with a single cycle button (System → Light → Dark).
+
+**REST API** — New read-only `api.php` with Bearer token auth. Resources: subnets, addresses (paginated), sites. Admin UI to generate, deactivate, and delete API keys.
+
 ### What's new in 0.10
 
-**Milestone 1 — Export Foundation**
-- New CSV exports for addresses, search results, audit log, unassigned IPs, and import reports
-- All export actions are recorded in the audit log
-- Shared export helpers added to `lib.php` (`safe_export_filename`, `csv_download_headers`, `csv_out`, etc.)
+**Exports** — CSV export for addresses, search results, audit log, unassigned IPs, and import reports.
 
-**Milestone 2 — Import Safety and Dry Run**
-- Import wizard now produces a frozen dry-run plan before applying any changes — row-level and summary reports show exactly what will happen
-- Apply step reads the saved plan rather than re-parsing the CSV, with conflict detection if the DB changes between dry-run and apply
-- Hardening: duplicate row detection within a CSV, CIDR/IP cross-validation, field length checks, clarified `fill_empty` semantics
+**Import safety** — Dry-run plan saved before applying; row-level report; duplicate detection; CIDR validation; conflict detection between dry-run and apply.
 
-**Milestone 3 — Subnet Overlap Detection**
-- `detect_subnet_overlaps()` in `lib.php` classifies existing subnets as parents or children of a proposed CIDR using binary network comparison
-- Informational warnings on subnet create and update (never blocks — hierarchy is valid); same check annotates the import dry-run report for subnets being auto-created
+**Subnet overlap detection** — Informational parent/child warnings on create, update, and import dry-run.
 
-**Milestone 4 — Dashboard and Search**
-- Dashboard rebuilt with a six-metric summary strip, top IPv4 subnet utilization bars (colour-coded at 70% / 90%), per-site address breakdown table, and a recent activity panel
-- Search gains a site filter, IP version filter (IPv4 / IPv6), client-side subnet dropdown narrowing, and a "Clear filters" link
-
+**Dashboard & Search** — Rebuilt dashboard with utilization bars and per-site breakdown. Search gains site, IP version, and subnet filters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,165 @@
+# Configuration Reference
+
+All application settings live in `config.php` in the application root. This file is preserved automatically during upgrades — you will never need to re-apply your settings after an upgrade.
+
+## Contents
+
+- [Full example](#full-example)
+- [Settings reference](#settings-reference)
+- [Behind a reverse proxy](#behind-a-reverse-proxy)
+
+---
+
+## Full example
+
+```php
+return [
+    // Path to the SQLite database file.
+    // The directory must be writable by the web server user.
+    'db_path' => __DIR__ . '/data/ipam.sqlite',
+
+    // Session cookie name.
+    'session_name' => 'IPAMSESSID',
+
+    // Set to true only if the app sits behind a trusted reverse proxy
+    // that sets X-Forwarded-Proto. Leave false if accessed directly.
+    'proxy_trust' => false,
+
+    // Bootstrap admin account — created on first run if no users exist.
+    // CHANGE THIS PASSWORD before exposing the site.
+    'bootstrap_admin' => [
+        'username' => 'admin',
+        'password' => 'ChangeMeNow!12345',
+    ],
+
+    // Session idle timeout (seconds). Users are logged out after this
+    // much inactivity. Default: 1800 (30 minutes).
+    'session_idle_seconds' => 1800,
+
+    // Login rate limiting: lock out an IP after this many consecutive
+    // failed attempts within the lockout window.
+    'login_max_attempts'    => 5,
+    'login_lockout_seconds' => 900,
+
+    // Maximum CSV upload size for the import wizard (MB). Range: 5–50.
+    'import_csv_max_mb' => 5,
+
+    // How long (seconds) to keep uploaded CSV temp files before cleanup.
+    'tmp_cleanup_ttl_seconds' => 86400,
+
+    // Lazy housekeeping: runs on normal site access at most once per interval.
+    'housekeeping' => [
+        'enabled'          => true,
+        'interval_seconds' => 86400, // once per day
+    ],
+];
+```
+
+---
+
+## Settings reference
+
+### `db_path`
+
+**Default:** `__DIR__ . '/data/ipam.sqlite'`
+
+Absolute path to the SQLite database file. The directory must exist and be writable by the web server user. The file is created automatically on first request.
+
+---
+
+### `session_name`
+
+**Default:** `'IPAMSESSID'`
+
+Name of the session cookie. Change this if you run multiple PHP applications on the same domain to avoid session collisions.
+
+---
+
+### `proxy_trust`
+
+**Default:** `false`
+
+Set to `true` if the application is behind a reverse proxy that sets `X-Forwarded-Proto: https`. See [Behind a reverse proxy](#behind-a-reverse-proxy).
+
+---
+
+### `bootstrap_admin`
+
+**Default:** `username: admin`, `password: ChangeMeNow!12345`
+
+Credentials for the initial admin account. This account is created automatically when the database is first initialised (i.e. when no users exist). **Change the password before the site receives any traffic.**
+
+Once any user exists in the database, changes to this setting have no effect.
+
+---
+
+### `session_idle_seconds`
+
+**Default:** `1800` (30 minutes)
+
+How long a session can be idle before the user is automatically logged out. On the next page load after the timeout the user is redirected to the login page with an informational message.
+
+Set to a higher value (e.g. `28800` for 8 hours) if your users work in long sessions.
+
+---
+
+### `login_max_attempts`
+
+**Default:** `5`
+
+Maximum number of consecutive failed login attempts from a single IP address before that IP is locked out. Works together with `login_lockout_seconds`.
+
+---
+
+### `login_lockout_seconds`
+
+**Default:** `900` (15 minutes)
+
+How long an IP address is locked out after exceeding `login_max_attempts`. Stale attempt records are purged automatically — no manual intervention is needed.
+
+Locked-out login attempts are recorded in the audit log as `auth.login_blocked`.
+
+---
+
+### `import_csv_max_mb`
+
+**Default:** `5`
+
+Maximum allowed CSV file size for the import wizard, in megabytes. Accepted range: `5`–`50`.
+
+---
+
+### `tmp_cleanup_ttl_seconds`
+
+**Default:** `86400` (24 hours)
+
+How long uploaded CSV files and import plan files in `data/tmp/` are kept before being eligible for deletion. Cleanup runs automatically via lazy housekeeping and can also be triggered manually with `php tmp_cleanup.php`.
+
+---
+
+### `housekeeping`
+
+Controls lazy background housekeeping (temp file cleanup, stale login attempt purge).
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `true` | Whether housekeeping runs automatically |
+| `interval_seconds` | `86400` | Minimum seconds between housekeeping runs (min: 3600) |
+
+Housekeeping runs at most once per `interval_seconds` on normal web traffic. It does not require a cron job, but you can also run `php tmp_cleanup.php` manually.
+
+---
+
+## Behind a reverse proxy
+
+If HTTPS is terminated at a load balancer or reverse proxy that forwards `X-Forwarded-Proto: https`, set:
+
+```php
+'proxy_trust' => true,
+```
+
+Only do this if:
+- You control the proxy
+- The proxy reliably strips or overwrites the `X-Forwarded-Proto` header from untrusted clients
+
+Setting `proxy_trust` to `true` on a server with no proxy in front of it allows clients to spoof HTTPS detection, which would bypass the HTTP→HTTPS redirect.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,151 @@
+# Installation Guide
+
+## Contents
+
+- [Requirements](#requirements)
+- [Step 1 — Download a release](#step-1--download-a-release)
+- [Step 2 — Set file permissions](#step-2--set-file-permissions)
+- [Step 3 — Configure the application](#step-3--configure-the-application)
+- [Step 4 — Configure your web server](#step-4--configure-your-web-server)
+- [Step 5 — Verify the install](#step-5--verify-the-install)
+- [First login](#first-login)
+- [File permissions reference](#file-permissions-reference)
+
+---
+
+## Requirements
+
+| Requirement | Details |
+|---|---|
+| **PHP** | 8.2 or later (8.3 recommended) |
+| **PHP extensions** | `pdo`, `pdo_sqlite`, `openssl` |
+| **Web server** | Apache or LiteSpeed (`.htaccess` support required); Nginx requires manual translation of `.htaccess` rules |
+| **SQLite** | 3.x via PDO SQLite |
+| **HTTPS** | Required — the app redirects all HTTP traffic to HTTPS |
+| **Writable `data/` dir** | The web server user needs read/write access to `data/` (and `data/tmp/` for CSV import) |
+
+### `upgrade.sh` dependencies (optional)
+
+`bash`, `rsync`, `tar`, `stat`, `find`, `chmod`, `sort`, `sed`, `head`, `rm`
+
+Optional: `php` CLI (for automatic DB migrations), `chown` (for ownership alignment).
+
+---
+
+## Step 1 — Download a release
+
+Download the latest release archive from the [Releases](../../../releases) page and extract it, or clone the repository:
+
+```bash
+# Option A — download a release bundle
+tar -xzf ipam-0.11.tar.gz -C /var/www/
+
+# Option B — clone the repository
+git clone https://github.com/seanmousseau/Simple-PHP-IPAM.git /var/www/ipam
+```
+
+The application files live inside the `Simple-PHP-IPAM/` subdirectory of the repo. Point your web server document root at that directory.
+
+---
+
+## Step 2 — Set file permissions
+
+```bash
+# Replace www-data with your web server user (e.g. apache, nginx, _www on macOS)
+chown -R www-data:www-data /var/www/ipam
+find /var/www/ipam -type f -name '*.php' -exec chmod 0644 {} \;
+find /var/www/ipam -type d -exec chmod 0755 {} \;
+
+# Restrict the data directory
+chmod 0700 /var/www/ipam/data
+```
+
+The `data/` directory and the SQLite database file are created automatically on first request. If they already exist:
+
+```bash
+chmod 0700 /var/www/ipam/data
+chmod 0600 /var/www/ipam/data/ipam.sqlite
+```
+
+---
+
+## Step 3 — Configure the application
+
+Copy or edit `config.php`. See the [Configuration guide](configuration.md) for all available settings.
+
+At minimum, **change the default admin password** before the site receives any traffic.
+
+---
+
+## Step 4 — Configure your web server
+
+### Apache (virtual host example)
+
+```apache
+<VirtualHost *:443>
+    ServerName ipam.example.com
+    DocumentRoot /var/www/ipam
+
+    SSLEngine on
+    SSLCertificateFile    /etc/ssl/certs/ipam.crt
+    SSLCertificateKeyFile /etc/ssl/private/ipam.key
+
+    <Directory /var/www/ipam>
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+
+# Redirect HTTP → HTTPS
+<VirtualHost *:80>
+    ServerName ipam.example.com
+    Redirect permanent / https://ipam.example.com/
+</VirtualHost>
+```
+
+Ensure `mod_rewrite` and `mod_headers` are enabled:
+
+```bash
+a2enmod rewrite headers
+systemctl reload apache2
+```
+
+### Nginx
+
+Nginx does not process `.htaccess` files. You must replicate the security rules manually. Key rules to translate:
+
+- Deny access to `data/` and `*.sqlite` / `*.db` files
+- Deny access to `*.sh`, `*.sql`, `*.json`, `*.tar.gz`, `*.zip`, `*.bundle.txt`, `SHA256SUMS`
+- Pass all `.php` requests through PHP-FPM
+
+---
+
+## Step 5 — Verify the install
+
+Open `https://ipam.example.com/` in a browser. You should be redirected to the login page. Log in with the bootstrap admin credentials from `config.php` and immediately change the password under **Password** in the navigation.
+
+---
+
+## First login
+
+1. Navigate to your install URL — you will be redirected to the login page.
+2. Log in with the credentials set in `config.php` under `bootstrap_admin` (default: `admin` / `ChangeMeNow!12345`).
+3. **Immediately change the password** — go to **Password** in the top navigation.
+4. Optionally create additional users under **Admin → Users**.
+
+> The bootstrap admin account is only created if no users exist in the database. Once any user account exists, changes to `bootstrap_admin` in `config.php` have no effect.
+
+---
+
+## File permissions reference
+
+| Path | Recommended permissions | Notes |
+|---|---|---|
+| Application files (`*.php`, `*.sql`, etc.) | `0644` | Web server reads; world-readable is fine |
+| Directories (except `data/`) | `0755` | Standard web directory permissions |
+| `data/` | `0700` | Web server user only — keeps DB out of reach of other users |
+| `data/ipam.sqlite` | `0600` | Web server user only |
+| `data/ipam.sqlite-wal` / `-shm` | `0600` | Created automatically by SQLite WAL mode |
+| `data/tmp/` | `0700` | Created automatically; holds CSV uploads and import plans |
+| `config.php` | `0640` | Web server readable, not world-readable |
+| `upgrade.sh` | `0755` | Executable; removed from webroot by default after upgrade |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,130 @@
+# Security Notes
+
+## Contents
+
+- [HTTPS](#https)
+- [Authentication](#authentication)
+- [Login rate limiting](#login-rate-limiting)
+- [Session management](#session-management)
+- [CSRF protection](#csrf-protection)
+- [Database access](#database-access)
+- [Audit log integrity](#audit-log-integrity)
+- [File system hardening](#file-system-hardening)
+- [REST API keys](#rest-api-keys)
+- [Reverse proxy considerations](#reverse-proxy-considerations)
+
+---
+
+## HTTPS
+
+**HTTPS is required.** The application redirects all HTTP traffic to HTTPS at the application layer and sets `Secure` on all session cookies. Do not run this in production over plain HTTP.
+
+If you terminate TLS at a reverse proxy, set `'proxy_trust' => true` in `config.php` so the app trusts `X-Forwarded-Proto: https`. See the [configuration guide](configuration.md#behind-a-reverse-proxy).
+
+---
+
+## Authentication
+
+- Passwords are stored using PHP's `password_hash()` with `PASSWORD_DEFAULT` (bcrypt).
+- `password_needs_rehash()` is checked on every login — hashes are silently upgraded if the cost factor changes.
+- Session cookies are set with `Secure`, `HttpOnly`, and `SameSite=Strict`.
+- `session.use_strict_mode` and `session.use_only_cookies` are enabled.
+- The session ID is regenerated on login (`session_regenerate_id(true)`).
+
+### Default credentials
+
+Change the bootstrap admin password **before** the site receives any traffic. The default credentials (`admin` / `ChangeMeNow!12345`) are well-known and must not be used in production.
+
+---
+
+## Login rate limiting
+
+From v0.11, failed login attempts are tracked per IP address in the `login_attempts` table.
+
+- After `login_max_attempts` consecutive failures (default: **5**) within the lockout window, the IP is blocked for `login_lockout_seconds` (default: **15 minutes**).
+- A successful login clears the failure counter for that IP.
+- Blocked attempts are recorded in the audit log as `auth.login_blocked`.
+- Stale records are purged automatically — no cron job or manual cleanup is required.
+
+These defaults can be tuned in `config.php`. See the [configuration reference](configuration.md#login_max_attempts).
+
+---
+
+## Session management
+
+- Sessions expire after `session_idle_seconds` of inactivity (default: **30 minutes**).
+- On expiry the user is redirected to the login page with an informational message.
+- The idle timeout is refreshed on every authenticated page load.
+
+---
+
+## CSRF protection
+
+All POST endpoints call `csrf_require()`, which validates a per-session token stored in `$_SESSION['csrf']`. Requests with a missing or mismatched token are rejected with HTTP 400.
+
+---
+
+## Database access
+
+- All queries use **PDO prepared statements** — no string interpolation of user input into SQL.
+- SQLite WAL mode is enabled for better concurrency and crash safety.
+- Foreign key enforcement is enabled (`PRAGMA foreign_keys = ON`).
+
+---
+
+## Audit log integrity
+
+The `audit_log` table is **append-only**. SQLite triggers prevent any `UPDATE` or `DELETE` on audit rows — even the database owner cannot silently alter past entries. The audit log records:
+
+- Login, logout, and failed login events (including rate-limited blocks)
+- All create / update / delete operations on subnets, addresses, sites, and users
+- CSV import events (dry-run and apply)
+- Export actions
+- API key lifecycle events (create, deactivate, activate, delete)
+
+---
+
+## File system hardening
+
+The included `.htaccess` (Apache / LiteSpeed) blocks direct HTTP access to:
+
+- `data/` directory and `*.sqlite` / `*.db` files
+- `*.sh`, `*.sql`, `*.json` files
+- Build and release artefacts (`*.tar.gz`, `*.zip`, `*.bundle.txt`, `SHA256SUMS`)
+
+**Nginx users** must replicate these rules manually — Nginx does not process `.htaccess` files. See the [install guide](install.md#nginx) for the rules to translate.
+
+The recommended file permissions further limit exposure:
+
+| Path | Permissions |
+|------|------------|
+| `data/` | `0700` — web server user only |
+| `data/ipam.sqlite` | `0600` — web server user only |
+| `config.php` | `0640` — not world-readable |
+
+See the full [permissions reference](install.md#file-permissions-reference).
+
+---
+
+## REST API keys
+
+API keys grant read-only access to the JSON API (`api.php`).
+
+- Keys are generated using `random_bytes(32)` (256 bits of entropy) and encoded as 64-character hex strings.
+- Only a **SHA-256 hash** of the key is stored — the raw key cannot be recovered from the database.
+- If a key is lost, delete it and generate a new one.
+- Keys can be deactivated instantly from **Admin → API Keys** without deleting them.
+- All key lifecycle events are recorded in the audit log.
+- The API is **read-only** — no write operations are exposed.
+
+Pass keys via the `Authorization: Bearer <key>` header. Avoid passing them as query parameters in environments where URLs may appear in server logs or browser history.
+
+---
+
+## Reverse proxy considerations
+
+If you place a reverse proxy (nginx, Caddy, HAProxy, AWS ALB, etc.) in front of the application:
+
+- Set `'proxy_trust' => true` in `config.php` only if the proxy reliably strips or overwrites `X-Forwarded-Proto` from untrusted clients.
+- Ensure the proxy forwards the real client IP in `REMOTE_ADDR` or a trusted header — the login rate limiter keys on `REMOTE_ADDR`. If all requests appear to come from a single proxy IP, the rate limiter will be ineffective.
+- Apply rate limiting or WAF rules at the proxy layer as an additional defence-in-depth measure.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,110 @@
+# Upgrading
+
+## Contents
+
+- [Overview](#overview)
+- [Upgrade steps](#upgrade-steps)
+- [upgrade.sh options](#upgradesh-options)
+- [Environment variables](#environment-variables)
+- [What the backup looks like](#what-the-backup-looks-like)
+- [CLI utilities](#cli-utilities)
+
+---
+
+## Overview
+
+Upgrades are handled by `upgrade.sh`, included in every release bundle. The script:
+
+- Creates a **timestamped backup** of your current install (including the SQLite DB and WAL files)
+- Syncs new application files into the target directory using `rsync`
+- **Preserves `config.php`** and the entire `data/` directory
+- Fixes file permissions after the sync
+- Runs **database migrations automatically** (if the `php` CLI is available)
+- Removes upgrade artefacts from the webroot
+
+If the migration step fails, `upgrade.sh` automatically **restores from the backup** and exits with code `10`.
+
+---
+
+## Upgrade steps
+
+```bash
+# 1. Download and extract the new release bundle
+tar -xzf ipam-0.11.tar.gz -C /tmp/
+
+# 2. Run upgrade.sh, pointing it at your current install directory
+bash /tmp/Simple-PHP-IPAM/upgrade.sh /var/www/ipam
+```
+
+The script confirms the version transition (e.g. `0.10 → 0.11`) before making any changes.
+
+To skip the confirmation prompt (e.g. in a CI/CD pipeline):
+
+```bash
+bash /tmp/Simple-PHP-IPAM/upgrade.sh --yes /var/www/ipam
+```
+
+---
+
+## upgrade.sh options
+
+| Flag | Description |
+|---|---|
+| `--yes` | Non-interactive — skip confirmation prompts |
+| `--force` | Allow reinstalling the same version |
+| `--force-downgrade` | Allow downgrading (not recommended — may break the DB schema) |
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CLEANUP_ARTIFACTS` | `1` | Remove build/upgrade artefacts from the target webroot after success |
+| `REMOVE_UPGRADE_SH_FROM_TARGET` | `1` | Also remove `upgrade.sh` from the target webroot |
+
+Example — keep `upgrade.sh` in place after the upgrade:
+
+```bash
+REMOVE_UPGRADE_SH_FROM_TARGET=0 bash /tmp/Simple-PHP-IPAM/upgrade.sh --yes /var/www/ipam
+```
+
+---
+
+## What the backup looks like
+
+```
+/var/www/ipam.backup.20260326-143000/   ← timestamped copy of entire install
+    data/
+        ipam.sqlite
+        ipam.sqlite-wal   ← if present (WAL mode journal)
+        ipam.sqlite-shm   ← if present
+    config.php
+    ... (all other app files)
+```
+
+The backup is left in place after a successful upgrade. You can remove it manually once you have verified the new version is working correctly.
+
+---
+
+## CLI utilities
+
+These scripts are run from the application directory using the PHP CLI.
+
+### Run database migrations manually
+
+```bash
+cd /var/www/ipam
+php migrate.php
+```
+
+Applies any pending schema migrations. Migrations are also applied automatically on each web request (`ipam_db_init()`) and during upgrades via `upgrade.sh`, so this is only needed for scripted or manual deployments.
+
+### Clean up stale temp files
+
+```bash
+cd /var/www/ipam
+php tmp_cleanup.php
+```
+
+Deletes uploaded CSV files and import plan files in `data/tmp/` that are older than `tmp_cleanup_ttl_seconds` (default: 24 hours). This also runs automatically as part of lazy housekeeping on normal site traffic — a cron job is not required.


### PR DESCRIPTION
Move detailed content from README into four new docs:
- docs/install.md     — requirements, web server setup, permissions, first login
- docs/configuration.md — full config.php reference including v0.11 settings
- docs/upgrading.md   — upgrade.sh guide + CLI utilities
- docs/security.md    — HTTPS, rate limiting, sessions, CSRF, audit, API keys

README is now a concise landing page with a features summary, quick-start steps, and a documentation index table.

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3