### PR TITLE
feat: move user menu to right nav with dropdown

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -186,15 +186,37 @@ h3{font-size:1.05rem}
 .nav-dropdown.open .nav-dropdown-menu{
   display:block;
 }
+.nav-dropdown-menu--right{
+  left:auto;
+  right:0;
+}
+.nav-user-toggle{
+  color:var(--fg);
+}
 .nav-dropdown-item{
   display:block;
+  width:100%;
   padding:9px 16px;
   color:var(--fg);
   white-space:nowrap;
+  /* reset for <button> */
+  background:none;
+  border:none;
+  border-radius:0;
+  text-align:left;
+  cursor:pointer;
+  font:inherit;
+  box-sizing:border-box;
 }
 .nav-dropdown-item:hover{
   background:var(--card-2);
   text-decoration:none;
+  filter:none;
+}
+.nav-dropdown-divider{
+  border:none;
+  border-top:1px solid var(--border);
+  margin:6px 0;
 }
 
 .card{

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -42,6 +42,11 @@
 
     // Dropdown toggle
     document.addEventListener("click", function(e) {
+      // Theme toggle inside user dropdown — cycle theme but keep dropdown open
+      if (e.target.closest("#theme-toggle")) {
+        return;
+      }
+
       const toggle = e.target.closest(".nav-dropdown-toggle");
       if (toggle) {
         const dropdown = toggle.closest(".nav-dropdown");

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -800,7 +800,6 @@ function page_header(string $title): void
     echo "<div class='topbar'><div class='nav-wrap'>";
     echo "<div class='nav-links'>";
     if ($u) {
-        echo "<span class='nav-user'>Logged in as <b>" . e((string)$u) . "</b> <span class='badge'>" . e((string)$role) . "</span></span>";
         echo "<a class='nav-pill' href='dashboard.php'>🏠 Dashboard</a>";
         echo "<a class='nav-pill' href='subnets.php'>🌐 Subnets</a>";
         echo "<a class='nav-pill' href='addresses.php'>🧾 Addresses</a>";
@@ -816,16 +815,25 @@ function page_header(string $title): void
             echo "<a class='nav-dropdown-item' href='import_csv.php'>⬆ Import CSV</a>";
             echo "</div></div>";
         }
-        echo "<a class='nav-pill' href='change_password.php'>🔐 Password</a>";
-        echo "<a class='nav-pill' href='logout.php'>↩ Logout</a>";
     } else {
         echo "<a class='nav-pill' href='login.php'>🔐 Login</a>";
     }
     echo "</div>";
 
-    echo "<div class='nav-right'>";
-    echo "<button type='button' class='button-secondary' id='theme-toggle' onclick='ipamCycleTheme()'>🌓 Theme</button>";
-    echo "</div>";
+    if ($u) {
+        echo "<div class='nav-right'>";
+        echo "<div class='nav-dropdown'>";
+        echo "<button type='button' class='nav-pill nav-dropdown-toggle nav-user-toggle'>";
+        echo e((string)$u) . " <span class='badge'>" . e((string)$role) . "</span> ▾";
+        echo "</button>";
+        echo "<div class='nav-dropdown-menu nav-dropdown-menu--right'>";
+        echo "<button type='button' class='nav-dropdown-item' id='theme-toggle' onclick='ipamCycleTheme()'>🌓 Theme</button>";
+        echo "<hr class='nav-dropdown-divider'>";
+        echo "<a class='nav-dropdown-item' href='change_password.php'>🔐 Password</a>";
+        echo "<a class='nav-dropdown-item' href='logout.php'>↩ Logout</a>";
+        echo "</div></div>";
+        echo "</div>";
+    }
 
     echo "</div></div>";
     echo "<div class='page'>";


### PR DESCRIPTION
- Username + role badge moved from far-left of nav to far-right
- Password, Logout, and Theme toggle collapsed into a user dropdown
- Theme button stays open in the dropdown while cycling (prevents dropdown from closing mid-cycle)
- Right-aligned dropdown variant (.nav-dropdown-menu--right) so menu never overflows off the right edge of the viewport
- .nav-dropdown-item button reset so <button> and <a> items render identically; divider between Theme and account links

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3