### PR TITLE
feat: v0.12 — OIDC authentication + user menu redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 0.12 — User Menu Redesign and OIDC Authentication
+
+### Milestone 1 — User Menu & Nav Polish
+
+#### User dropdown (`lib.php`, `assets/app.css`, `assets/app.js`)
+- Username and role badge moved from the far-left of the nav bar to the far-right
+- Password, Logout, and Theme toggle consolidated into a single user dropdown menu
+- Theme button remains open in the dropdown while cycling so the user can step through modes without re-opening
+- Right-anchored dropdown variant (`.nav-dropdown-menu--right`) prevents off-screen overflow
+- `.nav-dropdown-item` unified to style both `<a>` and `<button>` elements identically; divider between Theme and account links
+
+---
+
+### Milestone 2 — OIDC Authentication
+
+#### Authorization Code + PKCE flow (`oidc_login.php`, `oidc_callback.php`, `lib.php`)
+- Full OIDC Authorization Code + PKCE flow implemented in pure PHP — no Composer packages or external dependencies
+- `oidc_login.php`: generates PKCE verifier/challenge pair and state/nonce, stores them in session, redirects to IdP
+- `oidc_callback.php`: validates state (CSRF guard), exchanges authorization code for tokens, verifies ID token, resolves local user
+- ID token verification supports RS256/RS384/RS512; JWK→PEM conversion is done in-process using PHP's `openssl` extension
+- JWKS are cached in `data/tmp/` for 1 hour; one automatic cache-bust retry handles in-flight key rotation
+- Discovery document (`/.well-known/openid-configuration`) is also cached for 1 hour
+
+#### ID token verification (`lib.php`)
+- `oidc_verify_id_token()`: validates signature, `exp`, `iat`, `iss`, `aud`, and `nonce`
+- `jwk_rsa_to_pem()`: constructs DER SubjectPublicKeyInfo from JWK `n`/`e` fields without `ext-gmp`
+- `oidc_pkce_pair()`: generates RFC 7636 S256 code challenge from a 32-byte random verifier
+
+#### User provisioning and linking
+- On successful OIDC login the `sub` claim is matched against `users.oidc_sub`
+- With `auto_provision = true`: if no linked user is found, an existing local user with a matching username/email is linked; otherwise a new account is created with an unusable password and the configured `default_role`
+- OIDC lifecycle events recorded in audit log: `auth.oidc_login`, `auth.oidc_provision`, `auth.oidc_link`, `auth.oidc_failed`
+
+#### Database migration (`migrations.php`)
+- Migration `0.12` adds `oidc_sub TEXT` column to `users` table
+- Partial unique index enforces that each IdP subject maps to at most one local user
+
+#### Admin UI (`users.php`)
+- SSO column shows "linked" (green, full `sub` on hover) or "—" for each user
+- "Unlink SSO" button lets admins remove the `oidc_sub` association without deleting the account
+
+#### Login page (`login.php`)
+- When OIDC is enabled, a prominent "Sign in with \<display_name\>" button appears above the local login form
+- OIDC error flash messages (set by the callback on failure) are displayed on the login page
+
+#### Configuration (`config.php`)
+- New `oidc` section: `enabled`, `display_name`, `client_id`, `client_secret`, `discovery_url`, `redirect_uri`, `scopes`, `auto_provision`, `default_role`
+- Defaults to disabled; no behaviour change for existing installs
+
+#### Bug fix
+- `api.php`: addresses resource used non-existent `description` column; corrected to `note` to match schema
+
+---
+
 ## 0.11 — Security Hardening, Nav Polish, and REST API
 
 ### Milestone 1 — Security Hardening

--- a/README.md
+++ b/README.md
@@ -72,12 +72,19 @@ See the [Installation guide](docs/install.md) for full web server configuration 
 | [Upgrading](docs/upgrading.md) | Using `upgrade.sh`, CLI migration utilities |
 | [Security](docs/security.md) | HTTPS, rate limiting, session hardening, audit log, API keys |
 | [REST API](docs/api.md) | API authentication, endpoints, pagination, examples |
+| [OIDC Authentication](docs/oidc.md) | SSO setup, IdP examples, user provisioning |
 
 ---
 
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.
+
+### What's new in 0.12
+
+**User menu** — Username and role moved to the far-right of the nav bar; Password, Logout, and Theme toggle consolidated into a user dropdown.
+
+**OIDC Authentication** — Authorization Code + PKCE single sign-on in pure PHP. Supports any compliant IdP (Google, Azure AD, Okta, Keycloak, etc.). Auto-provisioning optional. Configured entirely in `config.php`.
 
 ### What's new in 0.11
 

--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -147,7 +147,7 @@ function api_addresses(PDO $db): never
     $total = (int)$cntSt->fetch()['c'];
 
     $sql = "SELECT a.id, a.subnet_id, a.ip, a.hostname, a.owner,
-                   a.status, a.description, a.created_at
+                   a.status, a.note, a.created_at
             FROM addresses a $whereSql
             ORDER BY a.ip_bin
             LIMIT :lim OFFSET :off";
@@ -168,7 +168,7 @@ function api_addresses(PDO $db): never
             'hostname'    => (string)$r['hostname'],
             'owner'       => (string)$r['owner'],
             'status'      => $r['status'],
-            'description' => (string)$r['description'],
+            'note'        => (string)$r['note'],
             'created_at'  => $r['created_at'],
         ];
     }, $st->fetchAll());

--- a/Simple-PHP-IPAM/config.php
+++ b/Simple-PHP-IPAM/config.php
@@ -29,4 +29,42 @@ return [
         'enabled' => true,
         'interval_seconds' => 86400, // once per day
     ],
+
+    // -----------------------------------------------------------------------
+    // OIDC — Authorization Code + PKCE single sign-on (optional)
+    // Set 'enabled' => true and fill in the IdP details to activate.
+    // The redirect_uri must be registered with your IdP exactly as written.
+    // -----------------------------------------------------------------------
+    'oidc' => [
+        'enabled'        => false,
+
+        // Label shown on the login page button, e.g. 'Okta', 'Azure AD', 'Google'
+        'display_name'   => 'SSO',
+
+        'client_id'      => '',
+        'client_secret'  => '',
+
+        // Base URL of the IdP (/.well-known/openid-configuration is appended automatically),
+        // or the full discovery document URL if the path differs.
+        // Examples:
+        //   'https://accounts.google.com'
+        //   'https://login.microsoftonline.com/{tenant}/v2.0'
+        //   'https://your-org.okta.com/oauth2/default'
+        'discovery_url'  => '',
+
+        // Must match exactly what is registered in the IdP application settings.
+        'redirect_uri'   => '',   // e.g. 'https://ipam.example.com/oidc_callback.php'
+
+        // Space-separated scopes. 'openid' is required; 'email' is needed for
+        // auto-provisioning. 'profile' is optional.
+        'scopes'         => 'openid email profile',
+
+        // auto_provision: if true, a local user is created on first OIDC login
+        // when no existing user is linked to the IdP subject (sub) claim.
+        // The email claim is used as the username.
+        'auto_provision' => false,
+
+        // Role assigned to auto-provisioned users. 'readonly' is recommended.
+        'default_role'   => 'readonly',
+    ],
 ];

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -845,3 +845,251 @@ function page_footer(): void
     echo "<hr><div class='muted'>PHP SQLite IPAM v" . e(IPAM_VERSION) . "</div>";
     echo "</div></body></html>";
 }
+
+/* ============================================================
+ * OIDC — Authorization Code + PKCE (pure PHP, no dependencies)
+ * ============================================================ */
+
+function oidc_enabled(array $config): bool
+{
+    $o = $config['oidc'] ?? [];
+    return !empty($o['enabled'])
+        && !empty($o['client_id'])
+        && !empty($o['client_secret'])
+        && !empty($o['discovery_url'])
+        && !empty($o['redirect_uri']);
+}
+
+/**
+ * Fetch and cache the IdP's OpenID Connect discovery document.
+ * Appends /.well-known/openid-configuration if the URL doesn't already
+ * contain that path.
+ */
+function oidc_discovery(array $config): array
+{
+    $base = rtrim((string)($config['oidc']['discovery_url'] ?? ''), '/');
+    if ($base === '') throw new RuntimeException('OIDC discovery_url not set');
+
+    $url = (str_contains($base, '.well-known')) ? $base : $base . '/.well-known/openid-configuration';
+
+    ensure_tmp_dir();
+    $cache = tmp_dir() . '/oidc-disc-' . md5($url) . '.json';
+
+    if (is_file($cache) && (time() - (int)filemtime($cache)) < 3600) {
+        $d = json_decode((string)file_get_contents($cache), true);
+        if (is_array($d) && !empty($d['authorization_endpoint'])) return $d;
+    }
+
+    $raw = oidc_http_get($url);
+    $d   = json_decode($raw, true);
+    if (!is_array($d) || empty($d['authorization_endpoint'])) {
+        throw new RuntimeException('Invalid OIDC discovery document from ' . $url);
+    }
+
+    file_put_contents($cache, json_encode($d));
+    @chmod($cache, 0600);
+    return $d;
+}
+
+/**
+ * Fetch and cache the IdP's JSON Web Key Set.
+ * Pass $forceRefresh = true to bypass the cache (used after a verify failure
+ * to handle key rotation).
+ */
+function oidc_jwks(string $jwksUri, bool $forceRefresh = false): array
+{
+    ensure_tmp_dir();
+    $cache = tmp_dir() . '/oidc-jwks-' . md5($jwksUri) . '.json';
+
+    if (!$forceRefresh && is_file($cache) && (time() - (int)filemtime($cache)) < 3600) {
+        $d = json_decode((string)file_get_contents($cache), true);
+        if (is_array($d) && !empty($d['keys'])) return (array)$d['keys'];
+    }
+
+    $raw = oidc_http_get($jwksUri);
+    $d   = json_decode($raw, true);
+    if (!is_array($d) || !isset($d['keys'])) {
+        throw new RuntimeException('Invalid JWKS from ' . $jwksUri);
+    }
+
+    file_put_contents($cache, json_encode($d));
+    @chmod($cache, 0600);
+    return (array)$d['keys'];
+}
+
+/** HTTP GET via file_get_contents with a short timeout. */
+function oidc_http_get(string $url): string
+{
+    $ctx = stream_context_create(['http' => ['timeout' => 10, 'ignore_errors' => true]]);
+    $raw = @file_get_contents($url, false, $ctx);
+    if ($raw === false || $raw === '') {
+        throw new RuntimeException('HTTP GET failed for ' . $url);
+    }
+    return $raw;
+}
+
+/** POST application/x-www-form-urlencoded and return decoded JSON array. */
+function oidc_http_post(string $url, array $params): array
+{
+    $body = http_build_query($params);
+    $ctx  = stream_context_create(['http' => [
+        'method'        => 'POST',
+        'header'        => "Content-Type: application/x-www-form-urlencoded\r\n"
+                         . "Content-Length: " . strlen($body) . "\r\n",
+        'content'       => $body,
+        'timeout'       => 15,
+        'ignore_errors' => true,
+    ]]);
+    $raw = @file_get_contents($url, false, $ctx);
+    if ($raw === false) throw new RuntimeException('Token endpoint request failed');
+    $d = json_decode($raw, true);
+    if (!is_array($d)) throw new RuntimeException('Invalid JSON from token endpoint');
+    if (!empty($d['error'])) {
+        throw new RuntimeException('Token endpoint error: ' . $d['error']
+            . (isset($d['error_description']) ? ' — ' . $d['error_description'] : ''));
+    }
+    return $d;
+}
+
+/* ---- PKCE ---- */
+
+function base64url_encode(string $bytes): string
+{
+    return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+}
+
+function base64url_decode(string $s): string
+{
+    $s = strtr($s, '-_', '+/');
+    $pad = strlen($s) % 4;
+    if ($pad) $s .= str_repeat('=', 4 - $pad);
+    $result = base64_decode($s, true);
+    if ($result === false) throw new RuntimeException('Invalid base64url string');
+    return $result;
+}
+
+/**
+ * Generate a PKCE verifier and S256 challenge pair.
+ * @return array{verifier: string, challenge: string}
+ */
+function oidc_pkce_pair(): array
+{
+    $verifier  = base64url_encode(random_bytes(32));
+    $challenge = base64url_encode(hash('sha256', $verifier, true));
+    return ['verifier' => $verifier, 'challenge' => $challenge];
+}
+
+/* ---- JWT / JWK verification ---- */
+
+/**
+ * Decode and verify an RS256/RS384/RS512 signed ID token.
+ * Returns the verified payload claims array.
+ *
+ * @param array $jwks    Keys from the IdP's JWKS endpoint
+ * @param array $expect  Claims to validate: iss, aud, nonce
+ */
+function oidc_verify_id_token(string $idToken, array $jwks, array $expect): array
+{
+    $parts = explode('.', $idToken);
+    if (count($parts) !== 3) throw new RuntimeException('Malformed JWT');
+
+    [$hdrB64, $payB64, $sigB64] = $parts;
+
+    $header  = json_decode(base64url_decode($hdrB64), true);
+    $payload = json_decode(base64url_decode($payB64), true);
+    if (!is_array($header) || !is_array($payload)) {
+        throw new RuntimeException('JWT header/payload decoding failed');
+    }
+
+    $alg = (string)($header['alg'] ?? '');
+    $algMap = ['RS256' => OPENSSL_ALGO_SHA256, 'RS384' => OPENSSL_ALGO_SHA384, 'RS512' => OPENSSL_ALGO_SHA512];
+    if (!isset($algMap[$alg])) {
+        throw new RuntimeException("Unsupported JWT alg: $alg");
+    }
+
+    // Find the matching JWK
+    $kid = $header['kid'] ?? null;
+    $jwk = null;
+    foreach ($jwks as $k) {
+        if (!is_array($k) || ($k['kty'] ?? '') !== 'RSA') continue;
+        if ($kid !== null && ($k['kid'] ?? '') !== $kid) continue;
+        $jwk = $k;
+        break;
+    }
+    if ($jwk === null) {
+        throw new RuntimeException('No matching RSA JWK for kid=' . ($kid ?? 'none'));
+    }
+
+    $pem    = jwk_rsa_to_pem($jwk);
+    $pubKey = openssl_pkey_get_public($pem);
+    if ($pubKey === false) throw new RuntimeException('Failed to import JWK public key');
+
+    $sig    = base64url_decode($sigB64);
+    $result = openssl_verify($hdrB64 . '.' . $payB64, $sig, $pubKey, $algMap[$alg]);
+    if ($result !== 1) throw new RuntimeException('JWT signature invalid');
+
+    // Standard claim validation
+    $now = time();
+    if (isset($payload['exp']) && (int)$payload['exp'] < $now - 60) {
+        throw new RuntimeException('ID token has expired');
+    }
+    if (isset($payload['iat']) && (int)$payload['iat'] > $now + 60) {
+        throw new RuntimeException('ID token iat is in the future');
+    }
+    if (isset($expect['iss']) && ($payload['iss'] ?? '') !== $expect['iss']) {
+        throw new RuntimeException('ID token issuer mismatch');
+    }
+    if (isset($expect['aud'])) {
+        $aud   = $payload['aud'] ?? '';
+        $audOk = (is_string($aud) && $aud === $expect['aud'])
+              || (is_array($aud)  && in_array($expect['aud'], $aud, true));
+        if (!$audOk) throw new RuntimeException('ID token audience mismatch');
+    }
+    if (isset($expect['nonce']) && ($payload['nonce'] ?? '') !== $expect['nonce']) {
+        throw new RuntimeException('ID token nonce mismatch');
+    }
+
+    return $payload;
+}
+
+/**
+ * Convert an RSA JWK (n, e fields) to a PEM-encoded public key.
+ * Builds the DER SubjectPublicKeyInfo structure manually so we have
+ * no dependency on ext-gmp or any JOSE library.
+ */
+function jwk_rsa_to_pem(array $jwk): string
+{
+    $n = base64url_decode((string)($jwk['n'] ?? ''));
+    $e = base64url_decode((string)($jwk['e'] ?? ''));
+    if ($n === '' || $e === '') throw new RuntimeException('JWK missing n or e');
+
+    // DER integers must not have a leading 1-bit (would be interpreted as negative)
+    if (ord($n[0]) & 0x80) $n = "\x00" . $n;
+    if (ord($e[0]) & 0x80) $e = "\x00" . $e;
+
+    $intN   = "\x02" . der_len(strlen($n)) . $n;
+    $intE   = "\x02" . der_len(strlen($e)) . $e;
+    $rsaSeq = "\x30" . der_len(strlen($intN) + strlen($intE)) . $intN . $intE;
+
+    // AlgorithmIdentifier for rsaEncryption (OID 1.2.840.113549.1.1.1) with NULL params
+    $oid   = "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00";
+    $algId = "\x30" . der_len(strlen($oid)) . $oid;
+
+    // BIT STRING: 0x00 unused-bits prefix + DER RSAPublicKey
+    $bitStr = "\x03" . der_len(strlen($rsaSeq) + 1) . "\x00" . $rsaSeq;
+
+    // SubjectPublicKeyInfo SEQUENCE
+    $spki = "\x30" . der_len(strlen($algId) + strlen($bitStr)) . $algId . $bitStr;
+
+    return "-----BEGIN PUBLIC KEY-----\n"
+         . chunk_split(base64_encode($spki), 64, "\n")
+         . "-----END PUBLIC KEY-----\n";
+}
+
+/** Encode an ASN.1 DER length. */
+function der_len(int $len): string
+{
+    if ($len < 0x80) return chr($len);
+    if ($len < 0x100) return "\x81" . chr($len);
+    return "\x82" . chr($len >> 8) . chr($len & 0xFF);
+}

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -11,6 +11,12 @@ $lockoutSeconds = (int)($config['login_lockout_seconds'] ?? 900);
 $error = '';
 $timedOut = !empty($_GET['timeout']);
 
+// Consume any OIDC error flash set by oidc_callback.php or oidc_login.php
+if (!empty($_SESSION['oidc_error'])) {
+    $error = (string)$_SESSION['oidc_error'];
+    unset($_SESSION['oidc_error']);
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $username = trim((string)($_POST['username'] ?? ''));
     $password = (string)($_POST['password'] ?? '');
@@ -53,6 +59,15 @@ page_header('Login');
   <p class="warning">Your session expired due to inactivity. Please log in again.</p>
 <?php endif; ?>
 <?php if ($error): ?><p class="danger"><?= e($error) ?></p><?php endif; ?>
+
+<?php if (oidc_enabled($config)): ?>
+<p>
+  <a href="oidc_login.php" style="display:inline-block;padding:10px 18px;border-radius:12px;background:var(--btn);color:var(--btnfg);text-decoration:none;font-weight:600">
+    Sign in with <?= e((string)($config['oidc']['display_name'] ?? 'SSO')) ?>
+  </a>
+</p>
+<p class="muted" style="margin:14px 0 4px">— or sign in with a local account —</p>
+<?php endif; ?>
 
 <form method="post" action="login.php" autocomplete="off">
   <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -75,6 +75,20 @@ function ipam_migrations(): array
             $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id)");
         },
 
+        // 0.12: OIDC subject claim column on users
+        '0.12' => function(PDO $db) {
+            $cols  = $db->query("PRAGMA table_info(users)")->fetchAll();
+            $names = array_map(fn($c) => $c['name'], $cols);
+
+            if (!in_array('oidc_sub', $names, true)) {
+                $db->exec("ALTER TABLE users ADD COLUMN oidc_sub TEXT");
+            }
+
+            // Partial unique index: only enforce uniqueness when oidc_sub is not NULL
+            $db->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_oidc_sub
+                       ON users(oidc_sub) WHERE oidc_sub IS NOT NULL");
+        },
+
         // 0.11: login rate-limiting + REST API keys
         '0.11' => function(PDO $db) {
             $db->exec("

--- a/Simple-PHP-IPAM/oidc_callback.php
+++ b/Simple-PHP-IPAM/oidc_callback.php
@@ -1,0 +1,148 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+
+if (is_logged_in())         { header('Location: dashboard.php'); exit; }
+if (!oidc_enabled($config)) { header('Location: login.php');     exit; }
+
+/**
+ * Redirect to login with a generic error message.
+ * Detailed reason is only written to the server error log.
+ */
+function oidc_fail(PDO $db, string $logMsg): never
+{
+    error_log('OIDC callback failure: ' . $logMsg);
+    audit($db, 'auth.oidc_failed', 'user', null, $logMsg);
+    $_SESSION['oidc_error'] = 'SSO authentication failed. Please try again or contact your administrator.';
+    header('Location: login.php');
+    exit;
+}
+
+// ---- State validation (CSRF guard) ----
+
+$returnedState = (string)($_GET['state'] ?? '');
+$savedState    = (string)($_SESSION['oidc_state']    ?? '');
+$nonce         = (string)($_SESSION['oidc_nonce']    ?? '');
+$verifier      = (string)($_SESSION['oidc_verifier'] ?? '');
+
+// Always clear OIDC session keys regardless of outcome
+unset($_SESSION['oidc_state'], $_SESSION['oidc_nonce'], $_SESSION['oidc_verifier']);
+
+if ($savedState === '' || !hash_equals($savedState, $returnedState)) {
+    oidc_fail($db, 'state mismatch');
+}
+
+// ---- IdP error response ----
+if (!empty($_GET['error'])) {
+    oidc_fail($db, 'IdP returned error: ' . $_GET['error']
+        . (isset($_GET['error_description']) ? ' — ' . $_GET['error_description'] : ''));
+}
+
+$code = (string)($_GET['code'] ?? '');
+if ($code === '') oidc_fail($db, 'no authorization code in callback');
+
+// ---- Fetch discovery document ----
+try {
+    $discovery = oidc_discovery($config);
+} catch (Throwable $e) {
+    oidc_fail($db, 'discovery: ' . $e->getMessage());
+}
+
+// ---- Exchange code for tokens ----
+try {
+    $tokens = oidc_http_post($discovery['token_endpoint'], [
+        'grant_type'    => 'authorization_code',
+        'code'          => $code,
+        'redirect_uri'  => (string)$config['oidc']['redirect_uri'],
+        'client_id'     => (string)$config['oidc']['client_id'],
+        'client_secret' => (string)$config['oidc']['client_secret'],
+        'code_verifier' => $verifier,
+    ]);
+} catch (Throwable $e) {
+    oidc_fail($db, 'token exchange: ' . $e->getMessage());
+}
+
+if (empty($tokens['id_token'])) {
+    oidc_fail($db, 'no id_token in token response');
+}
+
+// ---- Verify ID token (with one JWKS cache-bust retry for key rotation) ----
+$expect = [
+    'iss'   => (string)($discovery['issuer'] ?? ''),
+    'aud'   => (string)$config['oidc']['client_id'],
+    'nonce' => $nonce,
+];
+
+try {
+    $jwks    = oidc_jwks((string)$discovery['jwks_uri']);
+    $payload = oidc_verify_id_token((string)$tokens['id_token'], $jwks, $expect);
+} catch (Throwable $e) {
+    // One retry with a fresh JWKS in case the IdP rotated keys
+    try {
+        $jwks    = oidc_jwks((string)$discovery['jwks_uri'], forceRefresh: true);
+        $payload = oidc_verify_id_token((string)$tokens['id_token'], $jwks, $expect);
+    } catch (Throwable $e2) {
+        oidc_fail($db, 'id_token verification: ' . $e2->getMessage());
+    }
+}
+
+$sub   = (string)($payload['sub']   ?? '');
+$email = (string)($payload['email'] ?? '');
+
+if ($sub === '') oidc_fail($db, 'id_token missing sub claim');
+
+// ---- Find or provision local user ----
+
+$st = $db->prepare("SELECT id, username, role, is_active FROM users WHERE oidc_sub = :sub");
+$st->execute([':sub' => $sub]);
+$user = $st->fetch();
+
+if (!$user && !empty($config['oidc']['auto_provision']) && $email !== '') {
+    // Try to link an existing local user whose username matches the email
+    $st2 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE username = :u AND oidc_sub IS NULL");
+    $st2->execute([':u' => $email]);
+    $existing = $st2->fetch();
+
+    if ($existing) {
+        // Link the existing account to this OIDC subject
+        $db->prepare("UPDATE users SET oidc_sub = :sub WHERE id = :id")
+           ->execute([':sub' => $sub, ':id' => (int)$existing['id']]);
+        audit($db, 'auth.oidc_link', 'user', (int)$existing['id'], 'sub=' . $sub);
+        $user = $existing;
+    } else {
+        // Auto-provision a new local user
+        $role = (string)($config['oidc']['default_role'] ?? 'readonly');
+        if (!in_array($role, ['admin', 'readonly'], true)) $role = 'readonly';
+
+        // Set an unusable password hash so the account cannot be used with local auth
+        $unusableHash = password_hash(bin2hex(random_bytes(32)), PASSWORD_DEFAULT);
+
+        $ins = $db->prepare(
+            "INSERT INTO users (username, password_hash, role, is_active, oidc_sub)
+             VALUES (:u, :h, :r, 1, :sub)"
+        );
+        $ins->execute([':u' => $email, ':h' => $unusableHash, ':r' => $role, ':sub' => $sub]);
+        $newId = (int)$db->lastInsertId();
+        audit($db, 'auth.oidc_provision', 'user', $newId, 'email=' . $email . ' sub=' . $sub);
+
+        $st3 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE id = :id");
+        $st3->execute([':id' => $newId]);
+        $user = $st3->fetch();
+    }
+}
+
+if (!$user) {
+    oidc_fail($db, 'no local user found for sub=' . $sub
+        . '. An admin must create or link an account.');
+}
+
+if ((int)$user['is_active'] !== 1) {
+    oidc_fail($db, 'user account is inactive: ' . $user['username']);
+}
+
+// ---- All checks passed — log in ----
+login_user((int)$user['id'], (string)$user['username'], (string)$user['role']);
+audit($db, 'auth.oidc_login', 'user', (int)$user['id'], 'sub=' . $sub);
+
+header('Location: dashboard.php');
+exit;

--- a/Simple-PHP-IPAM/oidc_login.php
+++ b/Simple-PHP-IPAM/oidc_login.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+
+if (is_logged_in())      { header('Location: dashboard.php'); exit; }
+if (!oidc_enabled($config)) { header('Location: login.php');     exit; }
+
+try {
+    $discovery = oidc_discovery($config);
+} catch (Throwable $e) {
+    error_log('OIDC discovery error: ' . $e->getMessage());
+    $_SESSION['oidc_error'] = 'Could not reach the identity provider. Please try again later.';
+    header('Location: login.php');
+    exit;
+}
+
+$pkce  = oidc_pkce_pair();
+$state = bin2hex(random_bytes(16));
+$nonce = bin2hex(random_bytes(16));
+
+$_SESSION['oidc_state']    = $state;
+$_SESSION['oidc_nonce']    = $nonce;
+$_SESSION['oidc_verifier'] = $pkce['verifier'];
+
+$params = [
+    'response_type'         => 'code',
+    'client_id'             => (string)$config['oidc']['client_id'],
+    'redirect_uri'          => (string)$config['oidc']['redirect_uri'],
+    'scope'                 => (string)($config['oidc']['scopes'] ?? 'openid email profile'),
+    'state'                 => $state,
+    'nonce'                 => $nonce,
+    'code_challenge'        => $pkce['challenge'],
+    'code_challenge_method' => 'S256',
+];
+
+header('Location: ' . $discovery['authorization_endpoint'] . '?' . http_build_query($params));
+exit;

--- a/Simple-PHP-IPAM/users.php
+++ b/Simple-PHP-IPAM/users.php
@@ -57,10 +57,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             audit($db, 'user.reset_password', 'user', $id, 'admin reset');
             $msg = 'Password reset.';
         }
+    } elseif ($action === 'unlink_oidc') {
+        $id = (int)($_POST['id'] ?? 0);
+        $db->prepare("UPDATE users SET oidc_sub = NULL WHERE id = :id")
+           ->execute([':id' => $id]);
+        audit($db, 'user.oidc_unlink', 'user', $id, '');
+        $msg = 'OIDC link removed.';
     }
 }
 
-$st = $db->prepare("SELECT id, username, role, is_active, created_at, updated_at FROM users ORDER BY username ASC");
+$st = $db->prepare("SELECT id, username, role, is_active, created_at, updated_at, oidc_sub FROM users ORDER BY username ASC");
 $st->execute();
 $users = $st->fetchAll();
 
@@ -91,7 +97,7 @@ page_header('Users');
 <table>
   <thead>
     <tr>
-      <th>Username</th><th>Role</th><th>Active</th><th>Created</th><th>Updated</th><th>Actions</th>
+      <th>Username</th><th>Role</th><th>Active</th><th>SSO</th><th>Created</th><th>Updated</th><th>Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -100,6 +106,13 @@ page_header('Users');
       <td><?= e($u['username']) ?></td>
       <td><?= e($u['role']) ?></td>
       <td><?= ((int)$u['is_active'] === 1) ? 'yes' : 'no' ?></td>
+      <td>
+        <?php if ($u['oidc_sub'] !== null): ?>
+          <span class="success" title="<?= e((string)$u['oidc_sub']) ?>">linked</span>
+        <?php else: ?>
+          <span class="muted">—</span>
+        <?php endif; ?>
+      </td>
       <td class="muted"><?= e($u['created_at']) ?></td>
       <td class="muted"><?= e($u['updated_at']) ?></td>
       <td>
@@ -128,6 +141,16 @@ page_header('Users');
           <input type="password" name="new_password" placeholder="New password" required>
           <button type="submit">Reset PW</button>
         </form>
+
+        <?php if ($u['oidc_sub'] !== null): ?>
+        <form method="post" action="users.php" class="row" style="gap:6px; margin-top:6px"
+              onsubmit="return confirm('Remove SSO link for <?= e((string)$u['username']) ?>?')">
+          <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+          <input type="hidden" name="action" value="unlink_oidc">
+          <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+          <button type="submit" class="button-secondary">Unlink SSO</button>
+        </form>
+        <?php endif; ?>
       </td>
     </tr>
   <?php endforeach; ?>

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-const IPAM_VERSION = '0.11';
+const IPAM_VERSION = '0.12';

--- a/docs/api.md
+++ b/docs/api.md
@@ -174,7 +174,7 @@ Returns a paginated list of address records.
       "hostname": "server01.example.com",
       "owner": "ops-team",
       "status": "used",
-      "description": "Primary web server",
+      "note": "Primary web server",
       "created_at": "2025-02-01 08:15:30"
     }
   ]
@@ -193,7 +193,7 @@ Results are ordered by IP address (binary sort — correct numerical order withi
 | `hostname` | string | Hostname (may be empty) |
 | `owner` | string | Owner/team (may be empty) |
 | `status` | string | `used`, `reserved`, or `free` |
-| `description` | string | Free-text description (may be empty) |
+| `note` | string | Free-text note (may be empty) |
 | `created_at` | string | UTC timestamp (`YYYY-MM-DD HH:MM:SS`) |
 
 ---

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -1,0 +1,181 @@
+# OIDC Authentication
+
+Simple-PHP-IPAM supports single sign-on via OpenID Connect (OIDC) Authorization Code + PKCE flow. Any compliant IdP works: Google, Microsoft Entra ID (Azure AD), Okta, Keycloak, Auth0, Authentik, Dex, and others.
+
+OIDC is implemented in pure PHP using only the built-in `openssl` extension — no Composer packages required.
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Configuration](#configuration)
+- [IdP setup examples](#idp-setup-examples)
+- [User provisioning and linking](#user-provisioning-and-linking)
+- [Disabling local login](#disabling-local-login)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## How it works
+
+1. User clicks **Sign in with \<display\_name\>** on the login page
+2. Browser is redirected to the IdP with a PKCE code challenge, state, and nonce
+3. User authenticates at the IdP
+4. IdP redirects back to `oidc_callback.php` with an authorization code
+5. The callback exchanges the code for an ID token (verifying the PKCE code verifier)
+6. The ID token signature is verified against the IdP's JWKS (RS256/RS384/RS512)
+7. The `sub` claim is matched to a local user account; if `auto_provision` is enabled a new account is created if none exists
+8. The user is logged in with the same session mechanism as local auth
+
+The discovery document and JWKS are cached in `data/tmp/` for one hour. A single automatic JWKS cache-bust is attempted if signature verification fails, to handle in-flight key rotation.
+
+---
+
+## Prerequisites
+
+- PHP 8.2+ with `openssl` extension (standard on most hosts)
+- HTTPS — OIDC callbacks must be served over HTTPS
+- `allow_url_fopen = On` in `php.ini` (used for discovery and JWKS fetches)
+- An OIDC client registered with your IdP (see [IdP setup examples](#idp-setup-examples))
+
+---
+
+## Configuration
+
+Add the following to your `config.php`:
+
+```php
+'oidc' => [
+    'enabled'        => true,
+    'display_name'   => 'Okta',          // Label on the login button
+    'client_id'      => 'your-client-id',
+    'client_secret'  => 'your-client-secret',
+    'discovery_url'  => 'https://your-org.okta.com/oauth2/default',
+    'redirect_uri'   => 'https://ipam.example.com/oidc_callback.php',
+    'scopes'         => 'openid email profile',
+    'auto_provision' => false,
+    'default_role'   => 'readonly',
+],
+```
+
+### Settings
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `enabled` | yes | Set to `true` to activate OIDC |
+| `display_name` | no | Button label on the login page (default: `SSO`) |
+| `client_id` | yes | OAuth 2.0 client ID from your IdP |
+| `client_secret` | yes | OAuth 2.0 client secret from your IdP |
+| `discovery_url` | yes | IdP base URL — `/.well-known/openid-configuration` is appended automatically, or supply the full path |
+| `redirect_uri` | yes | Must match exactly what is registered with the IdP |
+| `scopes` | no | Space-separated scopes (default: `openid email profile`) |
+| `auto_provision` | no | Create a local user on first OIDC login if none exists (default: `false`) |
+| `default_role` | no | Role assigned to auto-provisioned users: `admin` or `readonly` (default: `readonly`) |
+
+---
+
+## IdP setup examples
+
+### Google
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Credentials
+2. Create an **OAuth 2.0 Client ID** (type: Web application)
+3. Add `https://ipam.example.com/oidc_callback.php` to **Authorized redirect URIs**
+4. Copy the client ID and secret
+
+```php
+'discovery_url' => 'https://accounts.google.com',
+```
+
+### Microsoft Entra ID (Azure AD)
+
+1. Azure Portal → App registrations → New registration
+2. Set redirect URI to `https://ipam.example.com/oidc_callback.php` (platform: Web)
+3. Under **Certificates & secrets**, create a new client secret
+4. Note your **tenant ID**
+
+```php
+'discovery_url' => 'https://login.microsoftonline.com/{tenant-id}/v2.0',
+```
+
+### Okta
+
+1. Okta Admin Console → Applications → Create App Integration (OIDC, Web Application)
+2. Add `https://ipam.example.com/oidc_callback.php` to **Sign-in redirect URIs**
+3. Copy the client ID and secret
+
+```php
+'discovery_url' => 'https://your-org.okta.com/oauth2/default',
+```
+
+### Keycloak
+
+1. Keycloak Admin → Realm → Clients → Create
+2. Set **Valid Redirect URIs** to `https://ipam.example.com/oidc_callback.php`
+3. Enable **Client authentication** (confidential client)
+
+```php
+'discovery_url' => 'https://keycloak.example.com/realms/your-realm',
+```
+
+### Authentik
+
+1. Authentik Admin → Applications → Providers → Create OAuth2/OpenID Connect Provider
+2. Set redirect URI to `https://ipam.example.com/oidc_callback.php`
+
+```php
+'discovery_url' => 'https://authentik.example.com/application/o/your-app',
+```
+
+---
+
+## User provisioning and linking
+
+### Manual linking (recommended for existing installs)
+
+By default, `auto_provision` is `false`. An admin must create or link accounts:
+
+1. Create the local user account in **Admin → Users** as normal
+2. When the user first logs in via OIDC, the callback will fail (no `oidc_sub` match)
+3. Ask the user for their IdP email/username, then have the user log in via OIDC once with `auto_provision = true` temporarily enabled — or manually set `oidc_sub` in the database
+
+The simplest approach for a small team: enable `auto_provision` for the first login of each user, then disable it again. The `sub` claim is now stored and subsequent logins work without provisioning.
+
+### Auto-provisioning
+
+With `auto_provision = true`:
+
+1. On the first OIDC login, the `sub` claim is looked up in `users.oidc_sub` — no match
+2. The `email` claim is checked against existing usernames — if a match is found, the account is linked
+3. If no match, a new account is created with `email` as the username, an unusable random password, and `default_role`
+
+> Auto-provisioned accounts cannot log in with local credentials (the password is a random bcrypt hash). If OIDC becomes unavailable, an admin can set a proper password via **Admin → Users → Reset PW**.
+
+### Unlinking an account
+
+Admins can remove the OIDC link from any user in **Admin → Users** by clicking **Unlink SSO**. The local account remains active; the user can log in with their local password if one is set.
+
+---
+
+## Disabling local login
+
+There is no built-in option to enforce OIDC-only login. If you want to prevent local password logins:
+
+- Disable all local user accounts except an emergency break-glass admin account
+- Set unusable passwords on accounts that should only use OIDC (done automatically for auto-provisioned accounts)
+
+---
+
+## Troubleshooting
+
+All OIDC errors are written to PHP's error log. The login page shows only a generic "SSO authentication failed" message to avoid leaking configuration details.
+
+| Symptom | Likely cause |
+|---------|-------------|
+| "Could not reach the identity provider" | `discovery_url` is wrong or unreachable; check `allow_url_fopen` |
+| "SSO authentication failed" after redirect | Check the PHP error log for the specific reason |
+| "state mismatch" in error log | Session lost between `oidc_login.php` and `oidc_callback.php` — check session cookie settings |
+| "No matching RSA JWK" | The IdP uses a key `kid` not in its published JWKS, or JWKS cache is stale |
+| "No local user found for sub=..." | `auto_provision` is false and no account has been linked to this `sub` |
+| ID token expired | Large clock skew between your server and the IdP — sync server time via NTP |
+| Redirect URI mismatch error from IdP | `redirect_uri` in `config.php` must exactly match the value registered with the IdP |


### PR DESCRIPTION
Milestone 1 — User menu:
- Username/role moved to far-right nav; Password, Logout, and Theme consolidated into a right-anchored user dropdown
- Theme button stays open while cycling; nav-dropdown-item unified for <a> and <button> elements

Milestone 2 — OIDC Authentication:
- Authorization Code + PKCE flow in pure PHP (no Composer deps)
- oidc_login.php: PKCE pair + state/nonce generation, IdP redirect
- oidc_callback.php: state validation, code exchange, ID token verification, user resolution with auto-provision support
- lib.php: oidc_discovery(), oidc_jwks() (1h cache + auto refresh), oidc_verify_id_token() (RS256/384/512), jwk_rsa_to_pem() (no ext-gmp), oidc_pkce_pair(), oidc_http_get/post helpers
- Migration 0.12: oidc_sub column + partial unique index on users table
- users.php: SSO linked/unlinked status column, Unlink SSO action
- login.php: SSO button when OIDC enabled, OIDC error flash display
- config.php: full oidc{} section (disabled by default)
- docs/oidc.md: setup guide with Google/Entra/Okta/Keycloak/Authentik examples

Bug fix: api.php addresses resource used wrong column name 'description'
  (corrected to 'note' to match schema); docs/api.md updated to match

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3