### PR TITLE
feat(v0.14): DHCP pools, update check, user hardening, utilization badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 0.14 — DHCP Pools, Update Check, User Hardening, Utilization Badges
+
+### Application branding
+- Application renamed from **PHP SQLite IPAM** to **Simple PHP IPAM** throughout
+- Footer app name is now a link to the GitHub repository (opens in new tab)
+
+### Update check
+- Footer shows an **Update available vX.Y** badge when a newer GitHub release exists
+- Fetches the GitHub releases API with a User-Agent header; result cached for 6 hours (configurable)
+- Skips drafts and pre-releases; silently no-ops on network failure
+- Opt-out via `'update_check' => ['enabled' => false]` in `config.php`
+
+### DHCP pool reservation tool (`dhcp_pool.php`)
+- New admin page to bulk-reserve a contiguous IPv4 range within any subnet
+- IPs already marked `used` are always skipped; `reserved`/`free` records are updated
+- Separate **Clear** form removes `reserved` records from a range (leaves `used` untouched)
+- Max 1,024 IPs per operation; linked from each subnet's action bar and the Admin nav dropdown
+- All operations recorded in the audit log
+
+### User management hardening (`users.php`)
+- **Disable**, **Set role**, and **Unlink SSO** are hidden in the UI for the logged-in admin's own row
+- Server-side guards: `toggle_active`, `set_role`, and `unlink_oidc` all reject self-targeting
+- **Last login** column added to the users table; populated on every login (local and OIDC)
+
+### Subnet utilization badges (`subnets.php`, `assets/app.css`)
+- IPv4 subnets show a colour-coded mini progress bar and percentage next to assignable counts
+- Green → yellow (≥ `utilization_warn`, default 80%) → red (≥ `utilization_critical`, default 95%)
+- Thresholds configurable in `config.php`
+
+### OIDC emergency access controls (`login.php`, `config.php`)
+- New `hide_emergency_link` option: hides the emergency link text without disabling the URL
+- New `disable_emergency_bypass` option: makes `login.php?local=1` completely ineffective
+
+### Database migration
+- Migration `0.14`: adds `last_login_at TEXT` column to the `users` table
+
+---
+
 ## 0.13 — User Management, Site Inheritance, OIDC Improvements
 
 ### User management (`users.php`, `migrations.php`)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ See the [Installation guide](docs/install.md) for full web server configuration 
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.
 
+### What's new in 0.14
+
+**DHCP pool tool** — Bulk-reserve a contiguous IPv4 range as DHCP pool addresses in one action. Used IPs are never overwritten. Accessible from each subnet's action bar and the Admin menu.
+
+**Update check** — Footer shows an "Update available" badge when a newer GitHub release is published. Result is cached; opt-out in `config.php`.
+
+**User hardening** — Admins can no longer accidentally disable themselves, change their own role, or unlink their own SSO from the users admin page. Last login time now visible per user.
+
+**Utilization badges** — IPv4 subnets show a colour-coded mini progress bar (green/yellow/red) with configurable warn and critical thresholds.
+
+**Emergency access controls** — New `hide_emergency_link` and `disable_emergency_bypass` config options for stricter SSO-only enforcement.
+
+**App rename** — Application renamed to Simple PHP IPAM throughout.
+
 ### What's new in 0.13
 
 **User management** — Name and email fields on every account. Delete users (with guard against removing the last admin). Inline OIDC linking from the admin UI.

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -382,6 +382,29 @@ button:disabled{opacity:.6;cursor:not-allowed}
 .status-used{color:var(--success);font-weight:600}
 .status-reserved{color:var(--warn);font-weight:600}
 .status-free{color:var(--muted);font-weight:600}
+.badge-update{
+  background:color-mix(in srgb,var(--warn) 12%,var(--badge-bg) 88%);
+  color:var(--warn);
+  border-color:color-mix(in srgb,var(--warn) 40%,var(--border) 60%);
+}
+.util-bar{
+  display:inline-block;
+  width:60px;
+  height:8px;
+  background:var(--border);
+  border-radius:3px;
+  overflow:hidden;
+  vertical-align:middle;
+  margin-left:4px;
+}
+.util-bar-fill{
+  height:100%;
+  background:var(--success);
+  border-radius:3px;
+  transition:width .3s;
+}
+.util-bar-fill--warn{background:var(--warn)}
+.util-bar-fill--crit{background:var(--danger)}
 
 summary{
   cursor:pointer;

--- a/Simple-PHP-IPAM/config.php
+++ b/Simple-PHP-IPAM/config.php
@@ -30,6 +30,18 @@ return [
         'interval_seconds' => 86400, // once per day
     ],
 
+    // Subnet utilization thresholds. Utilization bars in the subnet list turn
+    // yellow at 'warn' percent and red at 'critical' percent.
+    'utilization_warn'     => 80,
+    'utilization_critical' => 95,
+
+    // Update check: fetches the latest release tag from GitHub and shows a
+    // banner in the footer when a newer version is available.
+    'update_check' => [
+        'enabled'     => true,
+        'ttl_seconds' => 21600, // cache result for 6 hours
+    ],
+
     // -----------------------------------------------------------------------
     // OIDC — Authorization Code + PKCE single sign-on (optional)
     // Set 'enabled' => true and fill in the IdP details to activate.
@@ -70,7 +82,17 @@ return [
 
         // disable_local_login: if true, the username/password form is hidden
         // when OIDC is enabled. Users must authenticate via SSO.
-        // Emergency local access is always available at login.php?local=1
         'disable_local_login' => false,
+
+        // hide_emergency_link: hides the "(emergency local access)" link text on
+        // the login page. The URL login.php?local=1 still works unless
+        // disable_emergency_bypass is also true.
+        'hide_emergency_link' => false,
+
+        // disable_emergency_bypass: when true, login.php?local=1 has no effect
+        // and local login is entirely unavailable when disable_local_login is set.
+        // WARNING: if your IdP becomes unavailable you will be locked out.
+        // Only set this after verifying your IdP is reliable.
+        'disable_emergency_bypass' => false,
     ],
 ];

--- a/Simple-PHP-IPAM/dhcp_pool.php
+++ b/Simple-PHP-IPAM/dhcp_pool.php
@@ -1,0 +1,267 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+require_write_access();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
+
+$err     = '';
+$msg     = '';
+$results = null;
+
+// Load all IPv4 subnets for the selector
+$st = $db->prepare(
+    "SELECT s.id, s.cidr, s.description, s.network_bin, s.prefix,
+            si.name AS site_name
+     FROM subnets s LEFT JOIN sites si ON si.id = s.site_id
+     WHERE s.ip_version = 4
+     ORDER BY s.network_bin ASC"
+);
+$st->execute();
+$subnets = $st->fetchAll();
+
+// Selected subnet from query string or POST
+$subnetId = (int)($_GET['subnet_id'] ?? $_POST['subnet_id'] ?? 0);
+
+$subnet = null;
+foreach ($subnets as $s) {
+    if ((int)$s['id'] === $subnetId) { $subnet = $s; break; }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action   = (string)($_POST['action']   ?? '');
+    $subnetId = (int)($_POST['subnet_id']   ?? 0);
+    $startIp  = trim((string)($_POST['start_ip'] ?? ''));
+    $endIp    = trim((string)($_POST['end_ip']   ?? ''));
+    $note     = trim((string)($_POST['note']     ?? ''));
+
+    // Re-resolve subnet from POST in case it changed
+    $subnet = null;
+    foreach ($subnets as $s) {
+        if ((int)$s['id'] === $subnetId) { $subnet = $s; break; }
+    }
+
+    if ($action === 'reserve_pool') {
+        if (!$subnet) {
+            $err = 'Subnet not found.';
+        } elseif ($startIp === '' || $endIp === '') {
+            $err = 'Start and end IPs are required.';
+        } else {
+            $p      = parse_cidr($subnet['cidr']);
+            $startN = normalize_ip($startIp);
+            $endN   = normalize_ip($endIp);
+
+            if (!$startN || $startN['version'] !== 4) {
+                $err = 'Invalid start IP.';
+            } elseif (!$endN || $endN['version'] !== 4) {
+                $err = 'Invalid end IP.';
+            } elseif (!ip_in_cidr($startN['ip'], (string)$p['network'], (int)$p['prefix'])) {
+                $err = 'Start IP is not within the selected subnet (' . $subnet['cidr'] . ').';
+            } elseif (!ip_in_cidr($endN['ip'], (string)$p['network'], (int)$p['prefix'])) {
+                $err = 'End IP is not within the selected subnet (' . $subnet['cidr'] . ').';
+            } else {
+                $startInt = ipv4_bin_to_int($startN['bin']);
+                $endInt   = ipv4_bin_to_int($endN['bin']);
+
+                if ($startInt > $endInt) {
+                    $err = 'Start IP must be less than or equal to End IP.';
+                } elseif (($endInt - $startInt + 1) > 1024) {
+                    $err = 'Range too large (max 1,024 IPs per operation). Split into smaller ranges.';
+                } else {
+                    $created = 0;
+                    $updated = 0;
+                    $skipped = 0;
+
+                    $db->beginTransaction();
+                    try {
+                        $stCheck = $db->prepare(
+                            "SELECT id, status FROM addresses WHERE subnet_id = :sid AND ip_bin = :b"
+                        );
+                        $stUpd = $db->prepare(
+                            "UPDATE addresses SET status = 'reserved', note = :n WHERE id = :id"
+                        );
+                        $stIns = $db->prepare(
+                            "INSERT INTO addresses (subnet_id, ip, ip_bin, ip_version, status, note)
+                             VALUES (:sid, :ip, :b, 4, 'reserved', :n)"
+                        );
+
+                        for ($ipInt = $startInt; $ipInt <= $endInt; $ipInt++) {
+                            $ipBin = ipv4_int_to_bin($ipInt);
+                            $ipStr = (string)inet_ntop($ipBin);
+
+                            $stCheck->execute([':sid' => $subnetId, ':b' => $ipBin]);
+                            $existing = $stCheck->fetch();
+
+                            if ($existing) {
+                                if ($existing['status'] === 'used') {
+                                    $skipped++;
+                                } else {
+                                    $stUpd->execute([':n' => $note, ':id' => $existing['id']]);
+                                    $updated++;
+                                }
+                            } else {
+                                $stIns->execute([
+                                    ':sid' => $subnetId, ':ip' => $ipStr,
+                                    ':b' => $ipBin, ':n' => $note,
+                                ]);
+                                $created++;
+                            }
+                        }
+
+                        $db->commit();
+
+                        audit($db, 'dhcp_pool.reserve', 'subnet', $subnetId,
+                            "start={$startIp} end={$endIp} created={$created} updated={$updated} skipped={$skipped}");
+
+                        $results = compact('created', 'updated', 'skipped', 'startIp', 'endIp');
+                        $msg = "{$created} reserved (new), {$updated} updated, {$skipped} skipped (already used).";
+                    } catch (Throwable $e) {
+                        $db->rollBack();
+                        $err = 'Failed to reserve pool: ' . $e->getMessage();
+                    }
+                }
+            }
+        }
+    } elseif ($action === 'clear_pool') {
+        if (!$subnet) {
+            $err = 'Subnet not found.';
+        } elseif ($startIp === '' || $endIp === '') {
+            $err = 'Start and end IPs are required.';
+        } else {
+            $p      = parse_cidr($subnet['cidr']);
+            $startN = normalize_ip($startIp);
+            $endN   = normalize_ip($endIp);
+
+            if (!$startN || $startN['version'] !== 4 || !$endN || $endN['version'] !== 4) {
+                $err = 'Invalid IP address.';
+            } elseif (!ip_in_cidr($startN['ip'], (string)$p['network'], (int)$p['prefix'])
+                   || !ip_in_cidr($endN['ip'], (string)$p['network'], (int)$p['prefix'])) {
+                $err = 'IPs are not within the selected subnet.';
+            } else {
+                $startInt = ipv4_bin_to_int($startN['bin']);
+                $endInt   = ipv4_bin_to_int($endN['bin']);
+
+                if ($startInt > $endInt) {
+                    $err = 'Start IP must be less than or equal to End IP.';
+                } elseif (($endInt - $startInt + 1) > 1024) {
+                    $err = 'Range too large (max 1,024 IPs per operation).';
+                } else {
+                    $deleted = 0;
+
+                    $db->beginTransaction();
+                    try {
+                        $stDel = $db->prepare(
+                            "DELETE FROM addresses WHERE subnet_id = :sid AND ip_bin = :b AND status = 'reserved'"
+                        );
+                        for ($ipInt = $startInt; $ipInt <= $endInt; $ipInt++) {
+                            $stDel->execute([':sid' => $subnetId, ':b' => ipv4_int_to_bin($ipInt)]);
+                            $deleted += $stDel->rowCount();
+                        }
+                        $db->commit();
+
+                        audit($db, 'dhcp_pool.clear', 'subnet', $subnetId,
+                            "start={$startIp} end={$endIp} deleted={$deleted}");
+                        $msg = "{$deleted} reserved address record(s) removed from the range.";
+                    } catch (Throwable $e) {
+                        $db->rollBack();
+                        $err = 'Failed to clear pool: ' . $e->getMessage();
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Load existing reserved addresses for the selected subnet (for display)
+$reserved = [];
+if ($subnet) {
+    $stR = $db->prepare(
+        "SELECT ip, note FROM addresses WHERE subnet_id = :sid AND status = 'reserved'
+         ORDER BY ip_bin ASC"
+    );
+    $stR->execute([':sid' => $subnetId]);
+    $reserved = $stR->fetchAll();
+}
+
+page_header('DHCP Pools');
+?>
+<div class="breadcrumbs">
+  <a href="dashboard.php">🏠 Dashboard</a><span class="sep">›</span>
+  <a href="subnets.php">🌐 Subnets</a><span class="sep">›</span>
+  <span>🔒 DHCP Pools</span>
+</div>
+
+<div class="toolbar">
+  <div>
+    <h1>DHCP Pool Reservation</h1>
+    <div class="muted">Bulk-reserve a contiguous IP range within an IPv4 subnet. Addresses already marked <em>used</em> are never overwritten.</div>
+  </div>
+</div>
+
+<?php if ($err): ?><p class="danger"><?= e($err) ?></p><?php endif; ?>
+<?php if ($msg): ?><p class="success"><?= e($msg) ?></p><?php endif; ?>
+
+<div class="card" style="margin-top:16px">
+  <h2>Reserve a range</h2>
+  <form method="post" action="dhcp_pool.php">
+    <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+    <input type="hidden" name="action" value="reserve_pool">
+    <div class="row" style="flex-wrap:wrap;gap:10px">
+      <label>Subnet<br>
+        <select name="subnet_id" onchange="this.form.submit()" style="min-width:200px">
+          <option value="0">— select subnet —</option>
+          <?php foreach ($subnets as $s): ?>
+            <option value="<?= (int)$s['id'] ?>" <?= ((int)$s['id'] === $subnetId) ? 'selected' : '' ?>>
+              <?= e($s['cidr']) ?><?= $s['description'] ? ' — ' . e($s['description']) : '' ?>
+              <?= $s['site_name'] ? ' [' . e($s['site_name']) . ']' : '' ?>
+            </option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <?php if ($subnet): ?>
+      <label>Start IP<br><input name="start_ip" placeholder="e.g. <?= e(explode('/', $subnet['cidr'])[0]) ?>" required style="min-width:140px"></label>
+      <label>End IP<br><input name="end_ip" placeholder="e.g. <?= e(explode('/', $subnet['cidr'])[0]) ?>" required style="min-width:140px"></label>
+      <label>Note<br><input name="note" placeholder="DHCP pool" value="DHCP pool" style="min-width:160px"></label>
+      <label style="align-self:flex-end"><br><button type="submit">Reserve</button></label>
+      <?php endif; ?>
+    </div>
+  </form>
+</div>
+
+<?php if ($subnet): ?>
+<div class="card" style="margin-top:16px">
+  <h2>Clear a range <span class="muted" style="font-size:.85em;font-weight:400">(removes <em>reserved</em> records only)</span></h2>
+  <form method="post" action="dhcp_pool.php" onsubmit="return confirm('Delete all reserved records in this range?')">
+    <input type="hidden" name="csrf"      value="<?= e(csrf_token()) ?>">
+    <input type="hidden" name="action"    value="clear_pool">
+    <input type="hidden" name="subnet_id" value="<?= (int)$subnetId ?>">
+    <div class="row" style="gap:10px">
+      <label>Start IP<br><input name="start_ip" required style="min-width:140px"></label>
+      <label>End IP<br><input name="end_ip"   required style="min-width:140px"></label>
+      <label style="align-self:flex-end"><br><button type="submit" class="button-danger">Clear</button></label>
+    </div>
+  </form>
+</div>
+
+<div class="card" style="margin-top:16px">
+  <h2>Reserved addresses in <?= e($subnet['cidr']) ?> <span class="muted" style="font-size:.85em;font-weight:400">(<?= count($reserved) ?>)</span></h2>
+  <?php if (empty($reserved)): ?>
+    <div class="empty-state">No reserved addresses in this subnet.</div>
+  <?php else: ?>
+    <table>
+      <thead><tr><th>IP</th><th>Note</th></tr></thead>
+      <tbody>
+      <?php foreach ($reserved as $r): ?>
+        <tr>
+          <td><?= e($r['ip']) ?></td>
+          <td class="muted"><?= e((string)$r['note']) ?></td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+    <p style="margin-top:8px"><a href="addresses.php?subnet_id=<?= (int)$subnetId ?>">View all addresses →</a></p>
+  <?php endif; ?>
+</div>
+<?php endif; ?>
+
+<?php page_footer();

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -793,8 +793,8 @@ function page_header(string $title): void
 
     echo "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>";
     echo "<title>" . e($title) . "</title>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=0.11'>";
-    echo "<script defer src='assets/app.js?v=0.11'></script>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=0.14'>";
+    echo "<script defer src='assets/app.js?v=0.14'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";
@@ -811,6 +811,7 @@ function page_header(string $title): void
             echo "<div class='nav-dropdown-menu'>";
             echo "<a class='nav-dropdown-item' href='sites.php'>📍 Sites</a>";
             echo "<a class='nav-dropdown-item' href='users.php'>👤 Users</a>";
+            echo "<a class='nav-dropdown-item' href='dhcp_pool.php'>🔒 DHCP Pools</a>";
             echo "<a class='nav-dropdown-item' href='api_keys.php'>🔑 API Keys</a>";
             echo "<a class='nav-dropdown-item' href='import_csv.php'>⬆ Import CSV</a>";
             echo "</div></div>";
@@ -841,9 +842,75 @@ function page_header(string $title): void
 
 function page_footer(): void
 {
+    global $config;
     require __DIR__ . '/version.php';
-    echo "<hr><div class='muted'>PHP SQLite IPAM v" . e(IPAM_VERSION) . "</div>";
-    echo "</div></body></html>";
+
+    echo "<hr><div class='muted' style='display:flex;align-items:center;gap:10px;flex-wrap:wrap'>";
+    echo "<a href='https://github.com/seanmousseau/Simple-PHP-IPAM' target='_blank' rel='noopener' "
+       . "style='color:inherit;text-decoration:none'>Simple PHP IPAM</a> v" . e(IPAM_VERSION);
+
+    $update = ipam_update_check($config ?? []);
+    if ($update) {
+        $uv  = e((string)$update['version']);
+        $url = e((string)$update['url']);
+        echo " <a href='{$url}' target='_blank' rel='noopener' class='badge badge-update'>"
+           . "Update available v{$uv}</a>";
+    }
+
+    echo "</div></div></body></html>";
+}
+
+/**
+ * Check GitHub for a newer release. Results are cached in data/tmp/ for the
+ * configured TTL (default 6 hours). Network failures are silently ignored.
+ *
+ * Returns ['version' => '0.15', 'url' => 'https://...'] if newer, otherwise null.
+ */
+function ipam_update_check(array $config): ?array
+{
+    $uc = $config['update_check'] ?? [];
+    if (isset($uc['enabled']) && !(bool)$uc['enabled']) return null;
+
+    $ttl = max(3600, (int)($uc['ttl_seconds'] ?? 21600));
+
+    ensure_tmp_dir();
+    $cache = tmp_dir() . '/update-check.json';
+
+    if (is_file($cache) && (time() - (int)filemtime($cache)) < $ttl) {
+        $d = json_decode((string)file_get_contents($cache), true);
+        if (is_array($d) && array_key_exists('checked', $d)) {
+            return isset($d['update']) ? (array)$d['update'] : null;
+        }
+    }
+
+    require_once __DIR__ . '/version.php';
+    $result = null;
+
+    try {
+        $url = 'https://api.github.com/repos/seanmousseau/Simple-PHP-IPAM/releases/latest';
+        $ctx = stream_context_create(['http' => [
+            'timeout' => 5,
+            'ignore_errors' => true,
+            'header' => "User-Agent: Simple-PHP-IPAM/" . IPAM_VERSION . "\r\n"
+                      . "Accept: application/vnd.github+json\r\n",
+        ]]);
+        $raw = @file_get_contents($url, false, $ctx);
+        if ($raw !== false && $raw !== '') {
+            $data = json_decode($raw, true);
+            if (is_array($data) && !empty($data['tag_name']) && empty($data['draft']) && empty($data['prerelease'])) {
+                $latest = ltrim((string)$data['tag_name'], 'v');
+                if (version_compare($latest, IPAM_VERSION, '>')) {
+                    $result = ['version' => $latest, 'url' => (string)($data['html_url'] ?? '')];
+                }
+            }
+        }
+    } catch (Throwable) {
+        // Non-critical — silently skip on network failure
+    }
+
+    @file_put_contents($cache, json_encode(['checked' => time(), 'update' => $result]));
+    @chmod($cache, 0600);
+    return $result;
 }
 
 /**

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -41,6 +41,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             clear_login_failures($db, $ip);
             login_user((int)$user['id'], (string)$user['username'], (string)$user['role']);
+            $db->prepare("UPDATE users SET last_login_at=datetime('now') WHERE id=:id")
+               ->execute([':id' => (int)$user['id']]);
             audit($db, 'auth.login', 'user', (int)$user['id'], 'login ok');
             header('Location: dashboard.php');
             exit;
@@ -55,9 +57,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 // First-run hint: show only if no successful login has ever occurred
 $firstRun = !$db->query("SELECT 1 FROM audit_log WHERE action='auth.login' LIMIT 1")->fetch();
 
-$oidcActive       = oidc_enabled($config);
-$disableLocal     = $oidcActive && !empty($config['oidc']['disable_local_login']);
-$localForceShown  = isset($_GET['local']); // emergency bypass
+$oidcActive              = oidc_enabled($config);
+$disableLocal            = $oidcActive && !empty($config['oidc']['disable_local_login']);
+$disableEmergencyBypass  = $oidcActive && !empty($config['oidc']['disable_emergency_bypass']);
+$hideEmergencyLink       = $oidcActive && !empty($config['oidc']['hide_emergency_link']);
+$localForceShown         = isset($_GET['local']) && !$disableEmergencyBypass;
 
 page_header('Login');
 ?>
@@ -92,7 +96,9 @@ page_header('Login');
 </form>
 <?php elseif ($oidcActive): ?>
   <p class="muted" style="margin-top:16px">Local password login is disabled. Use SSO above.
-    <a href="login.php?local=1" class="muted" style="font-size:.9em">(emergency local access)</a>
+    <?php if (!$hideEmergencyLink && !$disableEmergencyBypass): ?>
+      <a href="login.php?local=1" class="muted" style="font-size:.9em">(emergency local access)</a>
+    <?php endif; ?>
   </p>
 <?php endif; ?>
 <?php page_footer();

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -75,6 +75,15 @@ function ipam_migrations(): array
             $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id)");
         },
 
+        // 0.14: last_login_at timestamp on users
+        '0.14' => function(PDO $db) {
+            $cols  = $db->query("PRAGMA table_info(users)")->fetchAll();
+            $names = array_map(fn($c) => $c['name'], $cols);
+            if (!in_array('last_login_at', $names, true)) {
+                $db->exec("ALTER TABLE users ADD COLUMN last_login_at TEXT");
+            }
+        },
+
         // 0.13: name + email fields on users
         '0.13' => function(PDO $db) {
             $cols  = $db->query("PRAGMA table_info(users)")->fetchAll();

--- a/Simple-PHP-IPAM/oidc_callback.php
+++ b/Simple-PHP-IPAM/oidc_callback.php
@@ -172,6 +172,8 @@ if ((int)$user['is_active'] !== 1) {
 
 // ---- All checks passed — log in ----
 login_user((int)$user['id'], (string)$user['username'], (string)$user['role']);
+$db->prepare("UPDATE users SET last_login_at=datetime('now') WHERE id=:id")
+   ->execute([':id' => (int)$user['id']]);
 audit($db, 'auth.oidc_login', 'user', (int)$user['id'], 'sub=' . $sub);
 
 header('Location: dashboard.php');

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -357,9 +357,22 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
 
     if ((int)$row['ip_version'] === 4 && isset($ipv4Unassigned[$id])) {
         $u = $ipv4Unassigned[$id];
-        echo "<br><span class='muted'>Assignable: " . e((string)$u['assignable_total']) .
-             " | Assigned: " . e((string)$u['assigned_assignable']) .
-             " | Unassigned: <b>" . e((string)$u['unassigned_assignable']) . "</b></span>";
+        $assignable = (int)$u['assignable_total'];
+        $assigned   = (int)$u['assigned_assignable'];
+        $pct = $assignable > 0 ? (int)round($assigned / $assignable * 100) : 0;
+        $cfg = $GLOBALS['config'] ?? [];
+        $warnThreshold = (int)($cfg['utilization_warn']     ?? 80);
+        $critThreshold = (int)($cfg['utilization_critical'] ?? 95);
+        $barClass = $pct >= $critThreshold ? 'util-bar-fill--crit'
+                  : ($pct >= $warnThreshold ? 'util-bar-fill--warn' : '');
+        $pctLabel = $pct >= $critThreshold ? "<span class='danger'>{$pct}%</span>"
+                  : ($pct >= $warnThreshold ? "<span class='warning'>{$pct}%</span>"
+                  : "<span>{$pct}%</span>");
+        echo "<br><span class='muted'>Assignable: " . e((string)$assignable) .
+             " | Assigned: " . e((string)$assigned) .
+             " | Unassigned: <b>" . e((string)$u['unassigned_assignable']) . "</b></span>"
+           . " <span class='util-bar'><span class='util-bar-fill {$barClass}' style='width:{$pct}%'></span></span>"
+           . " {$pctLabel}";
     }
     echo "</summary>";
 
@@ -371,6 +384,9 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
     }
     if (current_user()['role'] !== 'readonly') {
         echo "<a class='action-pill' href='bulk_update.php?subnet_id=" . (int)$row['id'] . "'>✏ Bulk Update</a>";
+        if ((int)$row['ip_version'] === 4) {
+            echo "<a class='action-pill' href='dhcp_pool.php?subnet_id=" . (int)$row['id'] . "'>🔒 DHCP Pool</a>";
+        }
     }
     echo "</div>";
 

--- a/Simple-PHP-IPAM/users.php
+++ b/Simple-PHP-IPAM/users.php
@@ -42,15 +42,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     } elseif ($action === 'toggle_active') {
         $id = (int)($_POST['id'] ?? 0);
-        $db->prepare("UPDATE users SET is_active = CASE WHEN is_active=1 THEN 0 ELSE 1 END WHERE id = :id")
-           ->execute([':id' => $id]);
-        audit($db, 'user.toggle_active', 'user', $id, '');
-        $msg = 'User updated.';
+        if ($id === $self['id']) {
+            $err = 'You cannot disable your own account.';
+        } else {
+            $db->prepare("UPDATE users SET is_active = CASE WHEN is_active=1 THEN 0 ELSE 1 END WHERE id = :id")
+               ->execute([':id' => $id]);
+            audit($db, 'user.toggle_active', 'user', $id, '');
+            $msg = 'User updated.';
+        }
 
     } elseif ($action === 'set_role') {
         $id   = (int)($_POST['id']   ?? 0);
         $role = (string)($_POST['role'] ?? '');
-        if (!in_array($role, ['admin', 'readonly'], true)) {
+        if ($id === $self['id']) {
+            $err = 'You cannot change your own role.';
+        } elseif (!in_array($role, ['admin', 'readonly'], true)) {
             $err = 'Invalid role.';
         } else {
             $db->prepare("UPDATE users SET role = :r WHERE id = :id")
@@ -99,10 +105,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     } elseif ($action === 'unlink_oidc') {
         $id = (int)($_POST['id'] ?? 0);
-        $db->prepare("UPDATE users SET oidc_sub = NULL WHERE id = :id")
-           ->execute([':id' => $id]);
-        audit($db, 'user.oidc_unlink', 'user', $id, '');
-        $msg = 'OIDC link removed.';
+        if ($id === $self['id']) {
+            $err = 'You cannot unlink your own SSO account from this page. Use your profile settings.';
+        } else {
+            $db->prepare("UPDATE users SET oidc_sub = NULL WHERE id = :id")
+               ->execute([':id' => $id]);
+            audit($db, 'user.oidc_unlink', 'user', $id, '');
+            $msg = 'OIDC link removed.';
+        }
 
     } elseif ($action === 'delete') {
         $id = (int)($_POST['id'] ?? 0);
@@ -132,7 +142,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $st = $db->prepare(
-    "SELECT id, username, name, email, role, is_active, created_at, updated_at, oidc_sub
+    "SELECT id, username, name, email, role, is_active, created_at, updated_at, oidc_sub, last_login_at
      FROM users ORDER BY username ASC"
 );
 $st->execute();
@@ -173,6 +183,7 @@ page_header('Users');
       <th>Role</th>
       <th>Active</th>
       <th>SSO</th>
+      <th>Last Login</th>
       <th>Created</th>
       <th>Actions</th>
     </tr>
@@ -192,12 +203,14 @@ page_header('Users');
           <span class="muted">—</span>
         <?php endif; ?>
       </td>
+      <td class="muted"><?= $u['last_login_at'] ? e($u['last_login_at']) : '<span class="muted">never</span>' ?></td>
       <td class="muted"><?= e($u['created_at']) ?></td>
       <td>
         <details>
           <summary class="muted" style="cursor:pointer;font-size:.9em">Actions ▾</summary>
           <div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">
 
+            <?php if ((int)$u['id'] !== $self['id']): ?>
             <form method="post" action="users.php" class="row" style="gap:6px">
               <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
               <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
@@ -215,6 +228,7 @@ page_header('Users');
               </select>
               <button type="submit">Set role</button>
             </form>
+            <?php endif; ?>
 
             <form method="post" action="users.php" class="row" style="gap:6px">
               <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
@@ -234,6 +248,7 @@ page_header('Users');
             </form>
 
             <?php if ($u['oidc_sub'] !== null): ?>
+              <?php if ((int)$u['id'] !== $self['id']): ?>
               <form method="post" action="users.php" class="row" style="gap:6px"
                     onsubmit="return confirm('Remove SSO link for <?= e((string)$u['username']) ?>?')">
                 <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
@@ -241,6 +256,9 @@ page_header('Users');
                 <input type="hidden" name="id"     value="<?= (int)$u['id'] ?>">
                 <button type="submit" class="button-secondary">Unlink SSO</button>
               </form>
+              <?php else: ?>
+              <span class="muted" style="font-size:.9em">SSO linked (manage in your own profile)</span>
+              <?php endif; ?>
             <?php else: ?>
               <form method="post" action="users.php" class="row" style="gap:6px">
                 <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-const IPAM_VERSION = '0.13';
+const IPAM_VERSION = '0.14';

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,18 +54,30 @@ return [
         'interval_seconds' => 86400, // once per day
     ],
 
+    // Subnet utilization thresholds for the colour-coded progress bars.
+    'utilization_warn'     => 80,
+    'utilization_critical' => 95,
+
+    // Update check: shows a footer badge when a newer GitHub release is available.
+    'update_check' => [
+        'enabled'     => true,
+        'ttl_seconds' => 21600,
+    ],
+
     // OIDC single sign-on — see docs/oidc.md for full setup guide.
     'oidc' => [
-        'enabled'             => false,
-        'display_name'        => 'SSO',
-        'client_id'           => '',
-        'client_secret'       => '',
-        'discovery_url'       => '',
-        'redirect_uri'        => '',
-        'scopes'              => 'openid email profile',
-        'auto_provision'      => false,
-        'default_role'        => 'readonly',
-        'disable_local_login' => false,
+        'enabled'                   => false,
+        'display_name'              => 'SSO',
+        'client_id'                 => '',
+        'client_secret'             => '',
+        'discovery_url'             => '',
+        'redirect_uri'              => '',
+        'scopes'                    => 'openid email profile',
+        'auto_provision'            => false,
+        'default_role'              => 'readonly',
+        'disable_local_login'       => false,
+        'hide_emergency_link'       => false,
+        'disable_emergency_bypass'  => false,
     ],
 ];
 ```
@@ -180,9 +192,32 @@ The `oidc` block configures optional OIDC single sign-on. All keys are ignored w
 | `scopes` | `'openid email profile'` | Space-separated scopes |
 | `auto_provision` | `false` | Automatically create or link a local account on first OIDC login |
 | `default_role` | `'readonly'` | Role assigned to auto-provisioned users (`admin` or `readonly`) |
-| `disable_local_login` | `false` | Hide the password form when OIDC is enabled. Emergency bypass at `login.php?local=1` |
+| `disable_local_login` | `false` | Hide the password form when OIDC is enabled |
+| `hide_emergency_link` | `false` | Hide the emergency local access link text (URL still works unless `disable_emergency_bypass` is also set) |
+| `disable_emergency_bypass` | `false` | Make `login.php?local=1` completely ineffective. **Warning:** locks you out if your IdP goes down |
 
 See the [OIDC guide](oidc.md) for IdP setup examples, user provisioning details, and troubleshooting.
+
+---
+
+## `utilization_warn` / `utilization_critical`
+
+**Defaults:** `80` / `95`
+
+Percentage thresholds for the IPv4 subnet utilization progress bars in the subnet list. The bar turns yellow at `utilization_warn` and red at `utilization_critical`.
+
+---
+
+## `update_check`
+
+Controls the automatic update check shown in the page footer.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `true` | Set to `false` to disable the update check entirely |
+| `ttl_seconds` | `21600` | How long to cache the result (default: 6 hours; minimum: 3600) |
+
+The check fetches the GitHub releases API once per TTL period and caches the result in `data/tmp/update-check.json`. Network failures are silently ignored. Drafts and pre-releases are not shown.
 
 ---
 

--- a/docs/oidc.md
+++ b/docs/oidc.md
@@ -184,7 +184,27 @@ Set `'disable_local_login' => true` in the `oidc` config block to hide the usern
 ],
 ```
 
-**Emergency access:** Even with `disable_local_login` enabled, local login is always accessible at `login.php?local=1`. Keep at least one active local admin account as a break-glass fallback in case your IdP becomes unavailable.
+**Emergency access:** Even with `disable_local_login` enabled, local login is accessible at `login.php?local=1` by default. Keep at least one active local admin account as a break-glass fallback.
+
+### Hiding the emergency link
+
+If you want SSO-only appearance without advertising the bypass URL, set `hide_emergency_link`:
+
+```php
+'hide_emergency_link' => true,
+```
+
+The `?local=1` URL still works — the link text is simply not shown on the login page.
+
+### Disabling emergency access entirely
+
+To make `login.php?local=1` completely non-functional:
+
+```php
+'disable_emergency_bypass' => true,
+```
+
+> **Warning:** If your IdP becomes unavailable while `disable_emergency_bypass` is `true`, no one can log in. Only set this after verifying your IdP uptime and having an out-of-band admin recovery procedure (e.g. SSH access to reset the DB).
 
 ---
 


### PR DESCRIPTION
Branding
- Rename app to Simple PHP IPAM; footer name links to GitHub repo

Update check
- ipam_update_check() fetches GitHub releases API, caches 6h in data/tmp/
- Footer shows badge-update pill when newer non-draft release available
- Configurable via update_check.enabled / update_check.ttl_seconds

DHCP pool tool (dhcp_pool.php)
- Bulk-reserve a contiguous IPv4 range as DHCP pool (max 1024 IPs/op)
- Skips IPs already marked used; updates reserved/free records in place
- Clear action removes reserved records from a range
- Linked from each subnet action bar and Admin nav dropdown
- Audit-logged per operation

User management hardening
- Block self-disable, self-role-change, self-unlink-oidc (UI + server)
- Add last_login_at column (migration 0.14), populated on local and OIDC login
- Show Last Login column in users table

Subnet utilization badges
- IPv4 subnets show mini progress bar + percentage next to assignable counts
- Colour: green / yellow (≥ utilization_warn) / red (≥ utilization_critical)
- Configurable thresholds in config.php (defaults: 80% / 95%)

OIDC emergency access controls
- hide_emergency_link: suppress link text without disabling URL
- disable_emergency_bypass: make ?local=1 completely non-functional
- Both config keys documented with warnings

Admin nav: add DHCP Pools link to admin dropdown
CSS: add .badge-update, .util-bar, .util-bar-fill{--warn,--crit} classes Update asset cache-buster to v=0.14

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3