### PR TITLE
feat(v0.13): user management, site inheritance, OIDC improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 0.13 — User Management, Site Inheritance, OIDC Improvements
+
+### User management (`users.php`, `migrations.php`)
+- Added **Name** and **Email** fields to every user account; stored in new `name` and `email` DB columns (migration `0.13`)
+- Users table now shows Name and Email columns; inline edit form per-user to update them
+- Added ability to **delete users** with guard: you cannot delete your own account or the last active admin
+- Added ability to **disable/enable** user accounts (previously existed but now surfaced more prominently)
+- Added **manual OIDC linking**: admin can paste an IdP subject ID (`sub` claim) to link any existing account to an SSO identity
+- Actions per user are collapsed in a `<details>` element to keep the table compact
+
+### OIDC improvements (`oidc_callback.php`, `config.php`)
+- Username for auto-provisioned users is now derived from the `preferred_username` claim (falls back to the local-part of `email`, then `sub`)
+- `name` claim is stored as the user's display name; `email` claim is stored as the email address on create or first link
+- Auto-link now tries `preferred_username` first, then `email`/username match against existing local accounts before creating a new account
+- Name and email are silently synced from IdP claims on every login when the fields are blank
+- Username collision during auto-provision is handled by appending a short random suffix
+- New `disable_local_login` config option: when OIDC is enabled and this is `true`, the password form is hidden; emergency local access always available at `login.php?local=1`
+
+### Site inheritance for child subnets (`subnets.php`, `lib.php`)
+- Child subnets automatically inherit the site of their tightest enclosing parent that has a site assigned
+- Site field is replaced with a read-only locked badge (showing the inherited site name) for child subnets in the edit form
+- `find_parent_site_id()` resolves the inherited site by querying the containment tree built by `detect_subnet_overlaps()`
+
+### Login page (`login.php`)
+- First-run hint ("use bootstrap admin…") is now hidden once any successful login has been recorded in the audit log — no migration or extra state needed
+
+---
+
 ## 0.12 — User Menu Redesign and OIDC Authentication
 
 ### Milestone 1 — User Menu & Nav Polish

--- a/Simple-PHP-IPAM/config.php
+++ b/Simple-PHP-IPAM/config.php
@@ -61,10 +61,16 @@ return [
 
         // auto_provision: if true, a local user is created on first OIDC login
         // when no existing user is linked to the IdP subject (sub) claim.
-        // The email claim is used as the username.
+        // Username is derived from the preferred_username claim (or email local-part).
+        // Name and email are populated from the corresponding ID token claims.
         'auto_provision' => false,
 
         // Role assigned to auto-provisioned users. 'readonly' is recommended.
         'default_role'   => 'readonly',
+
+        // disable_local_login: if true, the username/password form is hidden
+        // when OIDC is enabled. Users must authenticate via SSO.
+        // Emergency local access is always available at login.php?local=1
+        'disable_local_login' => false,
     ],
 ];

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -846,6 +846,26 @@ function page_footer(): void
     echo "</div></body></html>";
 }
 
+/**
+ * Find the site_id a subnet should inherit from its tightest parent.
+ * Returns null if no parent exists or no parent has a site assigned.
+ */
+function find_parent_site_id(PDO $db, string $cidr, ?int $excludeId = null): ?int
+{
+    $overlaps = detect_subnet_overlaps($db, $cidr, $excludeId);
+    if (empty($overlaps['parents'])) return null;
+
+    $placeholders = implode(',', array_fill(0, count($overlaps['parents']), '?'));
+    $st = $db->prepare(
+        "SELECT site_id FROM subnets
+         WHERE cidr IN ($placeholders) AND site_id IS NOT NULL
+         ORDER BY prefix DESC LIMIT 1"
+    );
+    $st->execute($overlaps['parents']);
+    $row = $st->fetch();
+    return $row ? (int)$row['site_id'] : null;
+}
+
 /* ============================================================
  * OIDC — Authorization Code + PKCE (pure PHP, no dependencies)
  * ============================================================ */

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -52,6 +52,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 
+// First-run hint: show only if no successful login has ever occurred
+$firstRun = !$db->query("SELECT 1 FROM audit_log WHERE action='auth.login' LIMIT 1")->fetch();
+
+$oidcActive       = oidc_enabled($config);
+$disableLocal     = $oidcActive && !empty($config['oidc']['disable_local_login']);
+$localForceShown  = isset($_GET['local']); // emergency bypass
+
 page_header('Login');
 ?>
 <h1>Login</h1>
@@ -60,15 +67,18 @@ page_header('Login');
 <?php endif; ?>
 <?php if ($error): ?><p class="danger"><?= e($error) ?></p><?php endif; ?>
 
-<?php if (oidc_enabled($config)): ?>
+<?php if ($oidcActive): ?>
 <p>
   <a href="oidc_login.php" style="display:inline-block;padding:10px 18px;border-radius:12px;background:var(--btn);color:var(--btnfg);text-decoration:none;font-weight:600">
     Sign in with <?= e((string)($config['oidc']['display_name'] ?? 'SSO')) ?>
   </a>
 </p>
-<p class="muted" style="margin:14px 0 4px">— or sign in with a local account —</p>
 <?php endif; ?>
 
+<?php if (!$disableLocal || $localForceShown): ?>
+<?php if ($oidcActive): ?>
+  <p class="muted" style="margin:14px 0 4px">— or sign in with a local account —</p>
+<?php endif; ?>
 <form method="post" action="login.php" autocomplete="off">
   <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
   <div class="row">
@@ -76,6 +86,13 @@ page_header('Login');
     <label>Password<br><input type="password" name="password" required></label>
   </div>
   <p><button type="submit">Login</button></p>
-  <p class="muted">First run: use bootstrap admin from <code>config.php</code>, then change it.</p>
+  <?php if ($firstRun): ?>
+    <p class="muted">First run: use bootstrap admin from <code>config.php</code>, then change it.</p>
+  <?php endif; ?>
 </form>
+<?php elseif ($oidcActive): ?>
+  <p class="muted" style="margin-top:16px">Local password login is disabled. Use SSO above.
+    <a href="login.php?local=1" class="muted" style="font-size:.9em">(emergency local access)</a>
+  </p>
+<?php endif; ?>
 <?php page_footer();

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -75,6 +75,19 @@ function ipam_migrations(): array
             $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id)");
         },
 
+        // 0.13: name + email fields on users
+        '0.13' => function(PDO $db) {
+            $cols  = $db->query("PRAGMA table_info(users)")->fetchAll();
+            $names = array_map(fn($c) => $c['name'], $cols);
+
+            if (!in_array('name', $names, true)) {
+                $db->exec("ALTER TABLE users ADD COLUMN name TEXT NOT NULL DEFAULT ''");
+            }
+            if (!in_array('email', $names, true)) {
+                $db->exec("ALTER TABLE users ADD COLUMN email TEXT NOT NULL DEFAULT ''");
+            }
+        },
+
         // 0.12: OIDC subject claim column on users
         '0.12' => function(PDO $db) {
             $cols  = $db->query("PRAGMA table_info(users)")->fetchAll();

--- a/Simple-PHP-IPAM/oidc_callback.php
+++ b/Simple-PHP-IPAM/oidc_callback.php
@@ -86,8 +86,10 @@ try {
     }
 }
 
-$sub   = (string)($payload['sub']   ?? '');
-$email = (string)($payload['email'] ?? '');
+$sub              = (string)($payload['sub']                ?? '');
+$claimEmail       = trim((string)($payload['email']           ?? ''));
+$claimName        = trim((string)($payload['name']            ?? ''));
+$claimPrefUsername = trim((string)($payload['preferred_username'] ?? ''));
 
 if ($sub === '') oidc_fail($db, 'id_token missing sub claim');
 
@@ -97,16 +99,24 @@ $st = $db->prepare("SELECT id, username, role, is_active FROM users WHERE oidc_s
 $st->execute([':sub' => $sub]);
 $user = $st->fetch();
 
-if (!$user && !empty($config['oidc']['auto_provision']) && $email !== '') {
-    // Try to link an existing local user whose username matches the email
-    $st2 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE username = :u AND oidc_sub IS NULL");
-    $st2->execute([':u' => $email]);
-    $existing = $st2->fetch();
+if (!$user && !empty($config['oidc']['auto_provision'])) {
+    // Try to link an existing local user by preferred_username then by email
+    $existing = false;
+    if ($claimPrefUsername !== '') {
+        $st2 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE username = :u AND oidc_sub IS NULL");
+        $st2->execute([':u' => $claimPrefUsername]);
+        $existing = $st2->fetch();
+    }
+    if (!$existing && $claimEmail !== '') {
+        $st2 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE (username = :u OR email = :e) AND oidc_sub IS NULL");
+        $st2->execute([':u' => $claimEmail, ':e' => $claimEmail]);
+        $existing = $st2->fetch();
+    }
 
     if ($existing) {
-        // Link the existing account to this OIDC subject
-        $db->prepare("UPDATE users SET oidc_sub = :sub WHERE id = :id")
-           ->execute([':sub' => $sub, ':id' => (int)$existing['id']]);
+        // Link the existing account to this OIDC subject and sync profile
+        $db->prepare("UPDATE users SET oidc_sub = :sub, name = CASE WHEN name='' THEN :n ELSE name END, email = CASE WHEN email='' THEN :e ELSE email END WHERE id = :id")
+           ->execute([':sub' => $sub, ':n' => $claimName, ':e' => $claimEmail, ':id' => (int)$existing['id']]);
         audit($db, 'auth.oidc_link', 'user', (int)$existing['id'], 'sub=' . $sub);
         $user = $existing;
     } else {
@@ -114,20 +124,40 @@ if (!$user && !empty($config['oidc']['auto_provision']) && $email !== '') {
         $role = (string)($config['oidc']['default_role'] ?? 'readonly');
         if (!in_array($role, ['admin', 'readonly'], true)) $role = 'readonly';
 
+        // Derive a username: prefer preferred_username, fall back to email local-part, then sub
+        $newUsername = $claimPrefUsername !== '' ? $claimPrefUsername
+            : ($claimEmail !== '' ? explode('@', $claimEmail)[0] : $sub);
+
         // Set an unusable password hash so the account cannot be used with local auth
         $unusableHash = password_hash(bin2hex(random_bytes(32)), PASSWORD_DEFAULT);
 
-        $ins = $db->prepare(
-            "INSERT INTO users (username, password_hash, role, is_active, oidc_sub)
-             VALUES (:u, :h, :r, 1, :sub)"
-        );
-        $ins->execute([':u' => $email, ':h' => $unusableHash, ':r' => $role, ':sub' => $sub]);
+        try {
+            $ins = $db->prepare(
+                "INSERT INTO users (username, password_hash, role, is_active, oidc_sub, name, email)
+                 VALUES (:u, :h, :r, 1, :sub, :n, :e)"
+            );
+            $ins->execute([':u' => $newUsername, ':h' => $unusableHash, ':r' => $role,
+                           ':sub' => $sub, ':n' => $claimName, ':e' => $claimEmail]);
+        } catch (PDOException $ex) {
+            // username collision — append a short random suffix
+            $newUsername .= '_' . substr(bin2hex(random_bytes(3)), 0, 6);
+            $ins->execute([':u' => $newUsername, ':h' => $unusableHash, ':r' => $role,
+                           ':sub' => $sub, ':n' => $claimName, ':e' => $claimEmail]);
+        }
         $newId = (int)$db->lastInsertId();
-        audit($db, 'auth.oidc_provision', 'user', $newId, 'email=' . $email . ' sub=' . $sub);
+        audit($db, 'auth.oidc_provision', 'user', $newId, 'username=' . $newUsername . ' sub=' . $sub);
 
         $st3 = $db->prepare("SELECT id, username, role, is_active FROM users WHERE id = :id");
         $st3->execute([':id' => $newId]);
         $user = $st3->fetch();
+    }
+}
+
+// For already-linked users: sync name/email from IdP claims if blank
+if ($user) {
+    if (($claimName !== '' || $claimEmail !== '')) {
+        $db->prepare("UPDATE users SET name = CASE WHEN name='' THEN :n ELSE name END, email = CASE WHEN email='' THEN :e ELSE email END WHERE id = :id")
+           ->execute([':n' => $claimName, ':e' => $claimEmail, ':id' => (int)$user['id']]);
     }
 }
 

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -40,6 +40,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $normalized = $p['network'] . '/' . $p['prefix'];
             $overlaps = detect_subnet_overlaps($db, $normalized);
+            // Inherit site from tightest parent if one exists
+            $inheritedSiteId = find_parent_site_id($db, $normalized);
+            if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
             try {
                 $st = $db->prepare("INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id)
                                     VALUES (:cidr,:ver,:net,:nb,:pre,:d,:site)");
@@ -53,9 +56,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     ':site' => $siteId,
                 ]);
                 audit($db, 'subnet.create', 'subnet', (int)$db->lastInsertId(), $normalized);
+                $warn = '';
                 if (!empty($overlaps['parents']) || !empty($overlaps['children'])) {
-                    $_SESSION['ipam_flash_warn'] = subnet_overlap_warning_text($overlaps);
+                    $warn = subnet_overlap_warning_text($overlaps);
                 }
+                if ($inheritedSiteId !== null) {
+                    $inheritedName = $siteMap[$inheritedSiteId] ?? "site #$inheritedSiteId";
+                    $siteNote = "Site automatically set to \"{$inheritedName}\" inherited from parent subnet.";
+                    $warn = $warn ? $warn . ' ' . $siteNote : $siteNote;
+                }
+                if ($warn) $_SESSION['ipam_flash_warn'] = $warn;
                 header('Location: subnets.php');
                 exit;
             } catch (PDOException $e) {
@@ -76,6 +86,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $normalized = $p['network'] . '/' . $p['prefix'];
             $overlaps = detect_subnet_overlaps($db, $normalized, $id);
+            // Inherit site from tightest parent if one exists
+            $inheritedSiteId = find_parent_site_id($db, $normalized, $id);
+            if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
             try {
                 $st = $db->prepare("UPDATE subnets
                                     SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site
@@ -94,6 +107,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $msg = 'Subnet updated.';
                 if (!empty($overlaps['parents']) || !empty($overlaps['children'])) {
                     $warn = subnet_overlap_warning_text($overlaps);
+                }
+                if ($inheritedSiteId !== null) {
+                    $inheritedName = $siteMap[$inheritedSiteId] ?? "site #$inheritedSiteId";
+                    $siteNote = "Site set to \"{$inheritedName}\" inherited from parent subnet.";
+                    $warn = $warn ? $warn . ' ' . $siteNote : $siteNote;
                 }
             } catch (PDOException $e) {
                 $err = 'Could not update subnet (duplicate?).';
@@ -365,14 +383,21 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
     echo "<label>CIDR<br><input name='cidr' value='" . e($row['cidr']) . "' required></label>";
     echo "<label>Description<br><input name='description' value='" . e($row['description']) . "'></label>";
 
-    echo "<label>Site<br><select name='site_id'>";
-    echo "<option value='0' " . ($siteId === 0 ? "selected" : "") . ">(none)</option>";
-    foreach ($siteList as $s) {
-        $sid = (int)$s['id'];
-        $sel = ($sid === $siteId) ? "selected" : "";
-        echo "<option value='" . $sid . "' $sel>" . e($s['name']) . "</option>";
+    if ($depth > 0) {
+        // Child subnet: site is inherited from parent and cannot be changed here
+        $lockedSiteName = ($siteId > 0 && isset($siteMap[$siteId])) ? $siteMap[$siteId] : '(none)';
+        echo "<input type='hidden' name='site_id' value='" . $siteId . "'>";
+        echo "<label>Site<br><span class='badge' title='Inherited from parent subnet'>" . e($lockedSiteName) . " ↑</span></label>";
+    } else {
+        echo "<label>Site<br><select name='site_id'>";
+        echo "<option value='0' " . ($siteId === 0 ? "selected" : "") . ">(none)</option>";
+        foreach ($siteList as $s) {
+            $sid = (int)$s['id'];
+            $sel = ($sid === $siteId) ? "selected" : "";
+            echo "<option value='" . $sid . "' $sel>" . e($s['name']) . "</option>";
+        }
+        echo "</select></label>";
     }
-    echo "</select></label>";
 
     echo "<button type='submit' $disabled>Save</button>";
     echo "</form>";

--- a/Simple-PHP-IPAM/users.php
+++ b/Simple-PHP-IPAM/users.php
@@ -7,6 +7,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
 
 $err = '';
 $msg = '';
+$self = current_user();
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = (string)($_POST['action'] ?? '');
@@ -14,59 +15,124 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($action === 'create') {
         $username = trim((string)($_POST['username'] ?? ''));
         $password = (string)($_POST['password'] ?? '');
-        $role = (string)($_POST['role'] ?? 'readonly');
+        $role     = (string)($_POST['role']     ?? 'readonly');
+        $name     = trim((string)($_POST['name']  ?? ''));
+        $email    = trim((string)($_POST['email'] ?? ''));
 
-        if ($username === '' || !preg_match('~^[a-zA-Z0-9_.-]{3,32}$~', $username)) $err = 'Username must be 3-32 chars (letters/numbers/._-).';
-        elseif (strlen($password) < 12) $err = 'Password must be at least 12 characters.';
-        elseif (!in_array($role, ['admin', 'readonly'], true)) $err = 'Invalid role.';
-        else {
+        if ($username === '' || !preg_match('~^[a-zA-Z0-9_.\-@]{3,64}$~', $username)) {
+            $err = 'Username must be 3–64 chars (letters, numbers, _ . - @).';
+        } elseif (strlen($password) < 12) {
+            $err = 'Password must be at least 12 characters.';
+        } elseif (!in_array($role, ['admin', 'readonly'], true)) {
+            $err = 'Invalid role.';
+        } else {
             try {
                 $hash = password_hash($password, PASSWORD_DEFAULT);
-                $st = $db->prepare("INSERT INTO users (username, password_hash, role, is_active) VALUES (:u,:h,:r,1)");
-                $st->execute([':u' => $username, ':h' => $hash, ':r' => $role]);
+                $st = $db->prepare(
+                    "INSERT INTO users (username, password_hash, role, is_active, name, email)
+                     VALUES (:u,:h,:r,1,:n,:e)"
+                );
+                $st->execute([':u' => $username, ':h' => $hash, ':r' => $role, ':n' => $name, ':e' => $email]);
                 audit($db, 'user.create', 'user', (int)$db->lastInsertId(), "username=$username role=$role");
                 $msg = 'User created.';
             } catch (PDOException $e) {
                 $err = 'Could not create user (duplicate username?).';
             }
         }
+
     } elseif ($action === 'toggle_active') {
         $id = (int)($_POST['id'] ?? 0);
-        $st = $db->prepare("UPDATE users SET is_active = CASE WHEN is_active=1 THEN 0 ELSE 1 END WHERE id = :id");
-        $st->execute([':id' => $id]);
+        $db->prepare("UPDATE users SET is_active = CASE WHEN is_active=1 THEN 0 ELSE 1 END WHERE id = :id")
+           ->execute([':id' => $id]);
         audit($db, 'user.toggle_active', 'user', $id, '');
         $msg = 'User updated.';
+
     } elseif ($action === 'set_role') {
-        $id = (int)($_POST['id'] ?? 0);
+        $id   = (int)($_POST['id']   ?? 0);
         $role = (string)($_POST['role'] ?? '');
-        if (!in_array($role, ['admin', 'readonly'], true)) $err = 'Invalid role.';
-        else {
-            $st = $db->prepare("UPDATE users SET role = :r WHERE id = :id");
-            $st->execute([':r' => $role, ':id' => $id]);
+        if (!in_array($role, ['admin', 'readonly'], true)) {
+            $err = 'Invalid role.';
+        } else {
+            $db->prepare("UPDATE users SET role = :r WHERE id = :id")
+               ->execute([':r' => $role, ':id' => $id]);
             audit($db, 'user.set_role', 'user', $id, "role=$role");
             $msg = 'Role updated.';
         }
+
+    } elseif ($action === 'update_profile') {
+        $id    = (int)($_POST['id']    ?? 0);
+        $name  = trim((string)($_POST['name']  ?? ''));
+        $email = trim((string)($_POST['email'] ?? ''));
+        $db->prepare("UPDATE users SET name = :n, email = :e WHERE id = :id")
+           ->execute([':n' => $name, ':e' => $email, ':id' => $id]);
+        audit($db, 'user.update_profile', 'user', $id, '');
+        $msg = 'Profile updated.';
+
     } elseif ($action === 'reset_password') {
         $id = (int)($_POST['id'] ?? 0);
         $pw = (string)($_POST['new_password'] ?? '');
-        if (strlen($pw) < 12) $err = 'Password must be at least 12 characters.';
-        else {
+        if (strlen($pw) < 12) {
+            $err = 'Password must be at least 12 characters.';
+        } else {
             $hash = password_hash($pw, PASSWORD_DEFAULT);
-            $st = $db->prepare("UPDATE users SET password_hash = :h WHERE id = :id");
-            $st->execute([':h' => $hash, ':id' => $id]);
+            $db->prepare("UPDATE users SET password_hash = :h WHERE id = :id")
+               ->execute([':h' => $hash, ':id' => $id]);
             audit($db, 'user.reset_password', 'user', $id, 'admin reset');
             $msg = 'Password reset.';
         }
+
+    } elseif ($action === 'link_oidc') {
+        $id  = (int)($_POST['id']       ?? 0);
+        $sub = trim((string)($_POST['oidc_sub'] ?? ''));
+        if ($sub === '') {
+            $err = 'OIDC subject ID is required.';
+        } else {
+            try {
+                $db->prepare("UPDATE users SET oidc_sub = :sub WHERE id = :id")
+                   ->execute([':sub' => $sub, ':id' => $id]);
+                audit($db, 'user.oidc_link', 'user', $id, 'manual sub=' . $sub);
+                $msg = 'OIDC subject linked.';
+            } catch (PDOException $e) {
+                $err = 'Could not link: subject ID may already be assigned to another user.';
+            }
+        }
+
     } elseif ($action === 'unlink_oidc') {
         $id = (int)($_POST['id'] ?? 0);
         $db->prepare("UPDATE users SET oidc_sub = NULL WHERE id = :id")
            ->execute([':id' => $id]);
         audit($db, 'user.oidc_unlink', 'user', $id, '');
         $msg = 'OIDC link removed.';
+
+    } elseif ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        if ($id === $self['id']) {
+            $err = 'You cannot delete your own account.';
+        } else {
+            $target = $db->prepare("SELECT role FROM users WHERE id = :id")->execute([':id' => $id])
+                        ? $db->prepare("SELECT role FROM users WHERE id = :id") : null;
+            $tSt = $db->prepare("SELECT role FROM users WHERE id = :id");
+            $tSt->execute([':id' => $id]);
+            $target = $tSt->fetch();
+            if ($target && $target['role'] === 'admin') {
+                $cnt = (int)$db->query("SELECT COUNT(*) AS c FROM users WHERE role='admin' AND is_active=1")->fetch()['c'];
+                if ($cnt <= 1) {
+                    $err = 'Cannot delete the last active admin account.';
+                }
+            }
+            if (!$err) {
+                $db->prepare("DELETE FROM users WHERE id = :id")->execute([':id' => $id]);
+                audit($db, 'user.delete', 'user', $id, '');
+                $msg = 'User deleted.';
+            }
+        }
     }
 }
 
-$st = $db->prepare("SELECT id, username, role, is_active, created_at, updated_at, oidc_sub FROM users ORDER BY username ASC");
+$st = $db->prepare(
+    "SELECT id, username, name, email, role, is_active, created_at, updated_at, oidc_sub
+     FROM users ORDER BY username ASC"
+);
 $st->execute();
 $users = $st->fetchAll();
 
@@ -74,14 +140,16 @@ page_header('Users');
 ?>
 <h1>Users</h1>
 <?php if ($err): ?><p class="danger"><?= e($err) ?></p><?php endif; ?>
-<?php if ($msg): ?><p><?= e($msg) ?></p><?php endif; ?>
+<?php if ($msg): ?><p class="success"><?= e($msg) ?></p><?php endif; ?>
 
 <h2>Create user</h2>
 <form method="post" action="users.php">
-  <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
+  <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
   <input type="hidden" name="action" value="create">
   <div class="row">
     <label>Username<br><input name="username" required></label>
+    <label>Full name<br><input name="name" placeholder="Jane Smith"></label>
+    <label>Email<br><input type="email" name="email" placeholder="jane@example.com"></label>
     <label>Password<br><input type="password" name="password" required></label>
     <label>Role<br>
       <select name="role">
@@ -93,17 +161,26 @@ page_header('Users');
   </div>
 </form>
 
-<h2>Existing users</h2>
+<h2 style="margin-top:24px">Existing users</h2>
 <table>
   <thead>
     <tr>
-      <th>Username</th><th>Role</th><th>Active</th><th>SSO</th><th>Created</th><th>Updated</th><th>Actions</th>
+      <th>Username</th>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Role</th>
+      <th>Active</th>
+      <th>SSO</th>
+      <th>Created</th>
+      <th>Actions</th>
     </tr>
   </thead>
   <tbody>
   <?php foreach ($users as $u): ?>
     <tr>
       <td><?= e($u['username']) ?></td>
+      <td><?= e((string)$u['name']) ?></td>
+      <td><?= e((string)$u['email']) ?></td>
       <td><?= e($u['role']) ?></td>
       <td><?= ((int)$u['is_active'] === 1) ? 'yes' : 'no' ?></td>
       <td>
@@ -114,43 +191,76 @@ page_header('Users');
         <?php endif; ?>
       </td>
       <td class="muted"><?= e($u['created_at']) ?></td>
-      <td class="muted"><?= e($u['updated_at']) ?></td>
       <td>
-        <form method="post" action="users.php" class="row" style="gap:6px">
-          <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
-          <input type="hidden" name="id" value="<?= (int)$u['id'] ?>">
-          <input type="hidden" name="action" value="toggle_active">
-          <button type="submit"><?= ((int)$u['is_active'] === 1) ? 'Disable' : 'Enable' ?></button>
-        </form>
+        <details>
+          <summary class="muted" style="cursor:pointer;font-size:.9em">Actions ▾</summary>
+          <div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">
 
-        <form method="post" action="users.php" class="row" style="gap:6px; margin-top:6px">
-          <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
-          <input type="hidden" name="action" value="set_role">
-          <input type="hidden" name="id" value="<?= (int)$u['id'] ?>">
-          <select name="role">
-            <option value="readonly" <?= ($u['role']==='readonly')?'selected':'' ?>>readonly</option>
-            <option value="admin" <?= ($u['role']==='admin')?'selected':'' ?>>admin</option>
-          </select>
-          <button type="submit">Set role</button>
-        </form>
+            <form method="post" action="users.php" class="row" style="gap:6px">
+              <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+              <input type="hidden" name="action" value="toggle_active">
+              <button type="submit"><?= ((int)$u['is_active'] === 1) ? 'Disable' : 'Enable' ?></button>
+            </form>
 
-        <form method="post" action="users.php" class="row" style="gap:6px; margin-top:6px">
-          <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
-          <input type="hidden" name="action" value="reset_password">
-          <input type="hidden" name="id" value="<?= (int)$u['id'] ?>">
-          <input type="password" name="new_password" placeholder="New password" required>
-          <button type="submit">Reset PW</button>
-        </form>
+            <form method="post" action="users.php" class="row" style="gap:6px">
+              <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action" value="set_role">
+              <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+              <select name="role">
+                <option value="readonly" <?= $u['role']==='readonly'?'selected':'' ?>>readonly</option>
+                <option value="admin"    <?= $u['role']==='admin'   ?'selected':'' ?>>admin</option>
+              </select>
+              <button type="submit">Set role</button>
+            </form>
 
-        <?php if ($u['oidc_sub'] !== null): ?>
-        <form method="post" action="users.php" class="row" style="gap:6px; margin-top:6px"
-              onsubmit="return confirm('Remove SSO link for <?= e((string)$u['username']) ?>?')">
-          <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
-          <input type="hidden" name="action" value="unlink_oidc">
-          <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
-          <button type="submit" class="button-secondary">Unlink SSO</button>
-        </form>
-        <?php endif; ?>
+            <form method="post" action="users.php" class="row" style="gap:6px">
+              <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action" value="update_profile">
+              <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+              <input name="name"  placeholder="Full name"  value="<?= e((string)$u['name']) ?>">
+              <input type="email" name="email" placeholder="Email" value="<?= e((string)$u['email']) ?>">
+              <button type="submit">Save profile</button>
+            </form>
+
+            <form method="post" action="users.php" class="row" style="gap:6px">
+              <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action" value="reset_password">
+              <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+              <input type="password" name="new_password" placeholder="New password (12+ chars)" required>
+              <button type="submit">Reset PW</button>
+            </form>
+
+            <?php if ($u['oidc_sub'] !== null): ?>
+              <form method="post" action="users.php" class="row" style="gap:6px"
+                    onsubmit="return confirm('Remove SSO link for <?= e((string)$u['username']) ?>?')">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="unlink_oidc">
+                <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+                <button type="submit" class="button-secondary">Unlink SSO</button>
+              </form>
+            <?php else: ?>
+              <form method="post" action="users.php" class="row" style="gap:6px">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="link_oidc">
+                <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+                <input name="oidc_sub" placeholder="IdP subject ID (sub claim)" style="min-width:220px">
+                <button type="submit" class="button-secondary">Link SSO</button>
+              </form>
+            <?php endif; ?>
+
+            <?php if ($u['id'] !== $self['id']): ?>
+              <form method="post" action="users.php"
+                    onsubmit="return confirm('Permanently delete user <?= e((string)$u['username']) ?>?')">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
+                <button type="submit" class="button-danger">Delete user</button>
+              </form>
+            <?php endif; ?>
+
+          </div>
+        </details>
       </td>
     </tr>
   <?php endforeach; ?>

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-const IPAM_VERSION = '0.12';
+const IPAM_VERSION = '0.13';


### PR DESCRIPTION
- Add name/email fields to users (migration 0.13)
- Add delete user action with self-delete and last-admin guard
- Add manual OIDC sub linking in users admin
- Collapse per-user actions into <details> element
- Derive OIDC username from preferred_username claim; populate name/email from claims
- Improved auto-link: try preferred_username then email before provisioning
- Sync name/email from IdP claims on every login when fields are blank
- Handle username collision during auto-provision with random suffix
- Add disable_local_login config option with emergency ?local=1 bypass
- Child subnets inherit site from tightest parent with a site set
- Site field shown as locked badge for child subnets in edit form
- Hide first-run login hint once any successful login exists in audit log
- Bump version to 0.13

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3