### PR TITLE
fix(db_tools): skip BEGIN/COMMIT from dump during import

### DIFF
--- a/Simple-PHP-IPAM/db_tools.php
+++ b/Simple-PHP-IPAM/db_tools.php
@@ -92,8 +92,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'impor
                 foreach ($statements as $stmt) {
                     $stmt = trim($stmt);
                     if ($stmt === '' || str_starts_with($stmt, '--')) continue;
-                    // Skip PRAGMA foreign_keys lines from the dump; we manage that ourselves
+                    // Skip transaction/pragma statements we manage ourselves
                     if (preg_match('/^PRAGMA\s+foreign_keys\s*=/i', $stmt)) continue;
+                    if (preg_match('/^BEGIN(\s+TRANSACTION)?\s*$/i', $stmt)) continue;
+                    if (preg_match('/^COMMIT\s*$/i', $stmt)) continue;
                     $db->exec($stmt);
                 }
 


### PR DESCRIPTION
## Summary

- The SQL dump generated by the export includes `BEGIN TRANSACTION` and `COMMIT` statements
- The import code wraps execution in its own `beginTransaction()`, causing SQLite to throw *"cannot start a transaction within a transaction"*
- Fix: skip `BEGIN TRANSACTION` and `COMMIT` statements from the dump during import execution — the import's own transaction handles atomicity and rollback

## Test plan

- [ ] Export the database via Database Tools → Export
- [ ] Import the exported dump via Database Tools → Import — confirm it completes without the transaction error
- [ ] Verify data integrity after a round-trip export → import

https://claude.ai/code/session_01VT45yuabk5Syj6V48RutJ3