### PR TITLE
v0.15 — Config Auto-Population, Backups, Database Tools, Mobile GUI, Update Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## 0.15 — Config Auto-Population, Backups, Database Tools, Mobile GUI, Update Check Enhancements
+
+### Config auto-population
+- Missing top-level keys are automatically appended to `config.php` with their defaults on application boot
+- A one-time notice is shown in the admin panel identifying which keys were added
+- Applies to: `update_check.notify_prerelease`, the new `backup` block, and any future keys added by upgrades
+
+### Automatic database backups (`lib.php`, `config.php`)
+- New `backup` config block: `enabled`, `frequency` (`daily`|`weekly`), `retention`, `dir`
+- Backup runs on page load when the configured interval has elapsed (file-locked, non-blocking)
+- Backup format: WAL-checkpointed SQLite copy with timestamp filename (`ipam-YYYY-MM-DD-HHmmss.sqlite`)
+- Older backups beyond the retention count are pruned automatically
+- Disabled by default — opt in via `'backup' => ['enabled' => true]` in `config.php`
+
+### Database Tools admin page (`db_tools.php`)
+- New **Database Tools** entry in the Admin nav dropdown
+- **Export**: one-click download of a full SQL dump (schema + data + indexes), compatible with SQLite
+- **Import**: upload a `.sql` dump to replace all data; pre-import backup is created automatically; executes in a transaction with rollback on error
+- **Manual backup**: trigger an out-of-schedule backup from the UI
+- Backup status panel: last backup time, last file name, current backup count
+- All export, import, and backup actions are recorded in the audit log
+
+### Mobile-optimized GUI (`assets/app.css`)
+- Responsive CSS breakpoints at **768 px** and **480 px**
+- Tables, cards, forms, toolbars, and metric blocks stack gracefully on narrow viewports
+- Navigation wraps and pills shrink on mobile; all primary CRUD actions remain accessible
+- New `.table-scroll` utility class for horizontally scrollable tables on small screens
+- Admin notice styles for config and update banners
+
+### GitHub update checker enhancements (`lib.php`, `config.php`)
+- New `update_check.notify_prerelease` option (default `false`): opt in to alerts for alpha/beta/RC releases
+- Update check now fetches the `/releases` list (not just `/releases/latest`) to support pre-release detection
+- Cache TTL extended to 24 hours (was 6 hours); configurable via `update_check.ttl_seconds`
+- **Dismissible update banner** shown to admins at the top of every page (separate from the footer badge)
+- Dismiss action stores dismissed version in `localStorage`; banner re-appears for the next release
+
+---
+
 ## 0.14 — DHCP Pools, Update Check, User Hardening, Utilization Badges
 
 ### Application branding

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ No Composer, no npm, no external dependencies — just PHP and a web server.
 - **OIDC SSO** — Authorization Code + PKCE in pure PHP; auto-provision and auto-link; optional `disable_local_login`
 - **User management** — name/email fields, per-user enable/disable, delete, manual SSO linking
 
+### Administration
+- **Database Tools** — one-click SQL export, SQL import with pre-import backup, manual backup trigger, backup status panel
+- **Automatic backups** — configurable daily/weekly SQLite snapshots with retention pruning
+- **Config auto-population** — missing config keys appended with defaults on boot; admin notice on first load
+- **Mobile-optimized GUI** — responsive layout works on phones and tablets at 375 px and 768 px
+
 ### REST API
 - Read-only JSON API (`api.php`) authenticated with API keys
 - Resources: subnets, addresses (paginated + filterable), sites
@@ -82,6 +88,18 @@ See the [Installation guide](docs/install.md) for full web server configuration 
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full version history.
+
+### What's new in 0.15
+
+**Config auto-population** — Any config keys added in an upgrade are automatically appended to `config.php` with their defaults. Admins see a one-time notice identifying the added keys.
+
+**Automatic backups** — Built-in backup scheduler writes timestamped SQLite snapshots on page load at a configurable interval (`daily`/`weekly`). Older backups beyond the retention count are pruned automatically. Opt in via `'backup' => ['enabled' => true]` in `config.php`.
+
+**Database Tools** — New admin page (⚙ Admin → Database Tools) for one-click SQL export, SQL import with pre-import backup and rollback on error, manual backup trigger, and backup status summary.
+
+**Mobile GUI** — Responsive CSS breakpoints at 768 px and 480 px. Nav, tables, cards, forms, and toolbars all adapt gracefully to phones and tablets.
+
+**Update check enhancements** — Dismissible update banner shown at the top of every admin page. New `notify_prerelease` option surfaces alpha/beta/RC releases. Cache TTL extended to 24 hours.
 
 ### What's new in 0.14
 

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -447,10 +447,66 @@ details > summary::-webkit-details-marker{display:none}
 .report-invalid{color:var(--danger);font-weight:600}
 .report-needs-subnet{color:var(--warn);font-weight:600}
 
+/* Admin notices (config updates, update-available banner) */
+.admin-notice{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  flex-wrap:wrap;
+  padding:10px 14px;
+  border-radius:12px;
+  margin-bottom:14px;
+  border:1px solid var(--border);
+  font-size:.95rem;
+}
+.admin-notice--info{
+  background:color-mix(in srgb,var(--link) 8%,var(--card));
+  border-color:color-mix(in srgb,var(--link) 30%,var(--border));
+  color:var(--fg);
+}
+.admin-notice--update{
+  background:color-mix(in srgb,var(--success) 8%,var(--card));
+  border-color:color-mix(in srgb,var(--success) 30%,var(--border));
+  color:var(--fg);
+}
+.admin-notice a{font-weight:600}
+
+/* Scrollable table wrapper — wrap tables in this on narrow pages */
+.table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+
+/* Mobile — 768px breakpoint */
 @media (max-width: 768px){
   .page{padding:14px}
-  .nav-wrap{padding:10px 14px}
-  th,td{padding:8px}
-  .nav-links{gap:8px}
-  .nav-pill{padding:8px 10px}
+  .nav-wrap{
+    padding:10px 14px;
+    gap:8px;
+  }
+  .nav-links{gap:6px}
+  .nav-pill{padding:7px 9px;font-size:.92rem}
+  th,td{padding:8px 10px;font-size:.9rem}
+  h1{font-size:1.45rem}
+  h2{font-size:1.15rem}
+  .grid.cols-2,.grid.cols-3{
+    grid-template-columns:1fr;
+  }
+  .metric .value{font-size:1.35rem}
+  .row{flex-direction:column;align-items:stretch}
+  .row > *{width:100%}
+  .toolbar{flex-direction:column;align-items:stretch}
+  .toolbar .spacer{display:none}
+  .page-actions{flex-direction:column;align-items:stretch}
+  table{font-size:.88rem}
+  /* Prevent nav-right from jumping to new row; keep it inline */
+  .nav-right{margin-left:auto}
+}
+
+/* Mobile — 480px breakpoint (small phones) */
+@media (max-width: 480px){
+  .page{padding:10px}
+  .nav-wrap{padding:8px 10px}
+  .nav-pill{padding:6px 8px;font-size:.88rem}
+  h1{font-size:1.25rem}
+  .card{padding:12px}
+  .metric{padding:10px 12px}
+  th,td{padding:6px 8px;font-size:.85rem}
 }

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -37,8 +37,25 @@
   window.ipamToggleTheme = window.ipamCycleTheme;
   window.ipamClearTheme = function() { applyTheme("auto"); updateThemeButton(); };
 
+  // Dismiss the update-available banner for the current version (stored in localStorage)
+  window.ipamDismissUpdate = function(version) {
+    localStorage.setItem("ipam_dismissed_update", version);
+    var banner = document.getElementById("ipam-update-banner");
+    if (banner) banner.style.display = "none";
+  };
+
   document.addEventListener("DOMContentLoaded", function() {
     updateThemeButton();
+
+    // Hide update banner if the version was already dismissed
+    var banner = document.getElementById("ipam-update-banner");
+    if (banner) {
+      var dismissed = localStorage.getItem("ipam_dismissed_update");
+      var bannerVersion = banner.dataset.version;
+      if (dismissed && bannerVersion && dismissed === bannerVersion) {
+        banner.style.display = "none";
+      }
+    }
 
     // Dropdown toggle
     document.addEventListener("click", function(e) {

--- a/Simple-PHP-IPAM/config.php
+++ b/Simple-PHP-IPAM/config.php
@@ -35,11 +35,23 @@ return [
     'utilization_warn'     => 80,
     'utilization_critical' => 95,
 
-    // Update check: fetches the latest release tag from GitHub and shows a
-    // banner in the footer when a newer version is available.
+    // Update check: fetches releases from GitHub and shows a banner when a newer
+    // version is available. notify_prerelease: also alert for alpha/beta/RC builds.
     'update_check' => [
-        'enabled'     => true,
-        'ttl_seconds' => 21600, // cache result for 6 hours
+        'enabled'           => true,
+        'ttl_seconds'       => 86400, // cache result for 24 hours
+        'notify_prerelease' => false,
+    ],
+
+    // Automatic database backups. Backups are written to 'dir' (default:
+    // data/backups/) on page load when the interval has elapsed.
+    // frequency: 'daily' | 'weekly'
+    // retention: number of most-recent backups to keep (older ones are deleted).
+    'backup' => [
+        'enabled'   => false,
+        'frequency' => 'daily',  // 'daily' | 'weekly'
+        'retention' => 7,
+        'dir'       => '',       // empty = data/backups/ relative to this file
     ],
 
     // -----------------------------------------------------------------------

--- a/Simple-PHP-IPAM/db_tools.php
+++ b/Simple-PHP-IPAM/db_tools.php
@@ -1,0 +1,240 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+require_role('admin');
+
+$err = '';
+$msg = '';
+
+/* ------------------------------------------------------------------ *
+ * POST: export                                                         *
+ * ------------------------------------------------------------------ */
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'export') {
+    csrf_require();
+    audit($db, 'db.export', 'system', null, 'Manual database export initiated');
+
+    $sql = ipam_db_dump($db);
+
+    $filename = 'ipam-export-' . date('Y-m-d-His') . '.sql';
+    header('Content-Type: application/sql; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    header('Cache-Control: no-store');
+    echo $sql;
+    exit;
+}
+
+/* ------------------------------------------------------------------ *
+ * POST: import                                                         *
+ * ------------------------------------------------------------------ */
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'import') {
+    csrf_require();
+
+    $confirmed = !empty($_POST['confirmed']);
+    $upload    = $_FILES['sql_file'] ?? null;
+
+    if (!$confirmed) {
+        $err = 'You must check the confirmation box before importing.';
+    } elseif (!$upload || $upload['error'] !== UPLOAD_ERR_OK) {
+        $errCode = $upload['error'] ?? -1;
+        $err = match ((int)$errCode) {
+            UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => 'Uploaded file exceeds the allowed size limit.',
+            UPLOAD_ERR_NO_FILE                        => 'No file was uploaded.',
+            default                                   => "Upload error (code {$errCode}).",
+        };
+    } else {
+        $tmpPath  = (string)$upload['tmp_name'];
+        $fileSize = filesize($tmpPath);
+        $maxBytes = 50 * 1024 * 1024; // 50 MB hard cap
+
+        if ($fileSize === false || $fileSize > $maxBytes) {
+            $err = 'Import file must be under 50 MB.';
+        } else {
+            $sql = file_get_contents($tmpPath);
+            if ($sql === false || trim($sql) === '') {
+                $err = 'Uploaded file is empty or unreadable.';
+            } else {
+                // Basic sanity check: must look like a SQL dump
+                if (!str_contains($sql, 'BEGIN TRANSACTION') && !str_contains($sql, 'CREATE TABLE')) {
+                    $err = 'File does not appear to be a valid SQL dump (missing BEGIN TRANSACTION or CREATE TABLE).';
+                }
+            }
+        }
+
+        if (!$err) {
+            // Back up the current database before import
+            $dbPath = (string)($config['db_path'] ?? (__DIR__ . '/data/ipam.sqlite'));
+            $backupPath = $dbPath . '.pre-import-' . date('YmdHis') . '.bak';
+            try { $db->exec("PRAGMA wal_checkpoint(FULL)"); } catch (Throwable) {}
+            if (!@copy($dbPath, $backupPath)) {
+                $err = 'Could not create a pre-import backup of the database. Import aborted for safety.';
+            }
+        }
+
+        if (!$err) {
+            // Execute import inside a transaction; rollback on any error
+            try {
+                // Close current connection cleanly, re-open after replacing DB content
+                $db->exec("PRAGMA foreign_keys=OFF");
+                $db->beginTransaction();
+
+                // Drop all user tables (except sqlite_sequence which is auto-managed)
+                $tables = $db->query(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+                )->fetchAll(PDO::FETCH_COLUMN);
+
+                foreach ($tables as $tbl) {
+                    $db->exec('DROP TABLE IF EXISTS "' . addslashes((string)$tbl) . '"');
+                }
+
+                // Execute the dump SQL (split on statement boundaries)
+                // Strip comments and split on semicolons cautiously
+                $statements = preg_split('/;\s*\n/', $sql ?? '');
+                foreach ($statements as $stmt) {
+                    $stmt = trim($stmt);
+                    if ($stmt === '' || str_starts_with($stmt, '--')) continue;
+                    // Skip PRAGMA foreign_keys lines from the dump; we manage that ourselves
+                    if (preg_match('/^PRAGMA\s+foreign_keys\s*=/i', $stmt)) continue;
+                    $db->exec($stmt);
+                }
+
+                $db->exec("PRAGMA foreign_keys=ON");
+                $db->commit();
+
+                audit($db, 'db.import', 'system', null,
+                    'Database import completed; pre-import backup: ' . basename($backupPath));
+                $msg = 'Import successful. A pre-import backup was saved to: ' . e(basename($backupPath));
+            } catch (Throwable $ex) {
+                if ($db->inTransaction()) $db->rollBack();
+                $db->exec("PRAGMA foreign_keys=ON");
+                $err = 'Import failed: ' . e($ex->getMessage())
+                     . ' The database has been restored from the pre-import state.';
+                audit($db, 'db.import_failed', 'system', null,
+                    'Import rolled back: ' . $ex->getMessage());
+            }
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * GET: manual backup trigger                                           *
+ * ------------------------------------------------------------------ */
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'backup_now') {
+    csrf_require();
+    // Force a backup regardless of schedule
+    $dbPath = (string)($config['db_path'] ?? (__DIR__ . '/data/ipam.sqlite'));
+    $bdir   = backup_dir($config);
+    if (!is_dir($bdir)) @mkdir($bdir, 0700, true);
+
+    try { $db->exec("PRAGMA wal_checkpoint(FULL)"); } catch (Throwable) {}
+
+    $ts   = date('Y-m-d-His');
+    $dest = $bdir . '/ipam-' . $ts . '.sqlite';
+
+    if (@copy($dbPath, $dest)) {
+        @chmod($dest, 0600);
+        $retention = max(1, (int)($config['backup']['retention'] ?? 7));
+        $files = glob($bdir . '/ipam-*.sqlite');
+        if (is_array($files)) {
+            rsort($files);
+            foreach (array_slice($files, $retention) as $old) @unlink($old);
+        }
+        $state = ['last_backup' => time(), 'last_file' => basename($dest)];
+        @file_put_contents(__DIR__ . '/data/backup-state.json', json_encode($state));
+        audit($db, 'db.backup', 'system', null, 'Manual backup: ' . basename($dest));
+        $msg = 'Backup created: ' . e(basename($dest));
+    } else {
+        $err = 'Backup failed: could not write to ' . e($bdir);
+    }
+}
+
+/* ------------------------------------------------------------------ *
+ * Gather backup info for display                                       *
+ * ------------------------------------------------------------------ */
+$backupEnabled = !empty($config['backup']['enabled']);
+$bInfo         = backup_info($config);
+
+page_header('Database Tools');
+?>
+<h1>🗄 Database Tools</h1>
+
+<?php if ($err): ?>
+  <p class='danger'><?= $err ?></p>
+<?php endif; ?>
+<?php if ($msg): ?>
+  <p class='success'><?= $msg ?></p>
+<?php endif; ?>
+
+<div class='grid cols-2' style='margin-top:16px'>
+
+  <!-- Export -->
+  <div class='card'>
+    <h2>Export Database</h2>
+    <p class='muted'>Download a full SQL dump of the database. This file can be used to restore or migrate the IPAM instance.</p>
+    <form method='post'>
+      <input type='hidden' name='csrf' value='<?= e(csrf_token()) ?>'>
+      <input type='hidden' name='action' value='export'>
+      <button type='submit'>⬇ Download SQL Dump</button>
+    </form>
+  </div>
+
+  <!-- Import -->
+  <div class='card'>
+    <h2>Import Database</h2>
+    <p class='danger' style='font-weight:600'>⚠ This will <strong>replace</strong> all current data. A pre-import backup is created automatically.</p>
+    <form method='post' enctype='multipart/form-data'>
+      <input type='hidden' name='csrf' value='<?= e(csrf_token()) ?>'>
+      <input type='hidden' name='action' value='import'>
+      <div class='row' style='flex-direction:column;gap:10px'>
+        <label>SQL file (.sql)
+          <input type='file' name='sql_file' accept='.sql,text/plain' required>
+        </label>
+        <label style='flex-direction:row;align-items:center;gap:8px;cursor:pointer'>
+          <input type='checkbox' name='confirmed' value='1' required>
+          I understand this will overwrite all existing data
+        </label>
+        <div>
+          <button type='submit' class='button-danger'>⬆ Import &amp; Replace</button>
+        </div>
+      </div>
+    </form>
+  </div>
+
+</div>
+
+<!-- Backups -->
+<div class='card' style='margin-top:16px'>
+  <h2>Automatic Backups</h2>
+  <?php if (!$backupEnabled): ?>
+    <p class='muted'>Automatic backups are <strong>disabled</strong>. Enable them by setting <code>'backup' => ['enabled' => true, ...]</code> in config.php.</p>
+  <?php else: ?>
+    <p>
+      Frequency: <strong><?= e(ucfirst((string)($config['backup']['frequency'] ?? 'daily'))) ?></strong>
+      &nbsp;|&nbsp; Retention: <strong><?= e((string)($config['backup']['retention'] ?? 7)) ?> backups</strong>
+      &nbsp;|&nbsp; Directory: <code><?= e($bInfo['dir']) ?></code>
+    </p>
+  <?php endif; ?>
+
+  <table style='margin-top:10px'>
+    <tr><th>Stat</th><th>Value</th></tr>
+    <tr>
+      <td>Last backup</td>
+      <td><?= $bInfo['last_backup'] ? e(date('Y-m-d H:i:s', $bInfo['last_backup'])) : '<span class=\'muted\'>Never</span>' ?></td>
+    </tr>
+    <tr>
+      <td>Last backup file</td>
+      <td><?= $bInfo['last_file'] ? e((string)$bInfo['last_file']) : '<span class=\'muted\'>—</span>' ?></td>
+    </tr>
+    <tr>
+      <td>Backup count</td>
+      <td><?= (int)$bInfo['count'] ?></td>
+    </tr>
+  </table>
+
+  <form method='post' style='margin-top:14px'>
+    <input type='hidden' name='csrf' value='<?= e(csrf_token()) ?>'>
+    <input type='hidden' name='action' value='backup_now'>
+    <button type='submit' class='button-secondary'>💾 Run Backup Now</button>
+  </form>
+</div>
+
+<?php page_footer(); ?>

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -42,8 +42,21 @@ require __DIR__ . '/lib.php';
 $db = ipam_db((string)$config['db_path']);
 ipam_db_init($db);
 
+// Auto-populate any missing config keys with their defaults
+$_addedConfigKeys = ipam_config_sync(__DIR__ . '/config.php', $config);
+if ($_addedConfigKeys && isset($_SESSION) && ($_SESSION['role'] ?? '') === 'admin') {
+    $_SESSION['config_notice'] = 'New configuration keys were automatically added to config.php: '
+        . implode(', ', array_map(fn($k) => "'{$k}'", $_addedConfigKeys)) . '.';
+}
+unset($_addedConfigKeys);
+
 // Run best-effort housekeeping at most once/day (configurable)
 run_housekeeping_if_due($config);
+
+// Run database backup if due (configurable frequency)
+if (!empty($config['backup']['enabled'])) {
+    run_db_backup_if_due($db, $config);
+}
 
 if (empty($_SESSION['csrf'])) {
     $_SESSION['csrf'] = bin2hex(random_bytes(32));

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -273,6 +273,120 @@ function apply_migrations(PDO $db): array
     return $appliedNow;
 }
 
+/* ---------------- Config auto-population ---------------- */
+
+/**
+ * Returns the canonical defaults map for all config keys that should exist in
+ * config.php. Each entry: ['default' => mixed, 'comment' => string].
+ * Only top-level keys are tracked; nested sub-keys are managed per-key.
+ */
+function ipam_config_defaults(): array
+{
+    return [
+        'db_path' => [
+            'default' => null, // path-dependent, skip auto-append
+            'comment' => '',
+        ],
+        'session_name' => ['default' => null, 'comment' => ''],
+        'proxy_trust'  => ['default' => null, 'comment' => ''],
+        'bootstrap_admin' => ['default' => null, 'comment' => ''],
+        'session_idle_seconds' => ['default' => null, 'comment' => ''],
+        'login_max_attempts'   => ['default' => null, 'comment' => ''],
+        'login_lockout_seconds'=> ['default' => null, 'comment' => ''],
+        'import_csv_max_mb'    => ['default' => null, 'comment' => ''],
+        'tmp_cleanup_ttl_seconds' => ['default' => null, 'comment' => ''],
+        'housekeeping' => ['default' => null, 'comment' => ''],
+        'utilization_warn'     => ['default' => null, 'comment' => ''],
+        'utilization_critical' => ['default' => null, 'comment' => ''],
+        'update_check' => [
+            'default' => [
+                'enabled'           => true,
+                'ttl_seconds'       => 86400,
+                'notify_prerelease' => false,
+            ],
+            'comment' => 'Update check: fetches releases from GitHub and shows a banner when a newer version is available.',
+        ],
+        'backup' => [
+            'default' => [
+                'enabled'   => false,
+                'frequency' => 'daily',
+                'retention' => 7,
+                'dir'       => '',
+            ],
+            'comment' => "Automatic database backups. frequency: 'daily' | 'weekly'. retention: keep last N backups.",
+        ],
+        'oidc' => ['default' => null, 'comment' => ''],
+    ];
+}
+
+/**
+ * Format a PHP value as clean source code with array [] syntax.
+ */
+function ipam_php_export(mixed $val, int $indent = 1): string
+{
+    if (is_null($val))    return 'null';
+    if (is_bool($val))    return $val ? 'true' : 'false';
+    if (is_int($val))     return (string)$val;
+    if (is_float($val))   return rtrim(number_format($val, 10, '.', ''), '0') ?: '0.0';
+    if (is_string($val))  return "'" . addcslashes($val, "'\\") . "'";
+
+    if (is_array($val)) {
+        if (count($val) === 0) return '[]';
+        $pad = str_repeat('    ', $indent);
+        $outerPad = str_repeat('    ', $indent - 1);
+        $isList = array_keys($val) === range(0, count($val) - 1);
+        $out = "[\n";
+        foreach ($val as $k => $v) {
+            $keyStr = $isList ? '' : "'" . addcslashes((string)$k, "'\\") . "' => ";
+            $out .= $pad . $keyStr . ipam_php_export($v, $indent + 1) . ",\n";
+        }
+        $out .= $outerPad . ']';
+        return $out;
+    }
+
+    return var_export($val, true);
+}
+
+/**
+ * Check config.php for missing top-level keys and append them with defaults.
+ * Returns list of key names that were added (empty if nothing changed).
+ * Only keys whose default is not null are auto-appended.
+ */
+function ipam_config_sync(string $configPath, array $loaded): array
+{
+    $defaults = ipam_config_defaults();
+    $added = [];
+
+    foreach ($defaults as $key => $meta) {
+        if (array_key_exists($key, $loaded)) continue;
+        if ($meta['default'] === null) continue;
+
+        $content = @file_get_contents($configPath);
+        if ($content === false) break;
+
+        // Find the closing ]; of the return array
+        if (!preg_match('/\n\];\s*$/', $content)) break;
+
+        $comment = (string)$meta['comment'];
+        $valuePhp = ipam_php_export($meta['default'], 2);
+
+        $block = '';
+        if ($comment !== '') {
+            $block .= "\n    // " . $comment;
+        }
+        $block .= "\n    '" . addcslashes($key, "'\\") . "' => " . $valuePhp . ",\n";
+
+        $content = preg_replace('/\n\];\s*$/', $block . "\n];", $content);
+        if ($content === null) break;
+
+        if (@file_put_contents($configPath, $content) !== false) {
+            $added[] = $key;
+        }
+    }
+
+    return $added;
+}
+
 /* ---------------- Housekeeping ---------------- */
 
 function housekeeping_state_path(): string
@@ -333,6 +447,197 @@ function run_housekeeping_if_due(array $config): void
         @flock($lock, LOCK_UN);
         @fclose($lock);
     }
+}
+
+/* ---------------- Database Backups ---------------- */
+
+function backup_dir(array $config): string
+{
+    $d = trim((string)($config['backup']['dir'] ?? ''));
+    if ($d === '') {
+        return __DIR__ . '/data/backups';
+    }
+    // Make relative paths relative to the app directory
+    if (!str_starts_with($d, '/')) {
+        $d = __DIR__ . '/' . $d;
+    }
+    return rtrim($d, '/');
+}
+
+function backup_state_path(): string
+{
+    return __DIR__ . '/data/backup-state.json';
+}
+
+function backup_interval_seconds(array $config): int
+{
+    $freq = strtolower(trim((string)($config['backup']['frequency'] ?? 'daily')));
+    return match ($freq) {
+        'weekly' => 604800,
+        default  => 86400,  // 'daily'
+    };
+}
+
+function backup_is_due(array $config): bool
+{
+    $bk = $config['backup'] ?? [];
+    if (empty($bk['enabled'])) return false;
+
+    $path = backup_state_path();
+    if (!is_file($path)) return true;
+
+    $d = @json_decode((string)file_get_contents($path), true);
+    if (!is_array($d) || !isset($d['last_backup'])) return true;
+
+    return (time() - (int)$d['last_backup']) >= backup_interval_seconds($config);
+}
+
+/**
+ * Run a database backup if one is due. Uses WAL checkpoint + file copy for
+ * a consistent snapshot without requiring SQLite3 extension.
+ * Returns true if a backup was written, false otherwise.
+ */
+function run_db_backup_if_due(PDO $db, array $config): bool
+{
+    if (!backup_is_due($config)) return false;
+
+    $lockPath = __DIR__ . '/data/backup.lock';
+    $lock = @fopen($lockPath, 'c');
+    if (!$lock) return false;
+
+    if (!@flock($lock, LOCK_EX | LOCK_NB)) {
+        @fclose($lock);
+        return false;
+    }
+
+    $wrote = false;
+    try {
+        if (!backup_is_due($config)) return false;
+
+        $dbPath = (string)($GLOBALS['config']['db_path'] ?? (__DIR__ . '/data/ipam.sqlite'));
+        if (!is_file($dbPath)) return false;
+
+        $dir = backup_dir($config);
+        if (!is_dir($dir)) {
+            if (!@mkdir($dir, 0700, true)) return false;
+        }
+
+        // Flush WAL to the main database file for a consistent copy
+        try { $db->exec("PRAGMA wal_checkpoint(FULL)"); } catch (Throwable) {}
+
+        $ts   = date('Y-m-d-His');
+        $dest = $dir . '/ipam-' . $ts . '.sqlite';
+
+        if (@copy($dbPath, $dest)) {
+            @chmod($dest, 0600);
+            $wrote = true;
+
+            // Prune old backups according to retention policy
+            $retention = max(1, (int)($config['backup']['retention'] ?? 7));
+            $files = glob($dir . '/ipam-*.sqlite');
+            if (is_array($files)) {
+                rsort($files); // newest first (lexicographic = chronological for our format)
+                foreach (array_slice($files, $retention) as $old) {
+                    @unlink($old);
+                }
+            }
+
+            // Record backup timestamp
+            $state = ['last_backup' => time(), 'last_file' => basename($dest)];
+            @file_put_contents(backup_state_path(), json_encode($state));
+            @chmod(backup_state_path(), 0600);
+        }
+    } finally {
+        @flock($lock, LOCK_UN);
+        @fclose($lock);
+    }
+
+    return $wrote;
+}
+
+/**
+ * Return info about the current backup state for display in the admin panel.
+ * ['last_backup' => timestamp|null, 'last_file' => string|null, 'count' => int, 'dir' => string]
+ */
+function backup_info(array $config): array
+{
+    $dir   = backup_dir($config);
+    $state = backup_state_path();
+    $last  = null;
+    $file  = null;
+
+    if (is_file($state)) {
+        $d = @json_decode((string)file_get_contents($state), true);
+        if (is_array($d)) {
+            $last = isset($d['last_backup']) ? (int)$d['last_backup'] : null;
+            $file = isset($d['last_file'])   ? (string)$d['last_file'] : null;
+        }
+    }
+
+    $files = is_dir($dir) ? (glob($dir . '/ipam-*.sqlite') ?: []) : [];
+
+    return [
+        'last_backup' => $last,
+        'last_file'   => $file,
+        'count'       => count($files),
+        'dir'         => $dir,
+    ];
+}
+
+/**
+ * Generate a full SQL dump of the SQLite database suitable for import.
+ */
+function ipam_db_dump(PDO $db): string
+{
+    $out = "-- Simple PHP IPAM database dump\n";
+    $out .= "-- Generated: " . date('Y-m-d H:i:s') . "\n\n";
+    $out .= "PRAGMA foreign_keys=OFF;\n";
+    $out .= "BEGIN TRANSACTION;\n\n";
+
+    // Tables: schema + data
+    $tables = $db->query(
+        "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )->fetchAll();
+
+    foreach ($tables as $t) {
+        $name = (string)$t['name'];
+        $out .= "-- Table: {$name}\n";
+        $out .= $t['sql'] . ";\n";
+
+        $rows = $db->query("SELECT * FROM " . '"' . addslashes($name) . '"')->fetchAll();
+        foreach ($rows as $row) {
+            $cols = array_map(fn($c) => '"' . addslashes($c) . '"', array_keys($row));
+            $vals = array_map(function($v) {
+                if ($v === null) return 'NULL';
+                if (is_int($v) || is_float($v)) return (string)$v;
+                // Detect binary blobs (ip_bin, network_bin)
+                if (!mb_check_encoding((string)$v, 'UTF-8')) {
+                    return "X'" . bin2hex((string)$v) . "'";
+                }
+                return "'" . str_replace("'", "''", (string)$v) . "'";
+            }, array_values($row));
+            $out .= "INSERT INTO \"{$name}\" (" . implode(',', $cols) . ") VALUES ("
+                  . implode(',', $vals) . ");\n";
+        }
+        $out .= "\n";
+    }
+
+    // Indices (non-system)
+    $indices = $db->query(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )->fetchAll();
+    if ($indices) {
+        $out .= "-- Indexes\n";
+        foreach ($indices as $idx) {
+            $out .= $idx['sql'] . ";\n";
+        }
+        $out .= "\n";
+    }
+
+    $out .= "COMMIT;\n";
+    $out .= "PRAGMA foreign_keys=ON;\n";
+
+    return $out;
 }
 
 /* ---------------- Pagination ---------------- */
@@ -793,8 +1098,8 @@ function page_header(string $title): void
 
     echo "<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'>";
     echo "<title>" . e($title) . "</title>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=0.14'>";
-    echo "<script defer src='assets/app.js?v=0.14'></script>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=0.15'>";
+    echo "<script defer src='assets/app.js?v=0.15'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";
@@ -814,6 +1119,7 @@ function page_header(string $title): void
             echo "<a class='nav-dropdown-item' href='dhcp_pool.php'>🔒 DHCP Pools</a>";
             echo "<a class='nav-dropdown-item' href='api_keys.php'>🔑 API Keys</a>";
             echo "<a class='nav-dropdown-item' href='import_csv.php'>⬆ Import CSV</a>";
+            echo "<a class='nav-dropdown-item' href='db_tools.php'>🗄 Database Tools</a>";
             echo "</div></div>";
         }
     } else {
@@ -838,6 +1144,31 @@ function page_header(string $title): void
 
     echo "</div></div>";
     echo "<div class='page'>";
+
+    // Config auto-population notice (shown once per session, admin only)
+    if (!empty($_SESSION['config_notice']) && ($role ?? '') === 'admin') {
+        $notice = e((string)$_SESSION['config_notice']);
+        echo "<div class='admin-notice admin-notice--info' role='alert'>"
+           . "⚙ Config updated: {$notice} Review and adjust values in config.php."
+           . "</div>";
+        unset($_SESSION['config_notice']);
+    }
+
+    // Update-available dismissible banner (admin only, client-side dismiss via localStorage)
+    if (($role ?? '') === 'admin') {
+        global $config;
+        $update = ipam_update_check($config ?? []);
+        if ($update) {
+            $uv  = e((string)$update['version']);
+            $url = e((string)$update['url']);
+            echo "<div class='admin-notice admin-notice--update' id='ipam-update-banner' data-version='{$uv}' role='alert'>"
+               . "🚀 Simple PHP IPAM v{$uv} is available. "
+               . "<a href='{$url}' target='_blank' rel='noopener'>View release</a>"
+               . " &nbsp;<button type='button' class='button-secondary' style='padding:4px 10px;font-size:.85em' "
+               . "onclick='ipamDismissUpdate(\"{$uv}\")'>Dismiss</button>"
+               . "</div>";
+        }
+    }
 }
 
 function page_footer(): void
@@ -871,7 +1202,8 @@ function ipam_update_check(array $config): ?array
     $uc = $config['update_check'] ?? [];
     if (isset($uc['enabled']) && !(bool)$uc['enabled']) return null;
 
-    $ttl = max(3600, (int)($uc['ttl_seconds'] ?? 21600));
+    $ttl             = max(3600, (int)($uc['ttl_seconds'] ?? 86400));
+    $notifyPrerelease = !empty($uc['notify_prerelease']);
 
     ensure_tmp_dir();
     $cache = tmp_dir() . '/update-check.json';
@@ -887,7 +1219,9 @@ function ipam_update_check(array $config): ?array
     $result = null;
 
     try {
-        $url = 'https://api.github.com/repos/seanmousseau/Simple-PHP-IPAM/releases/latest';
+        // Fetch list of releases (up to 10) so we can honour notify_prerelease.
+        // /releases/latest skips pre-releases entirely, so we use /releases instead.
+        $url = 'https://api.github.com/repos/seanmousseau/Simple-PHP-IPAM/releases?per_page=10';
         $ctx = stream_context_create(['http' => [
             'timeout' => 5,
             'ignore_errors' => true,
@@ -896,11 +1230,23 @@ function ipam_update_check(array $config): ?array
         ]]);
         $raw = @file_get_contents($url, false, $ctx);
         if ($raw !== false && $raw !== '') {
-            $data = json_decode($raw, true);
-            if (is_array($data) && !empty($data['tag_name']) && empty($data['draft']) && empty($data['prerelease'])) {
-                $latest = ltrim((string)$data['tag_name'], 'v');
-                if (version_compare($latest, IPAM_VERSION, '>')) {
-                    $result = ['version' => $latest, 'url' => (string)($data['html_url'] ?? '')];
+            $releases = json_decode($raw, true);
+            if (is_array($releases)) {
+                foreach ($releases as $rel) {
+                    if (!is_array($rel)) continue;
+                    if (!empty($rel['draft'])) continue;
+                    if (!empty($rel['prerelease']) && !$notifyPrerelease) continue;
+                    if (empty($rel['tag_name'])) continue;
+
+                    $latest = ltrim((string)$rel['tag_name'], 'v');
+                    if (version_compare($latest, IPAM_VERSION, '>')) {
+                        $result = [
+                            'version'    => $latest,
+                            'url'        => (string)($rel['html_url'] ?? ''),
+                            'prerelease' => !empty($rel['prerelease']),
+                        ];
+                    }
+                    break; // releases are newest-first; first match wins
                 }
             }
         }

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -1,4 +1,4 @@
 <?php
 declare(strict_types=1);
 
-const IPAM_VERSION = '0.14';
+const IPAM_VERSION = '0.15';

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,8 @@ All application settings live in `config.php` in the application root. This file
 - [Full example](#full-example)
 - [Settings reference](#settings-reference)
 - [OIDC settings](#oidc-settings)
+- [`update_check`](#update_check)
+- [`backup`](#backup)
 - [Behind a reverse proxy](#behind-a-reverse-proxy)
 
 ---
@@ -58,10 +60,21 @@ return [
     'utilization_warn'     => 80,
     'utilization_critical' => 95,
 
-    // Update check: shows a footer badge when a newer GitHub release is available.
+    // Update check: fetches GitHub releases and shows a banner/badge when a
+    // newer version is available. notify_prerelease includes alpha/beta/RC builds.
     'update_check' => [
-        'enabled'     => true,
-        'ttl_seconds' => 21600,
+        'enabled'           => true,
+        'ttl_seconds'       => 86400,  // cache 24 hours
+        'notify_prerelease' => false,
+    ],
+
+    // Automatic database backups (opt-in). Backups run on page load when the
+    // interval elapses. Older files beyond retention count are pruned.
+    'backup' => [
+        'enabled'   => false,
+        'frequency' => 'daily',   // 'daily' | 'weekly'
+        'retention' => 7,
+        'dir'       => '',        // empty = data/backups/
     ],
 
     // OIDC single sign-on — see docs/oidc.md for full setup guide.
@@ -210,14 +223,34 @@ Percentage thresholds for the IPv4 subnet utilization progress bars in the subne
 
 ## `update_check`
 
-Controls the automatic update check shown in the page footer.
+Controls the automatic update check shown in the page footer and admin banner.
 
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enabled` | `true` | Set to `false` to disable the update check entirely |
-| `ttl_seconds` | `21600` | How long to cache the result (default: 6 hours; minimum: 3600) |
+| `ttl_seconds` | `86400` | How long to cache the result (default: 24 hours; minimum: 3600) |
+| `notify_prerelease` | `false` | Set to `true` to also alert for alpha/beta/RC releases |
 
-The check fetches the GitHub releases API once per TTL period and caches the result in `data/tmp/update-check.json`. Network failures are silently ignored. Drafts and pre-releases are not shown.
+The check fetches the GitHub releases API once per TTL period, caches the result in `data/tmp/update-check.json`, and shows:
+- A badge in the page footer for all logged-in users
+- A dismissible banner at the top of each page for admins
+
+Network failures are silently ignored. Drafts are never shown.
+
+---
+
+## `backup`
+
+Controls automatic database backups.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Set to `true` to enable automatic backups |
+| `frequency` | `'daily'` | Backup interval: `'daily'` (24 h) or `'weekly'` (7 days) |
+| `retention` | `7` | Number of most-recent backup files to keep; older ones are deleted |
+| `dir` | `''` | Directory for backup files; empty string uses `data/backups/` |
+
+Backups run at most once per interval on normal page load (file-locked, non-blocking). The backup format is a WAL-checkpointed SQLite file copy with a timestamp filename (`ipam-YYYY-MM-DD-HHmmss.sqlite`). You can also trigger a manual backup from the **Database Tools** admin page.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Config auto-population**: Missing `config.php` keys are automatically appended with defaults on boot; admin sees a one-time notice listing added keys
- **Automatic backups**: New `backup` config block (enabled, frequency daily/weekly, retention, dir); WAL-checkpoint SQLite snapshots with retention pruning; opt-in via `config.php`
- **Database Tools** (`db_tools.php`): SQL export, SQL import (pre-import backup + transaction rollback, requires confirmation), manual backup trigger, backup status panel — all audit-logged
- **Mobile-optimized GUI**: Responsive CSS at 768px and 480px; grids, tables, forms, toolbars stack on narrow viewports; new `.table-scroll` utility class
- **Update checker enhancements**: Pre-release opt-in (`notify_prerelease`), dismissible admin banner per-version via localStorage, cache extended to 24h

## Test plan

- [ ] Fresh install: verify `backup` and `update_check.notify_prerelease` keys present in config.php
- [ ] Upgrade install: verify missing keys are auto-appended; admin notice appears on next page load
- [ ] Enable backups, load any page — confirm `.sqlite` file created in `data/backups/`
- [ ] Database Tools → Export: download SQL dump, verify schema + data present
- [ ] Database Tools → Import: import the exported dump, confirm data integrity
- [ ] Database Tools → Run Backup Now: confirm file created, status panel updates
- [ ] View at 375px: nav, tables, forms display without horizontal scroll
- [ ] View at 768px: layout stacks gracefully
- [ ] With a newer GitHub release: confirm dismissible update banner appears for admins
- [ ] Set `notify_prerelease: true`: confirm pre-release versions surface the banner
- [ ] Dismiss banner, reload: stays hidden for same version; reappears for next release

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3