### PR TITLE
fix(users): correct last-admin guard when deleting inactive admins

### DIFF
--- a/Simple-PHP-IPAM/users.php
+++ b/Simple-PHP-IPAM/users.php
@@ -109,14 +109,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($id === $self['id']) {
             $err = 'You cannot delete your own account.';
         } else {
-            $target = $db->prepare("SELECT role FROM users WHERE id = :id")->execute([':id' => $id])
-                        ? $db->prepare("SELECT role FROM users WHERE id = :id") : null;
-            $tSt = $db->prepare("SELECT role FROM users WHERE id = :id");
+            $tSt = $db->prepare("SELECT role, is_active FROM users WHERE id = :id");
             $tSt->execute([':id' => $id]);
             $target = $tSt->fetch();
-            if ($target && $target['role'] === 'admin') {
-                $cnt = (int)$db->query("SELECT COUNT(*) AS c FROM users WHERE role='admin' AND is_active=1")->fetch()['c'];
-                if ($cnt <= 1) {
+            // Only guard active admins — deleting an inactive admin can never remove the last active one
+            if ($target && $target['role'] === 'admin' && (int)$target['is_active'] === 1) {
+                $cntSt = $db->prepare(
+                    "SELECT COUNT(*) FROM users WHERE role='admin' AND is_active=1 AND id != :id"
+                );
+                $cntSt->execute([':id' => $id]);
+                if ((int)$cntSt->fetchColumn() === 0) {
                     $err = 'Cannot delete the last active admin account.';
                 }
             }
@@ -249,7 +251,7 @@ page_header('Users');
               </form>
             <?php endif; ?>
 
-            <?php if ($u['id'] !== $self['id']): ?>
+            <?php if ((int)$u['id'] !== $self['id']): ?>
               <form method="post" action="users.php"
                     onsubmit="return confirm('Permanently delete user <?= e((string)$u['username']) ?>?')">
                 <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">


### PR DESCRIPTION
The guard counted all active admins (including the target) and blocked deletion when count <= 1. This incorrectly prevented deleting an inactive admin account when only one active admin remained.

Fixes:
- Fetch is_active alongside role for the target user
- Only apply the guard when deleting an active admin
- Count remaining active admins EXCLUDING the target (post-delete view), block only when that count would reach zero
- Remove dead-code double-prepare on lines 112-113
- Fix strict type mismatch in UI (string DB id vs int self id) that caused the Delete button to render for the logged-in user's own row

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3