### PR TITLE
docs(v0.13): update all documentation for v0.13 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ No Composer, no npm, no external dependencies — just PHP and a web server.
 
 ### Organisation
 - **Sites** — group subnets by location or network segment
+- Child subnets automatically **inherit the site** of their enclosing parent
 
 ### Security & Access Control
 - HTTPS enforced at the application layer; secure session cookies (`Secure`, `HttpOnly`, `SameSite=Strict`)
@@ -32,6 +33,8 @@ No Composer, no npm, no external dependencies — just PHP and a web server.
 - CSRF protection on all POST requests; PDO prepared statements throughout
 - **RBAC roles:** `admin` (full access + user management) and `readonly`
 - Append-only audit log enforced with SQLite triggers
+- **OIDC SSO** — Authorization Code + PKCE in pure PHP; auto-provision and auto-link; optional `disable_local_login`
+- **User management** — name/email fields, per-user enable/disable, delete, manual SSO linking
 
 ### REST API
 - Read-only JSON API (`api.php`) authenticated with API keys
@@ -79,6 +82,14 @@ See the [Installation guide](docs/install.md) for full web server configuration 
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.
+
+### What's new in 0.13
+
+**User management** — Name and email fields on every account. Delete users (with guard against removing the last admin). Inline OIDC linking from the admin UI.
+
+**OIDC improvements** — Username derived from `preferred_username` claim; name and email synced from IdP claims. Auto-link tries `preferred_username` then `email` before provisioning. New `disable_local_login` option hides the password form; `?local=1` emergency bypass always available.
+
+**Site inheritance** — Child subnets automatically inherit the site of their tightest enclosing parent. The site field is locked to a read-only badge for child subnets.
 
 ### What's new in 0.12
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,7 @@ All application settings live in `config.php` in the application root. This file
 
 - [Full example](#full-example)
 - [Settings reference](#settings-reference)
+- [OIDC settings](#oidc-settings)
 - [Behind a reverse proxy](#behind-a-reverse-proxy)
 
 ---
@@ -51,6 +52,20 @@ return [
     'housekeeping' => [
         'enabled'          => true,
         'interval_seconds' => 86400, // once per day
+    ],
+
+    // OIDC single sign-on — see docs/oidc.md for full setup guide.
+    'oidc' => [
+        'enabled'             => false,
+        'display_name'        => 'SSO',
+        'client_id'           => '',
+        'client_secret'       => '',
+        'discovery_url'       => '',
+        'redirect_uri'        => '',
+        'scopes'              => 'openid email profile',
+        'auto_provision'      => false,
+        'default_role'        => 'readonly',
+        'disable_local_login' => false,
     ],
 ];
 ```
@@ -147,6 +162,27 @@ Controls lazy background housekeeping (temp file cleanup, stale login attempt pu
 | `interval_seconds` | `86400` | Minimum seconds between housekeeping runs (min: 3600) |
 
 Housekeeping runs at most once per `interval_seconds` on normal web traffic. It does not require a cron job, but you can also run `php tmp_cleanup.php` manually.
+
+---
+
+## OIDC settings
+
+The `oidc` block configures optional OIDC single sign-on. All keys are ignored when `enabled` is `false`.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Set to `true` to activate OIDC |
+| `display_name` | `'SSO'` | Label on the login page button |
+| `client_id` | `''` | OAuth 2.0 client ID from your IdP |
+| `client_secret` | `''` | OAuth 2.0 client secret from your IdP |
+| `discovery_url` | `''` | IdP base URL (`/.well-known/openid-configuration` appended automatically) |
+| `redirect_uri` | `''` | Callback URL — must match exactly what is registered with the IdP |
+| `scopes` | `'openid email profile'` | Space-separated scopes |
+| `auto_provision` | `false` | Automatically create or link a local account on first OIDC login |
+| `default_role` | `'readonly'` | Role assigned to auto-provisioned users (`admin` or `readonly`) |
+| `disable_local_login` | `false` | Hide the password form when OIDC is enabled. Emergency bypass at `login.php?local=1` |
+
+See the [OIDC guide](oidc.md) for IdP setup examples, user provisioning details, and troubleshooting.
 
 ---
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -46,15 +46,16 @@ Add the following to your `config.php`:
 
 ```php
 'oidc' => [
-    'enabled'        => true,
-    'display_name'   => 'Okta',          // Label on the login button
-    'client_id'      => 'your-client-id',
-    'client_secret'  => 'your-client-secret',
-    'discovery_url'  => 'https://your-org.okta.com/oauth2/default',
-    'redirect_uri'   => 'https://ipam.example.com/oidc_callback.php',
-    'scopes'         => 'openid email profile',
-    'auto_provision' => false,
-    'default_role'   => 'readonly',
+    'enabled'             => true,
+    'display_name'        => 'Okta',          // Label on the login button
+    'client_id'           => 'your-client-id',
+    'client_secret'       => 'your-client-secret',
+    'discovery_url'       => 'https://your-org.okta.com/oauth2/default',
+    'redirect_uri'        => 'https://ipam.example.com/oidc_callback.php',
+    'scopes'              => 'openid email profile',
+    'auto_provision'      => false,
+    'default_role'        => 'readonly',
+    'disable_local_login' => false,
 ],
 ```
 
@@ -71,6 +72,7 @@ Add the following to your `config.php`:
 | `scopes` | no | Space-separated scopes (default: `openid email profile`) |
 | `auto_provision` | no | Create a local user on first OIDC login if none exists (default: `false`) |
 | `default_role` | no | Role assigned to auto-provisioned users: `admin` or `readonly` (default: `readonly`) |
+| `disable_local_login` | no | Hide the password form when OIDC is enabled (default: `false`). See [Disabling local login](#disabling-local-login) |
 
 ---
 
@@ -133,23 +135,36 @@ Add the following to your `config.php`:
 
 ### Manual linking (recommended for existing installs)
 
-By default, `auto_provision` is `false`. An admin must create or link accounts:
+By default, `auto_provision` is `false`. An admin must create or link accounts before any user can sign in via SSO.
 
-1. Create the local user account in **Admin → Users** as normal
-2. When the user first logs in via OIDC, the callback will fail (no `oidc_sub` match)
-3. Ask the user for their IdP email/username, then have the user log in via OIDC once with `auto_provision = true` temporarily enabled — or manually set `oidc_sub` in the database
+**Option 1 — Link via the admin UI:**
 
-The simplest approach for a small team: enable `auto_provision` for the first login of each user, then disable it again. The `sub` claim is now stored and subsequent logins work without provisioning.
+1. Create or locate the local user account in **Admin → Users**
+2. In the user's Actions panel, paste the IdP `sub` claim value into the **Link SSO** field and submit
+3. The account is now linked; the user can sign in via SSO on their next visit
+
+**Option 2 — Temporary auto_provision:**
+
+Enable `auto_provision` briefly, have the user sign in once via OIDC, then disable it again. The `sub` claim is stored and subsequent logins work without provisioning.
 
 ### Auto-provisioning
 
 With `auto_provision = true`:
 
-1. On the first OIDC login, the `sub` claim is looked up in `users.oidc_sub` — no match
-2. The `email` claim is checked against existing usernames — if a match is found, the account is linked
-3. If no match, a new account is created with `email` as the username, an unusable random password, and `default_role`
+1. On the first OIDC login, the `sub` claim is looked up in `users.oidc_sub` — no match found
+2. An existing unlinked account is sought: first by matching `preferred_username`, then by matching `email` (against both the `username` and `email` columns)
+3. If a match is found, the account is automatically linked to the `sub` claim and name/email are populated from the ID token if they were blank
+4. If no match is found, a new account is created:
+   - Username derived from `preferred_username` claim → `email` local-part → `sub` (fallback)
+   - Name and email populated from the `name` and `email` claims
+   - Unusable random password (account cannot be used for local auth)
+   - Role set to `default_role` (default: `readonly`)
 
 > Auto-provisioned accounts cannot log in with local credentials (the password is a random bcrypt hash). If OIDC becomes unavailable, an admin can set a proper password via **Admin → Users → Reset PW**.
+
+### Name and email sync
+
+On every OIDC login, if a user's **Name** or **Email** fields are blank, they are silently populated from the `name` and `email` claims in the ID token. Fields that have already been set are not overwritten — you can always edit them manually in **Admin → Users**.
 
 ### Unlinking an account
 
@@ -159,10 +174,17 @@ Admins can remove the OIDC link from any user in **Admin → Users** by clicking
 
 ## Disabling local login
 
-There is no built-in option to enforce OIDC-only login. If you want to prevent local password logins:
+Set `'disable_local_login' => true` in the `oidc` config block to hide the username/password form on the login page. Users will only see the SSO button.
 
-- Disable all local user accounts except an emergency break-glass admin account
-- Set unusable passwords on accounts that should only use OIDC (done automatically for auto-provisioned accounts)
+```php
+'oidc' => [
+    'enabled'             => true,
+    // ... other settings ...
+    'disable_local_login' => true,
+],
+```
+
+**Emergency access:** Even with `disable_local_login` enabled, local login is always accessible at `login.php?local=1`. Keep at least one active local admin account as a break-glass fallback in case your IdP becomes unavailable.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,6 +31,12 @@ If you terminate TLS at a reverse proxy, set `'proxy_trust' => true` in `config.
 - `session.use_strict_mode` and `session.use_only_cookies` are enabled.
 - The session ID is regenerated on login (`session_regenerate_id(true)`).
 
+### OIDC single sign-on
+
+From v0.12, OIDC Authorization Code + PKCE is supported as an alternative to local passwords. ID token signatures are verified in-process using `openssl` — no network calls beyond the discovery and JWKS fetches.
+
+Auto-provisioned OIDC accounts are assigned an unusable random password and cannot log in locally unless an admin sets one. See the [OIDC guide](oidc.md) for setup and the `disable_local_login` option.
+
 ### Default credentials
 
 Change the bootstrap admin password **before** the site receives any traffic. The default credentials (`admin` / `ChangeMeNow!12345`) are well-known and must not be used in production.


### PR DESCRIPTION
- oidc.md: rewrite provisioning section (preferred_username, auto-link order, name/email sync), document manual linking via admin UI, add disable_local_login section with emergency bypass note, add disable_local_login to config example and settings table
- configuration.md: add oidc block to full example, add OIDC settings reference table with link to oidc.md
- security.md: add OIDC authentication paragraph under Authentication
- README.md: add What's new in 0.13 section, add OIDC/user management and site inheritance to feature list

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3