### PR TITLE
fix(dhcp_pool): remove ip_version from addresses INSERT

### DIFF
--- a/Simple-PHP-IPAM/dhcp_pool.php
+++ b/Simple-PHP-IPAM/dhcp_pool.php
@@ -81,8 +81,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             "UPDATE addresses SET status = 'reserved', note = :n WHERE id = :id"
                         );
                         $stIns = $db->prepare(
-                            "INSERT INTO addresses (subnet_id, ip, ip_bin, ip_version, status, note)
-                             VALUES (:sid, :ip, :b, 4, 'reserved', :n)"
+                            "INSERT INTO addresses (subnet_id, ip, ip_bin, status, note)
+                             VALUES (:sid, :ip, :b, 'reserved', :n)"
                         );
 
                         for ($ipInt = $startInt; $ipInt <= $endInt; $ipInt++) {
@@ -102,7 +102,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             } else {
                                 $stIns->execute([
                                     ':sid' => $subnetId, ':ip' => $ipStr,
-                                    ':b' => $ipBin, ':n' => $note,
+                                    ':b'   => $ipBin,    ':n'  => $note,
                                 ]);
                                 $created++;
                             }


### PR DESCRIPTION
The addresses table has no ip_version column (only subnets does). The INSERT was including it, causing a column-not-found error on reserve.

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3