### PR TITLE
feat(v2.1.0): VRF support, Contacts, ⌘K overlay, inline edit, subnet map, column visibility, dashboard widgets

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -97,6 +97,28 @@ reviews:
         - Audit every create/update/delete with vlan.create / vlan.update / vlan.delete.
         - subnets.vlan_fk is the FK; subnets.vlan_id is the legacy integer — display both correctly.
 
+    - path: "Simple-PHP-IPAM/vrfs.php"
+      instructions: |
+        vrfs.php is the VRF (Virtual Routing and Forwarding) admin CRUD page. Key invariants:
+        - Requires admin role — call require_role('admin') at top.
+        - VRF name must be unique (UNIQUE constraint on vrfs.name).
+        - Cannot delete a VRF that has subnets assigned (check subnets.vrf_id reference).
+        - Audit every create/update/delete with vrf.create / vrf.update / vrf.delete.
+        - rd (Route Distinguisher) is free-form text, no format validation required.
+        - subnets.vrf_id = NULL means the global/default VRF (not "no VRF").
+        - UNIQUE(cidr, vrf_id) in subnets uses IS NULL comparison for NULL-safe check.
+
+    - path: "Simple-PHP-IPAM/contacts.php"
+      instructions: |
+        contacts.php is the Contacts admin CRUD page. Key invariants:
+        - Requires admin role — call require_role('admin') at top.
+        - Contact name is required; email, phone, org, note are optional free-text.
+        - Contacts are linked to addresses via addresses.owner_contact_id (nullable FK).
+        - Deleting a contact sets addresses.owner_contact_id = NULL (ON DELETE SET NULL).
+        - Audit every create/update/delete with contact.create / contact.update / contact.delete.
+        - The owner field in addresses remains free-text for backwards compatibility;
+          owner_contact_id is an optional overlay, not a replacement.
+
     - path: "Simple-PHP-IPAM/tags.php"
       instructions: |
         tags.php is the tag admin CRUD page. Key invariants:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
+## [2.1.0] - 2026-04-12
+
+### Added
+- **#271** — VRF (Virtual Routing and Forwarding) support: new `vrfs` admin page (CRUD with name, description, route-distinguisher fields), `vrfs` DB table, `subnets.vrf_id` FK. Overlap detection is now VRF-scoped (same CIDR allowed in different VRFs). Subnet create/edit form includes a VRF picker; subnet list shows VRF badge. API: `?resource=vrfs` endpoint (GET/POST/PUT/DELETE); subnet response includes `vrf_id`/`vrf_name`; `?vrf_id=` filter on subnets.
+- **#272** — Contacts as first-class objects: new `contacts` admin page (CRUD with name, email, phone, org, note fields), `contacts` DB table, `addresses.owner_contact_id` FK. Address create/edit form includes a contact typeahead (debounced, session-auth). Address list shows linked contact name with mailto link. Free-text `owner` field retained for legacy rows. API: `?resource=contacts` endpoint (GET/POST/PUT/DELETE, `?q=` fuzzy search usable from browser session); address response includes `owner_contact_id`/`owner_contact_name`; `?contact_id=` filter on addresses.
+- **#253** — Global ⌘K / Ctrl+K search overlay: keydown listener opens a modal overlay; debounced 300ms fetch to `search.php?format=json`; ↑↓ keyboard navigation, Enter navigates, Escape/backdrop closes. New `format=json` branch on `search.php` returns up to 20 address results as JSON. ⌘K shortcut button added to nav bar.
+- **#254** — Inline cell editing on address rows: clicking hostname, owner, note, or group cells on the address list opens an in-place `<input>`; Enter saves, Escape reverts, Tab moves to next editable cell. New `action=update_cell` JSON handler on `addresses.php` (write role only; CSRF protected; whitelisted fields; history logged).
+- **#255** — Subnet visual hierarchy map view: "List / Map" toggle buttons on `subnets.php`. Map view renders a server-side indented tree with CIDR, description, and utilization bar per node. Toggle state persisted to `localStorage`. Graceful cap at 200 nodes.
+- **#256** — Per-user column visibility preferences: gear dropdown on the addresses table lets users show/hide columns; state persisted to `localStorage` per table. At least one column always remains visible.
+- **#257** — Dashboard pinnable widgets and site filter: ✕ button on each dashboard card hides the widget (persisted to `localStorage`). "Addresses by Site" panel has a live site-filter dropdown (saved to `localStorage`). "↺ Reset widgets" link in page-actions clears all `ipam_*` localStorage keys.
+
+---
+
 ## [2.0.0] - 2026-04-11
 
 ### Added
@@ -419,6 +432,7 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[2.1.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v1.19.1...v2.0.0
 [1.19.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v1.19.0...v1.19.1
 [1.19.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v1.18.0...v1.19.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,8 @@ Dev tooling at the repo root (not deployed): `composer.json`, `composer.lock`, `
 | `import_csv.php` | yes | admin | CSV import wizard |
 | `sites.php` | yes | admin | Site management (supports parent site / region hierarchy) |
 | `vlans.php` | yes | admin | VLAN management (first-class VLAN objects, linked to subnets via `vlan_fk`) |
+| `vrfs.php` | yes | admin | VRF management (Virtual Routing and Forwarding; admin CRUD) |
+| `contacts.php` | yes | admin | Contact management (first-class contact records linked to addresses via `owner_contact_id`) |
 | `tags.php` | yes | admin | Tag management (colour-coded tags attached to subnets and addresses) |
 | `users.php` | yes | admin | User management |
 | `api_keys.php` | yes | admin | REST API key management |
@@ -90,8 +92,10 @@ Every web page starts with `require __DIR__ . '/init.php'`, which:
 | Table | Key columns |
 |-------|------------|
 | `users` | `id`, `username`, `password_hash`, `role` (admin\|readonly), `is_active`, `oidc_sub`, `name`, `email`, `last_login_at`, `password_changed_at`, `theme` (auto\|light\|dark), `created_at`, `updated_at` |
-| `subnets` | `id`, `cidr`, `ip_version`, `network`, `network_bin` (BLOB), `prefix`, `description`, `site_id`, `vlan_id` (legacy int 1–4094, nullable), `vlan_fk` (FK → `vlans.id`, nullable), `created_at`, `updated_at` |
-| `addresses` | `id`, `subnet_id`, `ip`, `ip_bin` (BLOB), `hostname`, `owner`, `note`, `grp`, `status` (used\|reserved\|free), `mac` (free-form, default ''), `expires_at` (YYYY-MM-DD, nullable), `created_at`, `updated_at` |
+| `vrfs` | `id`, `name` (UNIQUE), `description`, `rd` (Route Distinguisher, free-form), `created_at`, `updated_at` |
+| `subnets` | `id`, `cidr`, `ip_version`, `network`, `network_bin` (BLOB), `prefix`, `description`, `site_id`, `vlan_id` (legacy int 1–4094, nullable), `vlan_fk` (FK → `vlans.id`, nullable), `vrf_id` (FK → `vrfs.id`, nullable), `created_at`, `updated_at` — UNIQUE(cidr, vrf_id) |
+| `contacts` | `id`, `name`, `email`, `phone`, `org`, `note`, `created_at`, `updated_at` |
+| `addresses` | `id`, `subnet_id`, `ip`, `ip_bin` (BLOB), `hostname`, `owner`, `owner_contact_id` (FK → `contacts.id`, nullable), `note`, `grp`, `status` (used\|reserved\|free), `mac` (free-form, default ''), `expires_at` (YYYY-MM-DD, nullable), `created_at`, `updated_at` |
 | `audit_log` | `id`, `action`, `entity_type`, `entity_id`, `user_id`, `username`, `ip`, `user_agent`, `details`, `created_at` |
 | `sites` | `id`, `name`, `description`, `parent_id` (FK → `sites.id`, nullable, added v2.0.0), `created_at` |
 | `vlans` | `id`, `vlan_id` (1–4094), `name`, `description`, `site_id` (FK → `sites.id`, nullable), `created_at`, `updated_at` — UNIQUE(vlan_id, site_id) |
@@ -206,7 +210,7 @@ Asset cache-buster: update `?v=X.Y.Z` in the `<link>` and `<script>` tags in `pa
 ### Nav structure
 - Left: nav-links (Dashboard, Subnets, Addresses, Search, Audit, ⚙ Admin dropdown)
 - Right: user dropdown (username + role badge → Theme, Password, Logout)
-- Admin dropdown items: Sites, VLANs, Tags, Users, DHCP Pools, API Keys, Import CSV, Database Tools
+- Admin dropdown items: Sites, VLANs, VRFs, Tags, Contacts, Users, DHCP Pools, API Keys, Import CSV, Database Tools
 
 ---
 
@@ -224,6 +228,8 @@ user.set_role       user.reset_password     user.update_profile
 user.oidc_link      user.oidc_unlink
 site.create         site.update             site.delete
 vlan.create         vlan.update             vlan.delete
+vrf.create          vrf.update              vrf.delete
+contact.create      contact.update          contact.delete
 tag.create          tag.update              tag.delete
 apikey.create       apikey.deactivate       apikey.activate      apikey.delete
 dhcp_pool.reserve   dhcp_pool.clear

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,9 @@ Before building a release bundle, **always** complete these steps in order:
    vendor/bin/phpunit
    semgrep --config=.semgrep/rules.yml Simple-PHP-IPAM/
    bash testing/scripts/test_api.sh https://dev-direct.seanmousseau.com:8343/claude/ipam
-   bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; python3 testing/scripts/cdp_test.py'
+   bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; \
+     IPAM_BASE_URL=https://dev-direct.seanmousseau.com:8343/claude/ipam \
+     npx --prefix testing/playwright playwright test --config=testing/playwright/playwright.config.ts'
    ```
 7. Run CodeRabbit review and address any Critical findings:
    ```bash

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ No Composer, no npm, no external dependencies — just PHP and a web server.
 
 ---
 
+## What's new in v2.1.0
+
+- **VRF support** — virtual routing tables with VRF-scoped overlap detection; same CIDR allowed in different VRFs; admin CRUD page + API
+- **Contacts** — first-class contact records (name, email, phone, org, note) linked to address owner fields via typeahead; API CRUD + fuzzy search
+- **⌘K / Ctrl+K search overlay** — instant global search from any page with keyboard navigation
+- **Inline cell editing** — click hostname, owner, note, or group on the address list to edit in-place; Enter saves, Escape reverts
+- **Subnet map view** — visual indented hierarchy map on subnets page with List / Map toggle (persisted to localStorage)
+- **Column visibility** — gear dropdown to show/hide address table columns; preference persisted per browser
+- **Dashboard widgets** — hide/show stat cards; site filter on "Addresses by Site" panel; one-click reset
+
+See [CHANGELOG.md](CHANGELOG.md) for full details.
+
 ## What's new in v2.0.0
 
 - **VLANs** — first-class VLAN objects with admin CRUD, subnet assignment picker, and list badge

--- a/Simple-PHP-IPAM/addresses.php
+++ b/Simple-PHP-IPAM/addresses.php
@@ -200,7 +200,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             audit($db, 'address.update', 'address', $id, "status=$newStatus via inline toggle");
         }
         header('Content-Type: application/json');
-        echo '{"ok":true,"status":"' . $newStatus . '"}';
+        echo json_encode(['ok' => true, 'status' => $newStatus]); // nosemgrep: php.lang.security.xss
         exit;
     } elseif ($action === 'update_cell') {
         // Inline cell edit — JSON response; CSRF already verified above
@@ -225,9 +225,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
         // Static SQL per field — no interpolation of user-controlled data
+        // Editing 'owner' free-text clears the structured contact link to keep them in sync.
         $updateSql = match ($field) {
             'hostname' => "UPDATE addresses SET hostname=:v, updated_at=datetime('now') WHERE id=:id",
-            'owner'    => "UPDATE addresses SET owner=:v, updated_at=datetime('now') WHERE id=:id",
+            'owner'    => "UPDATE addresses SET owner=:v, owner_contact_id=NULL, updated_at=datetime('now') WHERE id=:id",
             'note'     => "UPDATE addresses SET note=:v, updated_at=datetime('now') WHERE id=:id",
             'grp'      => "UPDATE addresses SET grp=:v, updated_at=datetime('now') WHERE id=:id",
         };

--- a/Simple-PHP-IPAM/addresses.php
+++ b/Simple-PHP-IPAM/addresses.php
@@ -49,6 +49,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $grp             = substr(trim(to_str($_POST['grp']            ?? '')), 0, 100);
         $mac             = substr(trim(to_str($_POST['mac']            ?? '')), 0, 64);
         $ownerContactId  = to_int($_POST['owner_contact_id'] ?? 0) ?: null;
+        if ($ownerContactId !== null) {
+            $cck = $db->prepare("SELECT id FROM contacts WHERE id = :id");
+            $cck->execute([':id' => $ownerContactId]);
+            if (!$cck->fetch()) $ownerContactId = null;
+        }
         $expiresAt = trim(to_str($_POST['expires_at'] ?? ''));
         if ($expiresAt !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresAt)) {
             $expiresAt = '';
@@ -124,6 +129,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $grp            = substr(trim(to_str($_POST['grp']           ?? '')), 0, 100);
         $mac            = substr(trim(to_str($_POST['mac']           ?? '')), 0, 64);
         $ownerContactId = to_int($_POST['owner_contact_id'] ?? 0) ?: null;
+        if ($ownerContactId !== null) {
+            $cck = $db->prepare("SELECT id FROM contacts WHERE id = :id");
+            $cck->execute([':id' => $ownerContactId]);
+            if (!$cck->fetch()) $ownerContactId = null;
+        }
         $expiresAt = trim(to_str($_POST['expires_at'] ?? ''));
         if ($expiresAt !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresAt)) {
             $expiresAt = '';
@@ -476,9 +486,11 @@ page_header('Addresses');
         $isWrite = (current_user()['role'] !== 'readonly');
         foreach ($addresses as $a):
           $isHighlighted = $highlightId > 0 && to_int($a['id']) === $highlightId;
+          $isExpired = isset($a['expires_at']) && to_str($a['expires_at']) < date('Y-m-d');
           $aid = to_int($a['id']);
+          $rowClasses = array_filter([$isHighlighted ? 'highlight-row' : '', $isExpired ? 'expired-row' : '']);
       ?>
-        <tr id="addr-<?= $aid ?>"<?= $isHighlighted ? ' class="highlight-row"' : '' ?>>
+        <tr id="addr-<?= $aid ?>"<?= $rowClasses ? ' class="' . e(implode(' ', $rowClasses)) . '"' : '' ?>>
           <td><?= e(to_str($a['ip'])) ?></td>
           <td<?= $isWrite ? ' data-editable="hostname" data-addr-id="' . $aid . '"' : '' ?>><?= e(to_str($a['hostname'])) ?></td>
           <td<?= $isWrite ? ' data-editable="owner" data-addr-id="' . $aid . '"' : '' ?>><?php

--- a/Simple-PHP-IPAM/addresses.php
+++ b/Simple-PHP-IPAM/addresses.php
@@ -43,11 +43,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $subnetId = to_int($_POST['subnet_id'] ?? 0);
         $ipInput = trim(to_str($_POST['ip'] ?? ''));
 
-        $hostname  = substr(trim(to_str($_POST['hostname']   ?? '')), 0, 253);
-        $owner     = substr(trim(to_str($_POST['owner']     ?? '')), 0, 255);
-        $note      = substr(trim(to_str($_POST['note']      ?? '')), 0, 1000);
-        $grp       = substr(trim(to_str($_POST['grp']       ?? '')), 0, 100);
-        $mac       = substr(trim(to_str($_POST['mac']       ?? '')), 0, 64);
+        $hostname        = substr(trim(to_str($_POST['hostname']        ?? '')), 0, 253);
+        $owner           = substr(trim(to_str($_POST['owner']          ?? '')), 0, 255);
+        $note            = substr(trim(to_str($_POST['note']           ?? '')), 0, 1000);
+        $grp             = substr(trim(to_str($_POST['grp']            ?? '')), 0, 100);
+        $mac             = substr(trim(to_str($_POST['mac']            ?? '')), 0, 64);
+        $ownerContactId  = to_int($_POST['owner_contact_id'] ?? 0) ?: null;
         $expiresAt = trim(to_str($_POST['expires_at'] ?? ''));
         if ($expiresAt !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresAt)) {
             $expiresAt = '';
@@ -73,8 +74,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $err = 'Invalid status.';
             } else {
                 try {
-                    $ins = $db->prepare("INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, note, grp, mac, expires_at, status)
-                                         VALUES (:sid,:ip,:bin,:hn,:ow,:nt,:grp,:mac,:exp,:st)");
+                    $ins = $db->prepare("INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, note, grp, mac, expires_at, status, owner_contact_id)
+                                         VALUES (:sid,:ip,:bin,:hn,:ow,:nt,:grp,:mac,:exp,:st,:cid)");
                     $ins->execute([
                         ':sid' => $subnetId,
                         ':ip'  => $norm['ip'],
@@ -86,17 +87,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         ':mac' => $mac,
                         ':exp' => $expiresAt !== '' ? $expiresAt : null,
                         ':st'  => $status,
+                        ':cid' => $ownerContactId,
                     ]);
                     $aid = (int)$db->lastInsertId();
 
                     history_log_address($db, 'create', $subnetId, $norm['ip'], $aid, null, [
-                        'hostname'   => $hostname,
-                        'owner'      => $owner,
-                        'note'       => $note,
-                        'grp'        => $grp,
-                        'mac'        => $mac,
-                        'expires_at' => $expiresAt !== '' ? $expiresAt : null,
-                        'status'     => $status,
+                        'hostname'        => $hostname,
+                        'owner'           => $owner,
+                        'note'            => $note,
+                        'grp'             => $grp,
+                        'mac'             => $mac,
+                        'expires_at'      => $expiresAt !== '' ? $expiresAt : null,
+                        'status'          => $status,
+                        'owner_contact_id' => $ownerContactId,
                     ]);
                     audit($db, 'address.create', 'address', $aid, "ip={$norm['ip']} subnet_id=$subnetId");
 
@@ -115,11 +118,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         $id = to_int($_POST['id'] ?? 0);
         $subnetId = to_int($_POST['subnet_id'] ?? 0);
-        $hostname  = substr(trim(to_str($_POST['hostname']   ?? '')), 0, 253);
-        $owner     = substr(trim(to_str($_POST['owner']     ?? '')), 0, 255);
-        $note      = substr(trim(to_str($_POST['note']      ?? '')), 0, 1000);
-        $grp       = substr(trim(to_str($_POST['grp']       ?? '')), 0, 100);
-        $mac       = substr(trim(to_str($_POST['mac']       ?? '')), 0, 64);
+        $hostname       = substr(trim(to_str($_POST['hostname']       ?? '')), 0, 253);
+        $owner          = substr(trim(to_str($_POST['owner']         ?? '')), 0, 255);
+        $note           = substr(trim(to_str($_POST['note']          ?? '')), 0, 1000);
+        $grp            = substr(trim(to_str($_POST['grp']           ?? '')), 0, 100);
+        $mac            = substr(trim(to_str($_POST['mac']           ?? '')), 0, 64);
+        $ownerContactId = to_int($_POST['owner_contact_id'] ?? 0) ?: null;
         $expiresAt = trim(to_str($_POST['expires_at'] ?? ''));
         if ($expiresAt !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresAt)) {
             $expiresAt = '';
@@ -129,7 +133,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (!in_array($status, ['used','reserved','free'], true)) {
             $err = 'Invalid status.';
         } else {
-            $sel = $db->prepare("SELECT id, ip, hostname, owner, note, grp, mac, expires_at, status FROM addresses WHERE id=:id AND subnet_id=:sid");
+            $sel = $db->prepare("SELECT id, ip, hostname, owner, note, grp, mac, expires_at, status, owner_contact_id FROM addresses WHERE id=:id AND subnet_id=:sid");
             $sel->execute([':id' => $id, ':sid' => $subnetId]);
             /** @var array<string, mixed>|false $before */
             $before = $sel->fetch();
@@ -138,7 +142,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $err = 'Address not found.';
             } else {
                 $up = $db->prepare("UPDATE addresses
-                                    SET hostname=:hn, owner=:ow, note=:nt, grp=:grp, mac=:mac, expires_at=:exp, status=:st
+                                    SET hostname=:hn, owner=:ow, note=:nt, grp=:grp, mac=:mac, expires_at=:exp, status=:st, owner_contact_id=:cid
                                     WHERE id=:id AND subnet_id=:sid");
                 $up->execute([
                     ':hn'  => $hostname,
@@ -148,28 +152,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     ':mac' => $mac,
                     ':exp' => $expiresAt !== '' ? $expiresAt : null,
                     ':st'  => $status,
+                    ':cid' => $ownerContactId,
                     ':id'  => $id,
                     ':sid' => $subnetId,
                 ]);
 
                 history_log_address($db, 'update', $subnetId, to_str($before['ip']), $id,
                     [
-                        'hostname'   => to_str($before['hostname']),
-                        'owner'      => to_str($before['owner']),
-                        'note'       => to_str($before['note']),
-                        'grp'        => to_str($before['grp']),
-                        'mac'        => to_str($before['mac']),
-                        'expires_at' => isset($before['expires_at']) ? to_str($before['expires_at']) : null,
-                        'status'     => to_str($before['status']),
+                        'hostname'        => to_str($before['hostname']),
+                        'owner'           => to_str($before['owner']),
+                        'note'            => to_str($before['note']),
+                        'grp'             => to_str($before['grp']),
+                        'mac'             => to_str($before['mac']),
+                        'expires_at'      => isset($before['expires_at']) ? to_str($before['expires_at']) : null,
+                        'status'          => to_str($before['status']),
+                        'owner_contact_id' => $before['owner_contact_id'] !== null ? to_int($before['owner_contact_id']) : null,
                     ],
                     [
-                        'hostname'   => $hostname,
-                        'owner'      => $owner,
-                        'note'       => $note,
-                        'grp'        => $grp,
-                        'mac'        => $mac,
-                        'expires_at' => $expiresAt !== '' ? $expiresAt : null,
-                        'status'     => $status,
+                        'hostname'        => $hostname,
+                        'owner'           => $owner,
+                        'note'            => $note,
+                        'grp'             => $grp,
+                        'mac'             => $mac,
+                        'expires_at'      => $expiresAt !== '' ? $expiresAt : null,
+                        'status'          => $status,
+                        'owner_contact_id' => $ownerContactId,
                     ]
                 );
 
@@ -194,6 +201,56 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         header('Content-Type: application/json');
         echo '{"ok":true,"status":"' . $newStatus . '"}';
+        exit;
+    } elseif ($action === 'update_cell') {
+        // Inline cell edit — JSON response; CSRF already verified above
+        require_write_access();
+        header('Content-Type: application/json');
+        $id     = to_int($_POST['id']    ?? 0);
+        $field  = to_str($_POST['field'] ?? '');
+        $value  = to_str($_POST['value'] ?? '');
+        $allowed = ['hostname', 'owner', 'note', 'grp'];
+        if ($id <= 0 || !in_array($field, $allowed, true)) {
+            echo json_encode(['ok' => false, 'error' => 'Invalid request.']);
+            exit;
+        }
+        $maxLen = ['hostname' => 253, 'owner' => 255, 'note' => 1000, 'grp' => 100];
+        $value = substr(trim($value), 0, $maxLen[$field]);
+        $sel = $db->prepare("SELECT id, ip, hostname, owner, note, grp FROM addresses WHERE id=:id");
+        $sel->execute([':id' => $id]);
+        /** @var array<string, mixed>|false $before */
+        $before = $sel->fetch();
+        if (!$before) {
+            echo json_encode(['ok' => false, 'error' => 'Address not found.']);
+            exit;
+        }
+        // Static SQL per field — no interpolation of user-controlled data
+        $updateSql = match ($field) {
+            'hostname' => "UPDATE addresses SET hostname=:v, updated_at=datetime('now') WHERE id=:id",
+            'owner'    => "UPDATE addresses SET owner=:v, updated_at=datetime('now') WHERE id=:id",
+            'note'     => "UPDATE addresses SET note=:v, updated_at=datetime('now') WHERE id=:id",
+            'grp'      => "UPDATE addresses SET grp=:v, updated_at=datetime('now') WHERE id=:id",
+        };
+        $db->prepare($updateSql)->execute([':v' => $value, ':id' => $id]);
+        $after = array_merge(
+            ['hostname' => to_str($before['hostname']), 'owner' => to_str($before['owner']),
+             'note'     => to_str($before['note']),     'grp'   => to_str($before['grp'])],
+            [$field => $value]
+        );
+        $subnetIdForHistory = to_int((function() use ($db, $id) {
+            $r = $db->prepare("SELECT subnet_id FROM addresses WHERE id=:id");
+            $r->execute([':id' => $id]);
+            /** @var array<string, mixed>|false $row */
+            $row = $r->fetch();
+            return $row ? to_int($row['subnet_id']) : 0;
+        })());
+        history_log_address($db, 'update', $subnetIdForHistory, to_str($before['ip']), $id,
+            ['hostname' => to_str($before['hostname']), 'owner' => to_str($before['owner']),
+             'note'     => to_str($before['note']),     'grp'   => to_str($before['grp'])],
+            $after
+        );
+        audit($db, 'address.update', 'address', $id, "inline_cell=$field");
+        echo json_encode(['ok' => true, 'value' => $value]);
         exit;
     } elseif ($action === 'delete') {
         require_write_access();
@@ -246,9 +303,11 @@ if ($selectedSubnetId > 0) {
 
     $p = paginate($total, $page, $pageSize);
 
-    $st = $db->prepare("SELECT id, ip, hostname, owner, note, grp, mac, expires_at, status, updated_at
-                        FROM addresses
-                        WHERE subnet_id = :sid
+    $st = $db->prepare("SELECT a.id, a.ip, a.hostname, a.owner, a.note, a.grp, a.mac, a.expires_at, a.status, a.updated_at,
+                               a.owner_contact_id, c.name AS owner_contact_name, c.email AS owner_contact_email
+                        FROM addresses a
+                        LEFT JOIN contacts c ON c.id = a.owner_contact_id
+                        WHERE a.subnet_id = :sid
                         ORDER BY {$addrSort['sql']}
                         LIMIT :lim OFFSET :off");
     $st->bindValue(':sid', $selectedSubnetId, PDO::PARAM_INT);
@@ -356,7 +415,10 @@ page_header('Addresses');
     <div class="row">
       <label>IP<br><input name="ip" value="<?= e($prefillIp) ?>" placeholder="<?= ($selectedSubnet && to_int($selectedSubnet['ip_version'])===6) ? '2001:db8::10' : '10.0.0.10' ?>" required data-validate="ip"></label>
       <label>Hostname<br><input name="hostname" maxlength="253"></label>
-      <label>Owner<br><input name="owner" maxlength="255"></label>
+      <label>Owner<br>
+        <input name="owner" maxlength="255" autocomplete="off" data-contact-typeahead>
+        <input type="hidden" name="owner_contact_id" value="0">
+      </label>
       <label>Group<br><input name="grp" maxlength="100" placeholder="e.g. web-tier" class="mw-160"></label>
       <label>MAC<br><input name="mac" maxlength="64" placeholder="e.g. aa:bb:cc:dd:ee:ff" class="mw-160"></label>
       <label>Expires<br><input name="expires_at" type="date" class="mw-160"></label>
@@ -391,38 +453,53 @@ page_header('Addresses');
     <div class="empty-state">No addresses in this subnet yet. <a class="action-pill" href="#add-address">+ Add Address</a></div>
   <?php else: ?>
     <div class="table-wrap">
-    <table>
+    <table data-col-table="addresses">
       <thead>
         <tr>
           <?php $addrQs = '?subnet_id=' . $selectedSubnetId . '&page_size=' . $pageSize;
-                echo sort_th('ip',       'IP',       $addrSort['col'], $addrSort['dir'], $addrQs);
-                echo sort_th('hostname', 'Hostname', $addrSort['col'], $addrSort['dir'], $addrQs);
-                echo sort_th('owner',    'Owner',    $addrSort['col'], $addrSort['dir'], $addrQs);
-                echo sort_th('status',   'Status',   $addrSort['col'], $addrSort['dir'], $addrQs);
+                echo sort_th('ip',       'IP',       $addrSort['col'], $addrSort['dir'], $addrQs, 'ip');
+                echo sort_th('hostname', 'Hostname', $addrSort['col'], $addrSort['dir'], $addrQs, 'hostname');
+                echo sort_th('owner',    'Owner',    $addrSort['col'], $addrSort['dir'], $addrQs, 'owner');
+                echo sort_th('status',   'Status',   $addrSort['col'], $addrSort['dir'], $addrQs, 'status');
           ?>
-          <th>Group</th>
-          <th>MAC</th>
-          <th>Expires</th>
-          <th>Note</th>
-          <?php echo sort_th('updated', 'Updated', $addrSort['col'], $addrSort['dir'], $addrQs); ?>
+          <th data-col="group">Group</th>
+          <th data-col="mac">MAC</th>
+          <th data-col="expires">Expires</th>
+          <th data-col="note">Note</th>
+          <?php echo sort_th('updated', 'Updated', $addrSort['col'], $addrSort['dir'], $addrQs, 'updated'); ?>
           <th>Actions</th>
         </tr>
       </thead>
       <tbody>
-      <?php foreach ($addresses as $a): $isHighlighted = $highlightId > 0 && to_int($a['id']) === $highlightId; ?>
-        <tr id="addr-<?= to_int($a['id']) ?>"<?= $isHighlighted ? ' class="highlight-row"' : '' ?>>
+      <?php
+        $isWrite = (current_user()['role'] !== 'readonly');
+        foreach ($addresses as $a):
+          $isHighlighted = $highlightId > 0 && to_int($a['id']) === $highlightId;
+          $aid = to_int($a['id']);
+      ?>
+        <tr id="addr-<?= $aid ?>"<?= $isHighlighted ? ' class="highlight-row"' : '' ?>>
           <td><?= e(to_str($a['ip'])) ?></td>
-          <td><?= e(to_str($a['hostname'])) ?></td>
-          <td><?= e(to_str($a['owner'])) ?></td>
+          <td<?= $isWrite ? ' data-editable="hostname" data-addr-id="' . $aid . '"' : '' ?>><?= e(to_str($a['hostname'])) ?></td>
+          <td<?= $isWrite ? ' data-editable="owner" data-addr-id="' . $aid . '"' : '' ?>><?php
+            $ownContactId    = to_int($a['owner_contact_id'] ?? 0);
+            $ownContactName  = to_str($a['owner_contact_name'] ?? '');
+            $ownContactEmail = to_str($a['owner_contact_email'] ?? '');
+            if ($ownContactId > 0 && $ownContactName !== '') {
+                echo '<a href="contacts.php">' . e($ownContactName) . '</a>';
+                if ($ownContactEmail !== '') echo ' <a href="mailto:' . e($ownContactEmail) . '" class="muted" title="' . e($ownContactEmail) . '">✉</a>';
+            } else {
+                echo e(to_str($a['owner']));
+            }
+          ?></td>
           <td><?php
             $addrStatus = e(to_str($a['status']));
-            $canToggle  = (current_user()['role'] !== 'readonly') ? ' data-addr-id="' . to_int($a['id']) . '"' : '';
+            $canToggle  = $isWrite ? ' data-addr-id="' . $aid . '"' : '';
             echo "<span class='status-badge status-{$addrStatus}'{$canToggle} title='Click to cycle status'>{$addrStatus}</span>";
           ?></td>
-          <td><?php if ($a['grp'] !== ''): ?><span class="badge"><?= e(to_str($a['grp'])) ?></span><?php endif; ?></td>
+          <td<?= $isWrite ? ' data-editable="grp" data-addr-id="' . $aid . '"' : '' ?>><?php if ($a['grp'] !== ''): ?><span class="badge"><?= e(to_str($a['grp'])) ?></span><?php endif; ?></td>
           <td class="muted"><?= e(to_str($a['mac'])) ?></td>
           <td class="muted"><?= e(to_str($a['expires_at'] ?? '')) ?></td>
-          <td><?= e(to_str($a['note'])) ?></td>
+          <td<?= $isWrite ? ' data-editable="note" data-addr-id="' . $aid . '"' : '' ?>><?= e(to_str($a['note'])) ?></td>
           <td class="muted"><?= e(to_str($a['updated_at'])) ?></td>
           <td>
             <div class="actions-inline">
@@ -440,7 +517,10 @@ page_header('Addresses');
 
                 <div class="row">
                   <label>Hostname<br><input name="hostname" maxlength="253" value="<?= e(to_str($a['hostname'])) ?>"></label>
-                  <label>Owner<br><input name="owner" maxlength="255" value="<?= e(to_str($a['owner'])) ?>"></label>
+                  <label>Owner<br>
+                    <input name="owner" maxlength="255" value="<?= e(to_str($a['owner'])) ?>" autocomplete="off" data-contact-typeahead>
+                    <input type="hidden" name="owner_contact_id" value="<?= to_int($a['owner_contact_id'] ?? 0) ?>">
+                  </label>
                   <label>Group<br><input name="grp" value="<?= e(to_str($a['grp'] ?? '')) ?>" maxlength="100" placeholder="e.g. web-tier" class="mw-160"></label>
                   <label>MAC<br><input name="mac" maxlength="64" value="<?= e(to_str($a['mac'])) ?>" placeholder="e.g. aa:bb:cc:dd:ee:ff" class="mw-160"></label>
                   <label>Expires<br><input name="expires_at" type="date" value="<?= e(to_str($a['expires_at'] ?? '')) ?>" class="mw-160"></label>
@@ -470,7 +550,7 @@ page_header('Addresses');
             </details>
           </td>
         </tr>
-      <?php endforeach; ?>
+        <?php endforeach; ?>
       </tbody>
     </table>
     </div>

--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -696,7 +696,7 @@ function api_vrfs(PDO $db): never
         /** @var array<string, mixed>|false $row */
         $row = $st->fetch();
         if (!$row) api_error(404, 'VRF not found.');
-        api_json(fmt_vrf($row));
+        api_json(['vrf' => fmt_vrf($row)]);
     }
 
     $st = $db->prepare("SELECT id, name, description, rd, created_at, updated_at FROM vrfs ORDER BY name");
@@ -759,10 +759,12 @@ function api_vrfs_update(PDO $db, array $apiKey, int $id, array $body): never
     $desc = trim(to_str($body['description'] ?? ''));
     $rd   = trim(to_str($body['rd'] ?? ''));
     if ($name === '') api_error(400, 'name is required.');
+    $checkSt = $db->prepare("SELECT id FROM vrfs WHERE id = :id");
+    $checkSt->execute([':id' => $id]);
+    if (!$checkSt->fetch()) api_error(404, 'VRF not found.');
     try {
         $st = $db->prepare("UPDATE vrfs SET name=:n, description=:d, rd=:rd, updated_at=datetime('now') WHERE id=:id");
         $st->execute([':n' => $name, ':d' => $desc, ':rd' => $rd, ':id' => $id]);
-        if ($st->rowCount() === 0) api_error(404, 'VRF not found.');
         audit($db, 'vrf.update', 'vrf', $id, "name=$name");
     } catch (PDOException $e) {
         api_error(409, 'A VRF with that name already exists.');
@@ -803,7 +805,7 @@ function api_contacts(PDO $db): never
         /** @var array<string, mixed>|false $row */
         $row = $st->fetch();
         if (!$row) api_error(404, 'Contact not found.');
-        api_json(fmt_contact($row));
+        api_json(['contact' => fmt_contact($row)]);
     }
 
     $where  = [];
@@ -904,9 +906,11 @@ function api_contacts_update(PDO $db, array $apiKey, int $id, array $body): neve
     $org   = trim(to_str($body['org']   ?? ''));
     $note  = trim(to_str($body['note']  ?? ''));
     if ($name === '') api_error(400, 'name is required.');
+    $checkSt = $db->prepare("SELECT id FROM contacts WHERE id = :id");
+    $checkSt->execute([':id' => $id]);
+    if (!$checkSt->fetch()) api_error(404, 'Contact not found.');
     $st = $db->prepare("UPDATE contacts SET name=:n, email=:e, phone=:p, org=:o, note=:nt, updated_at=datetime('now') WHERE id=:id");
     $st->execute([':n' => $name, ':e' => $email, ':p' => $phone, ':o' => $org, ':nt' => $note, ':id' => $id]);
-    if ($st->rowCount() === 0) api_error(404, 'Contact not found.');
     audit($db, 'contact.update', 'contact', $id, "name=$name");
     $st = $db->prepare("SELECT id, name, email, phone, org, note, created_at, updated_at FROM contacts WHERE id = :id");
     $st->execute([':id' => $id]);
@@ -1700,7 +1704,7 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
 {
     if ($id <= 0) api_error(400, 'id is required as a query parameter.');
 
-    $st = $db->prepare("SELECT id, cidr, description, site_id, vlan_id, vlan_fk FROM subnets WHERE id = :id");
+    $st = $db->prepare("SELECT id, cidr, description, site_id, vlan_id, vlan_fk, vrf_id FROM subnets WHERE id = :id");
     $st->execute([':id' => $id]);
     /** @var array<string, mixed>|false $subnet */
     $subnet = $st->fetch();
@@ -1716,6 +1720,9 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
     $vlanFk = array_key_exists('vlan_fk', $body)
         ? ($body['vlan_fk'] !== null ? to_int($body['vlan_fk']) : null)
         : ($subnet['vlan_fk'] !== null ? to_int($subnet['vlan_fk']) : null);
+    $vrfId = array_key_exists('vrf_id', $body)
+        ? ($body['vrf_id'] !== null ? to_int($body['vrf_id']) : null)
+        : ($subnet['vrf_id'] !== null ? to_int($subnet['vrf_id']) : null);
 
     if ($vlanId !== null && ($vlanId < 1 || $vlanId > 4094)) {
         api_error(400, 'vlan_id must be between 1 and 4094.');
@@ -1733,13 +1740,19 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
         if (!$siteSt->fetch()) api_error(404, 'Site not found.');
     }
 
-    // Inherit site from tightest parent if one exists
-    $inheritedSiteId = find_parent_site_id($db, to_str($subnet['cidr']), $id);
+    if ($vrfId !== null) {
+        $vrfSt = $db->prepare("SELECT id FROM vrfs WHERE id = :id");
+        $vrfSt->execute([':id' => $vrfId]);
+        if (!$vrfSt->fetch()) api_error(400, 'vrf_id refers to a non-existent VRF.');
+    }
+
+    // Inherit site from tightest parent if one exists (VRF-scoped)
+    $inheritedSiteId = find_parent_site_id($db, to_str($subnet['cidr']), $id, $vrfId);
     if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
     $db->prepare(
-        "UPDATE subnets SET description = :desc, site_id = :sid, vlan_id = :vlan, vlan_fk = :vfk WHERE id = :id"
-    )->execute([':desc' => $description, ':sid' => $siteId, ':vlan' => $vlanId, ':vfk' => $vlanFk, ':id' => $id]);
+        "UPDATE subnets SET description = :desc, site_id = :sid, vlan_id = :vlan, vlan_fk = :vfk, vrf_id = :vrf WHERE id = :id"
+    )->execute([':desc' => $description, ':sid' => $siteId, ':vlan' => $vlanId, ':vfk' => $vlanFk, ':vrf' => $vrfId, ':id' => $id]);
 
     api_audit($db, $apiKey, 'subnet.update', 'subnet', $id, 'cidr=' . to_str($subnet['cidr']));
 

--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
  *   Authorization: Bearer <key>
  *
  * Resources (read):
- *   GET  ?resource=subnets             — list subnets (paginated, filterable by ip_version, vlan_id)
+ *   GET  ?resource=subnets             — list subnets (paginated, filterable by ip_version, vlan_id, vrf_id)
  *   GET  ?resource=addresses           — list addresses (paginated, filterable)
  *   GET  ?resource=sites               — list all sites
+ *   GET  ?resource=vlans               — list all VLANs
+ *   GET  ?resource=vrfs                — list all VRFs
  *   GET  ?resource=history&address_id= — address change history (paginated)
  *   GET  ?resource=search&q=           — search addresses by IP/hostname/owner/note
  *   GET  ?resource=audit               — audit log (paginated, filterable by action/date)
@@ -19,6 +21,8 @@ declare(strict_types=1);
  *   POST/PUT/DELETE ?resource=subnets  — create/update/delete subnets
  *   POST/PUT/DELETE ?resource=addresses — create/update/delete addresses
  *   POST/PUT/DELETE ?resource=sites    — create/update/delete sites
+ *   POST/PUT/DELETE ?resource=vrfs     — create/update/delete VRFs
+ *   POST/PUT/DELETE ?resource=contacts — create/update/delete contacts
  */
 
 // No session; stateless API request
@@ -66,30 +70,51 @@ if (preg_match('/^Bearer\s+(\S+)$/i', $authHeader, $m)) {
     header('X-Deprecation-Reason: API key via query parameter is deprecated. Use Authorization: Bearer header.');
 }
 
+// Session-based auth for contacts typeahead (no API key required from browser sessions)
+$sessionApiKey = null;
 if ($rawKey === '') {
+    $resourcePeek = strtolower(trim(to_str($_GET['resource'] ?? '')));
+    $methodPeek   = strtoupper(to_str($_SERVER['REQUEST_METHOD'] ?? 'GET'));
+    if ($resourcePeek === 'contacts' && $methodPeek === 'GET' && isset($_GET['q'])) {
+        session_name(to_str($config['session_name']));
+        session_set_cookie_params(['lifetime' => 0, 'path' => '/', 'domain' => '', 'secure' => true, 'httponly' => true, 'samesite' => 'Strict']);
+        ini_set('session.use_strict_mode', '1');
+        ini_set('session.use_only_cookies', '1');
+        @session_start();
+        if (!empty($_SESSION['uid'])) {
+            $sessionApiKey = ['id' => 0, 'name' => 'session', 'is_readonly' => '1'];
+        }
+    }
+}
+
+if ($rawKey === '' && $sessionApiKey === null) {
     http_response_code(401);
     echo json_encode(['error' => 'API key required. Pass via Authorization: Bearer <key> header.']);
     exit;
 }
 
-$keyHash = hash('sha256', $rawKey);
-$st = $db->prepare("SELECT id, name, is_readonly FROM api_keys WHERE key_hash = :h AND is_active = 1");
-$st->execute([':h' => $keyHash]);
-/** @var array<string, mixed>|false $apiKey */
-$apiKey = $st->fetch();
+if ($sessionApiKey !== null) {
+    $apiKey = $sessionApiKey;
+} else {
+    $keyHash = hash('sha256', $rawKey);
+    $st = $db->prepare("SELECT id, name, is_readonly FROM api_keys WHERE key_hash = :h AND is_active = 1");
+    $st->execute([':h' => $keyHash]);
+    /** @var array<string, mixed>|false $apiKey */
+    $apiKey = $st->fetch();
 
-if (!$apiKey) {
-    record_login_failure($db, $clientIp);
-    http_response_code(401);
-    echo json_encode(['error' => 'Invalid or inactive API key.']);
-    exit;
+    if (!$apiKey) {
+        record_login_failure($db, $clientIp);
+        http_response_code(401);
+        echo json_encode(['error' => 'Invalid or inactive API key.']);
+        exit;
+    }
+
+    // Successful auth — clear any accumulated failures for this IP
+    clear_login_failures($db, $clientIp);
+
+    $db->prepare("UPDATE api_keys SET last_used_at = datetime('now') WHERE id = :id")
+       ->execute([':id' => to_int($apiKey['id'])]);
 }
-
-// Successful auth — clear any accumulated failures for this IP
-clear_login_failures($db, $clientIp);
-
-$db->prepare("UPDATE api_keys SET last_used_at = datetime('now') WHERE id = :id")
-   ->execute([':id' => to_int($apiKey['id'])]);
 
 // ---- Route ----
 
@@ -138,11 +163,31 @@ match ($resource) {
         default  => api_error(405, 'Method not allowed.'),
     },
     'history'    => $method === 'GET' ? api_history($db)      : api_error(405, 'Method not allowed.'),
-    'vlans'      => $method === 'GET' ? api_vlans($db)         : api_error(405, 'Method not allowed.'),
+    'vlans' => match ($method) {
+        'GET'    => api_vlans($db),
+        'POST'   => api_vlans_create($db, $apiKey, $body),
+        'PUT'    => api_vlans_update($db, $apiKey, to_int($_GET['id'] ?? 0), $body),
+        'DELETE' => api_vlans_delete($db, $apiKey, to_int($_GET['id'] ?? 0)),
+        default  => api_error(405, 'Method not allowed.'),
+    },
+    'vrfs'       => match ($method) {
+        'GET'    => api_vrfs($db),
+        'POST'   => api_vrfs_create($db, $apiKey, $body),
+        'PUT'    => api_vrfs_update($db, $apiKey, to_int($_GET['id'] ?? 0), $body),
+        'DELETE' => api_vrfs_delete($db, $apiKey, to_int($_GET['id'] ?? 0)),
+        default  => api_error(405, 'Method not allowed.'),
+    },
+    'contacts'   => match ($method) {
+        'GET'    => api_contacts($db),
+        'POST'   => api_contacts_create($db, $apiKey, $body),
+        'PUT'    => api_contacts_update($db, $apiKey, to_int($_GET['id'] ?? 0), $body),
+        'DELETE' => api_contacts_delete($db, $apiKey, to_int($_GET['id'] ?? 0)),
+        default  => api_error(405, 'Method not allowed.'),
+    },
     'search'     => $method === 'GET' ? api_search($db)       : api_error(405, 'Method not allowed.'),
     'audit'      => $method === 'GET' ? api_audit_log($db)    : api_error(405, 'Method not allowed.'),
     'unassigned' => $method === 'GET' ? api_unassigned($db)   : api_error(405, 'Method not allowed.'),
-    default      => api_error(404, 'Unknown resource. Valid: subnets, addresses, sites, vlans, history, search, audit, unassigned'),
+    default      => api_error(404, 'Unknown resource. Valid: subnets, addresses, sites, vlans, vrfs, contacts, history, search, audit, unassigned'),
 };
 
 // ---- Helpers ----
@@ -216,11 +261,13 @@ function api_subnets(PDO $db): never
         : '';
 
     $baseSql = "SELECT s.id, s.cidr, s.ip_version, s.network, s.prefix,
-                       s.description, s.vlan_id, s.vlan_fk, s.site_id, s.created_at,
-                       si.name AS site, v.vlan_id AS vlan_number, v.name AS vlan_name$countsSelect
+                       s.description, s.vlan_id, s.vlan_fk, s.site_id, s.vrf_id, s.created_at,
+                       si.name AS site, v.vlan_id AS vlan_number, v.name AS vlan_name,
+                       vr.name AS vrf_name$countsSelect
                 FROM subnets s
                 LEFT JOIN sites si ON si.id = s.site_id
                 LEFT JOIN vlans v ON v.id = s.vlan_fk
+                LEFT JOIN vrfs vr ON vr.id = s.vrf_id
                 $countsJoin";
 
     if (isset($_GET['id'])) {
@@ -231,7 +278,7 @@ function api_subnets(PDO $db): never
         $row = $st->fetch();
         if (!$row) api_error(404, 'Subnet not found.');
         $subnetTags = api_fetch_tags_for_ids($db, 'subnet', [$id]);
-        api_json(fmt_subnet($row, $withCounts, $subnetTags[$id] ?? []));
+        api_json(['subnet' => fmt_subnet($row, $withCounts, $subnetTags[$id] ?? [])]);
     }
 
     $page   = max(1, to_int($_GET['page']  ?? 1));
@@ -263,6 +310,12 @@ function api_subnets(PDO $db): never
         $params[':site_id'] = $v;
     }
 
+    if (isset($_GET['vrf_id'])) {
+        $v = to_int($_GET['vrf_id']);
+        $where[]         = 's.vrf_id = :vrf_id';
+        $params[':vrf_id'] = $v;
+    }
+
     $tagJoin = '';
     if (isset($_GET['tag'])) {
         $tagName = trim(to_str($_GET['tag']));
@@ -275,7 +328,7 @@ function api_subnets(PDO $db): never
 
     $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
 
-    $cntSt = $db->prepare("SELECT COUNT(*) AS c FROM subnets s $tagJoin $whereSql");
+    $cntSt = $db->prepare("SELECT COUNT(*) AS c FROM subnets s LEFT JOIN vlans v ON v.id = s.vlan_fk $tagJoin $whereSql");
     $cntSt->execute($params);
     /** @var array<string, mixed>|false $cntRow */
 
@@ -316,6 +369,7 @@ function api_subnets(PDO $db): never
 function fmt_subnet(array $r, bool $withCounts = false, array $tags = []): array
 {
     $vlanFk = $r['vlan_fk'] !== null ? to_int($r['vlan_fk']) : null;
+    $vrfId  = $r['vrf_id']  !== null ? to_int($r['vrf_id'])  : null;
     $out = [
         'id'          => to_int($r['id']),
         'cidr'        => $r['cidr'],
@@ -326,6 +380,8 @@ function fmt_subnet(array $r, bool $withCounts = false, array $tags = []): array
         'vlan_id'     => $r['vlan_id'] !== null ? to_int($r['vlan_id']) : null,
         'vlan_fk'     => $vlanFk,
         'vlan_name'   => $vlanFk !== null ? to_str($r['vlan_name'] ?? '') : null,
+        'vrf_id'      => $vrfId,
+        'vrf_name'    => $vrfId !== null ? to_str($r['vrf_name'] ?? '') : null,
         'site_id'     => $r['site_id'] !== null ? to_int($r['site_id']) : null,
         'site'        => $r['site'],
         'tags'        => $tags,
@@ -389,8 +445,14 @@ function api_addresses(PDO $db): never
         }
     }
 
+    if (isset($_GET['contact_id'])) {
+        $where[]             = 'a.owner_contact_id = :contact_id';
+        $params[':contact_id'] = to_int($_GET['contact_id']);
+    }
+
     $joins   = ($joinSite ? ' JOIN subnets s ON s.id = a.subnet_id' : '');
     $joins  .= ($joinTag  ? ' JOIN address_tags atf ON atf.address_id = a.id JOIN tags tf ON tf.id = atf.tag_id' : '');
+    $joins  .= ' LEFT JOIN contacts co ON co.id = a.owner_contact_id';
     $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
 
     $page   = max(1, to_int($_GET['page']  ?? 1));
@@ -406,7 +468,8 @@ function api_addresses(PDO $db): never
     $total = is_array($cntRow) ? to_int($cntRow['c']) : 0;
 
     $sql = "SELECT a.id, a.subnet_id, a.ip, a.hostname, a.owner,
-                   a.status, a.note, a.grp, a.mac, a.expires_at, a.created_at, a.updated_at
+                   a.status, a.note, a.grp, a.mac, a.expires_at, a.created_at, a.updated_at,
+                   a.owner_contact_id, co.name AS owner_contact_name
             FROM addresses a$joins $whereSql
             ORDER BY a.ip_bin
             LIMIT :lim OFFSET :off";
@@ -426,20 +489,23 @@ function api_addresses(PDO $db): never
 
     $rows = array_map(function(array $r) use ($tagsByAddr): array {
         $id = to_int($r['id']);
+        $contactId = $r['owner_contact_id'] !== null ? to_int($r['owner_contact_id']) : null;
         return [
-            'id'          => $id,
-            'subnet_id'   => to_int($r['subnet_id']),
-            'ip'          => $r['ip'],
-            'hostname'    => to_str($r['hostname']),
-            'owner'       => to_str($r['owner']),
-            'status'      => $r['status'],
-            'note'        => to_str($r['note']),
-            'group'       => to_str($r['grp']),
-            'mac'         => to_str($r['mac']),
-            'expires_at'  => isset($r['expires_at']) ? to_str($r['expires_at']) : null,
-            'tags'        => $tagsByAddr[$id] ?? [],
-            'created_at'  => $r['created_at'],
-            'updated_at'  => $r['updated_at'],
+            'id'                 => $id,
+            'subnet_id'          => to_int($r['subnet_id']),
+            'ip'                 => $r['ip'],
+            'hostname'           => to_str($r['hostname']),
+            'owner'              => to_str($r['owner']),
+            'owner_contact_id'   => $contactId,
+            'owner_contact_name' => $contactId !== null ? to_str($r['owner_contact_name'] ?? '') : null,
+            'status'             => $r['status'],
+            'note'               => to_str($r['note']),
+            'group'              => to_str($r['grp']),
+            'mac'                => to_str($r['mac']),
+            'expires_at'         => isset($r['expires_at']) ? to_str($r['expires_at']) : null,
+            'tags'               => $tagsByAddr[$id] ?? [],
+            'created_at'         => $r['created_at'],
+            'updated_at'         => $r['updated_at'],
         ];
     }, $rawRows);
 
@@ -460,7 +526,7 @@ function api_sites(PDO $db): never
         /** @var array<string, mixed>|false $row */
         $row = $st->fetch();
         if (!$row) api_error(404, 'Site not found.');
-        api_json(fmt_site($row));
+        api_json(['site' => fmt_site($row)]);
     }
 
     $where  = [];
@@ -506,7 +572,7 @@ function api_vlans(PDO $db): never
         /** @var array<string, mixed>|false $row */
         $row = $st->fetch();
         if (!$row) api_error(404, 'VLAN not found.');
-        api_json(fmt_vlan($row));
+        api_json(['vlan' => fmt_vlan($row)]);
     }
 
     $where  = [];
@@ -543,6 +609,326 @@ function fmt_vlan(array $r): array
         'created_at'  => $r['created_at'],
         'updated_at'  => $r['updated_at'],
     ];
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_vlans_create(PDO $db, array $apiKey, array $body): never
+{
+
+    $vlanId = to_int($body['vlan_id'] ?? 0);
+    $name   = trim(to_str($body['name']   ?? ''));
+    $desc   = trim(to_str($body['description'] ?? ''));
+    $siteId = isset($body['site_id']) ? to_int($body['site_id']) : null;
+
+    if ($vlanId < 1 || $vlanId > 4094) api_error(400, 'vlan_id must be between 1 and 4094.');
+    if ($name === '') api_error(400, 'name is required.');
+
+    $dup = $db->prepare("SELECT id FROM vlans WHERE vlan_id = :vid AND site_id IS :sid");
+    $dup->execute([':vid' => $vlanId, ':sid' => $siteId]);
+    if ($dup->fetch()) api_error(409, 'A VLAN with this vlan_id already exists in this site.');
+
+    $db->prepare("INSERT INTO vlans (vlan_id, name, description, site_id) VALUES (:vid, :n, :d, :sid)")
+       ->execute([':vid' => $vlanId, ':n' => $name, ':d' => $desc, ':sid' => $siteId]);
+    $newId = (int)$db->lastInsertId();
+    api_audit($db, $apiKey, 'vlan.create', 'vlan', $newId, "vlan_id=$vlanId name=$name");
+    http_response_code(201);
+    api_json(['id' => $newId]);
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_vlans_update(PDO $db, array $apiKey, int $id, array $body): never
+{
+
+    if ($id <= 0) api_error(400, 'id is required as a query parameter.');
+    $st = $db->prepare("SELECT id, vlan_id, name, description, site_id FROM vlans WHERE id = :id");
+    $st->execute([':id' => $id]);
+    /** @var array<string, mixed>|false $vlan */
+    $vlan = $st->fetch();
+    if (!$vlan) api_error(404, 'VLAN not found.');
+
+    $vlanId = array_key_exists('vlan_id', $body) ? to_int($body['vlan_id']) : to_int($vlan['vlan_id']);
+    $name   = array_key_exists('name', $body) ? trim(to_str($body['name'])) : to_str($vlan['name']);
+    $desc   = array_key_exists('description', $body) ? trim(to_str($body['description'])) : to_str($vlan['description']);
+    $siteId = array_key_exists('site_id', $body)
+        ? ($body['site_id'] !== null ? to_int($body['site_id']) : null)
+        : ($vlan['site_id'] !== null ? to_int($vlan['site_id']) : null);
+
+    if ($vlanId < 1 || $vlanId > 4094) api_error(400, 'vlan_id must be between 1 and 4094.');
+    if ($name === '') api_error(400, 'name cannot be empty.');
+
+    $dup = $db->prepare("SELECT id FROM vlans WHERE vlan_id = :vid AND site_id IS :sid AND id != :id");
+    $dup->execute([':vid' => $vlanId, ':sid' => $siteId, ':id' => $id]);
+    if ($dup->fetch()) api_error(409, 'A VLAN with this vlan_id already exists in this site.');
+
+    $db->prepare("UPDATE vlans SET vlan_id = :vid, name = :n, description = :d, site_id = :sid WHERE id = :id")
+       ->execute([':vid' => $vlanId, ':n' => $name, ':d' => $desc, ':sid' => $siteId, ':id' => $id]);
+    api_audit($db, $apiKey, 'vlan.update', 'vlan', $id, "vlan_id=$vlanId name=$name");
+    api_json(['id' => $id]);
+}
+
+/** @param array<string, mixed> $apiKey */
+function api_vlans_delete(PDO $db, array $apiKey, int $id): never
+{
+
+    if ($id <= 0) api_error(400, 'id is required as a query parameter.');
+    $st = $db->prepare("SELECT id FROM vlans WHERE id = :id");
+    $st->execute([':id' => $id]);
+    if (!$st->fetch()) api_error(404, 'VLAN not found.');
+
+    $db->prepare("DELETE FROM vlans WHERE id = :id")->execute([':id' => $id]);
+    api_audit($db, $apiKey, 'vlan.delete', 'vlan', $id, "id=$id");
+    http_response_code(204);
+    api_json([]);
+}
+
+function api_vrfs(PDO $db): never
+{
+    if (isset($_GET['id'])) {
+        $id = to_int($_GET['id']);
+        $st = $db->prepare("SELECT id, name, description, rd, created_at, updated_at FROM vrfs WHERE id = :id");
+        $st->execute([':id' => $id]);
+        /** @var array<string, mixed>|false $row */
+        $row = $st->fetch();
+        if (!$row) api_error(404, 'VRF not found.');
+        api_json(fmt_vrf($row));
+    }
+
+    $st = $db->prepare("SELECT id, name, description, rd, created_at, updated_at FROM vrfs ORDER BY name");
+    $st->execute();
+    api_json(['vrfs' => array_map('fmt_vrf', $st->fetchAll())]);
+}
+
+/**
+ * @param array<string, mixed> $r
+ * @return array<string, mixed>
+ */
+function fmt_vrf(array $r): array
+{
+    return [
+        'id'          => to_int($r['id']),
+        'name'        => to_str($r['name']),
+        'description' => to_str($r['description']),
+        'rd'          => to_str($r['rd']),
+        'created_at'  => $r['created_at'],
+        'updated_at'  => $r['updated_at'],
+    ];
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_vrfs_create(PDO $db, array $apiKey, array $body): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    $name = trim(to_str($body['name'] ?? ''));
+    $desc = trim(to_str($body['description'] ?? ''));
+    $rd   = trim(to_str($body['rd'] ?? ''));
+    if ($name === '') api_error(400, 'name is required.');
+    try {
+        $st = $db->prepare("INSERT INTO vrfs (name, description, rd) VALUES (:n,:d,:rd)");
+        $st->execute([':n' => $name, ':d' => $desc, ':rd' => $rd]);
+        $newId = (int)$db->lastInsertId();
+        audit($db, 'vrf.create', 'vrf', $newId, "name=$name");
+    } catch (PDOException $e) {
+        api_error(409, 'A VRF with that name already exists.');
+    }
+    http_response_code(201);
+    $st = $db->prepare("SELECT id, name, description, rd, created_at, updated_at FROM vrfs WHERE id = :id");
+    $st->execute([':id' => $newId]);
+    /** @var array<string, mixed>|false $row */
+    $row = $st->fetch();
+    api_json(fmt_vrf($row ?: []));
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_vrfs_update(PDO $db, array $apiKey, int $id, array $body): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    if ($id <= 0) api_error(400, 'id is required.');
+    $name = trim(to_str($body['name'] ?? ''));
+    $desc = trim(to_str($body['description'] ?? ''));
+    $rd   = trim(to_str($body['rd'] ?? ''));
+    if ($name === '') api_error(400, 'name is required.');
+    try {
+        $st = $db->prepare("UPDATE vrfs SET name=:n, description=:d, rd=:rd, updated_at=datetime('now') WHERE id=:id");
+        $st->execute([':n' => $name, ':d' => $desc, ':rd' => $rd, ':id' => $id]);
+        if ($st->rowCount() === 0) api_error(404, 'VRF not found.');
+        audit($db, 'vrf.update', 'vrf', $id, "name=$name");
+    } catch (PDOException $e) {
+        api_error(409, 'A VRF with that name already exists.');
+    }
+    $st = $db->prepare("SELECT id, name, description, rd, created_at, updated_at FROM vrfs WHERE id = :id");
+    $st->execute([':id' => $id]);
+    /** @var array<string, mixed>|false $row */
+    $row = $st->fetch();
+    api_json(fmt_vrf($row ?: []));
+}
+
+/** @param array<string, mixed> $apiKey */
+function api_vrfs_delete(PDO $db, array $apiKey, int $id): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    if ($id <= 0) api_error(400, 'id is required.');
+    $countSt = $db->prepare("SELECT COUNT(*) FROM subnets WHERE vrf_id = :id");
+    $countSt->execute([':id' => $id]);
+    $count = (int)$countSt->fetchColumn();
+    if ($count > 0) api_error(409, "Cannot delete: $count subnet(s) are assigned to this VRF.");
+    $nameSt = $db->prepare("SELECT name FROM vrfs WHERE id = :id");
+    $nameSt->execute([':id' => $id]);
+    /** @var array<string, mixed>|false $row */
+    $row = $nameSt->fetch();
+    if (!$row) api_error(404, 'VRF not found.');
+    $db->prepare("DELETE FROM vrfs WHERE id = :id")->execute([':id' => $id]);
+    audit($db, 'vrf.delete', 'vrf', $id, 'name=' . to_str($row['name']));
+    http_response_code(204);
+    api_json(['deleted' => true]);
+}
+
+function api_contacts(PDO $db): never
+{
+    if (isset($_GET['id'])) {
+        $id = to_int($_GET['id']);
+        $st = $db->prepare("SELECT id, name, email, phone, org, note, created_at, updated_at FROM contacts WHERE id = :id");
+        $st->execute([':id' => $id]);
+        /** @var array<string, mixed>|false $row */
+        $row = $st->fetch();
+        if (!$row) api_error(404, 'Contact not found.');
+        api_json(fmt_contact($row));
+    }
+
+    $where  = [];
+    $params = [];
+
+    // ?q= fuzzy name/email search
+    if (isset($_GET['q'])) {
+        $q = trim(to_str($_GET['q']));
+        if ($q !== '') {
+            $like            = '%' . str_replace(['%', '_'], ['\\%', '\\_'], $q) . '%';
+            $where[]         = '(name LIKE :q OR email LIKE :q2)';
+            $params[':q']    = $like;
+            $params[':q2']   = $like;
+        }
+    }
+
+    $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+    $page   = max(1, to_int($_GET['page']  ?? 1));
+    $limit  = max(1, min(200, to_int($_GET['limit'] ?? 50)));
+    $offset = ($page - 1) * $limit;
+
+    $cntSt = $db->prepare("SELECT COUNT(*) AS c FROM contacts $whereSql");
+    $cntSt->execute($params);
+    /** @var array<string, mixed>|false $cntRow */
+    $cntRow = $cntSt->fetch();
+    $total = is_array($cntRow) ? to_int($cntRow['c']) : 0;
+
+    $st = $db->prepare("SELECT id, name, email, phone, org, note, created_at, updated_at FROM contacts $whereSql ORDER BY name LIMIT :lim OFFSET :off");
+    foreach ($params as $k => $v2) {
+        $st->bindValue($k, $v2, PDO::PARAM_STR);
+    }
+    $st->bindValue(':lim', $limit, PDO::PARAM_INT);
+    $st->bindValue(':off', $offset, PDO::PARAM_INT);
+    $st->execute();
+    api_json([
+        'total'    => $total,
+        'page'     => $page,
+        'limit'    => $limit,
+        'contacts' => array_map('fmt_contact', $st->fetchAll()),
+    ]);
+}
+
+/**
+ * @param array<string, mixed> $r
+ * @return array<string, mixed>
+ */
+function fmt_contact(array $r): array
+{
+    return [
+        'id'         => to_int($r['id']),
+        'name'       => to_str($r['name']),
+        'email'      => to_str($r['email']),
+        'phone'      => to_str($r['phone']),
+        'org'        => to_str($r['org']),
+        'note'       => to_str($r['note']),
+        'created_at' => $r['created_at'],
+        'updated_at' => $r['updated_at'],
+    ];
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_contacts_create(PDO $db, array $apiKey, array $body): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    $name  = trim(to_str($body['name']  ?? ''));
+    $email = trim(to_str($body['email'] ?? ''));
+    $phone = trim(to_str($body['phone'] ?? ''));
+    $org   = trim(to_str($body['org']   ?? ''));
+    $note  = trim(to_str($body['note']  ?? ''));
+    if ($name === '') api_error(400, 'name is required.');
+    $st = $db->prepare("INSERT INTO contacts (name, email, phone, org, note) VALUES (:n,:e,:p,:o,:nt)");
+    $st->execute([':n' => $name, ':e' => $email, ':p' => $phone, ':o' => $org, ':nt' => $note]);
+    $newId = (int)$db->lastInsertId();
+    audit($db, 'contact.create', 'contact', $newId, "name=$name");
+    http_response_code(201);
+    $st = $db->prepare("SELECT id, name, email, phone, org, note, created_at, updated_at FROM contacts WHERE id = :id");
+    $st->execute([':id' => $newId]);
+    /** @var array<string, mixed>|false $row */
+    $row = $st->fetch();
+    api_json(fmt_contact($row ?: []));
+}
+
+/**
+ * @param array<string, mixed> $apiKey
+ * @param array<string, mixed> $body
+ */
+function api_contacts_update(PDO $db, array $apiKey, int $id, array $body): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    if ($id <= 0) api_error(400, 'id is required.');
+    $name  = trim(to_str($body['name']  ?? ''));
+    $email = trim(to_str($body['email'] ?? ''));
+    $phone = trim(to_str($body['phone'] ?? ''));
+    $org   = trim(to_str($body['org']   ?? ''));
+    $note  = trim(to_str($body['note']  ?? ''));
+    if ($name === '') api_error(400, 'name is required.');
+    $st = $db->prepare("UPDATE contacts SET name=:n, email=:e, phone=:p, org=:o, note=:nt, updated_at=datetime('now') WHERE id=:id");
+    $st->execute([':n' => $name, ':e' => $email, ':p' => $phone, ':o' => $org, ':nt' => $note, ':id' => $id]);
+    if ($st->rowCount() === 0) api_error(404, 'Contact not found.');
+    audit($db, 'contact.update', 'contact', $id, "name=$name");
+    $st = $db->prepare("SELECT id, name, email, phone, org, note, created_at, updated_at FROM contacts WHERE id = :id");
+    $st->execute([':id' => $id]);
+    /** @var array<string, mixed>|false $row */
+    $row = $st->fetch();
+    api_json(fmt_contact($row ?: []));
+}
+
+/** @param array<string, mixed> $apiKey */
+function api_contacts_delete(PDO $db, array $apiKey, int $id): never
+{
+    if (to_int($apiKey['is_readonly'] ?? 0) === 1) api_error(403, 'Read-only key.');
+    if ($id <= 0) api_error(400, 'id is required.');
+    $nameSt = $db->prepare("SELECT name FROM contacts WHERE id = :id");
+    $nameSt->execute([':id' => $id]);
+    /** @var array<string, mixed>|false $row */
+    $row = $nameSt->fetch();
+    if (!$row) api_error(404, 'Contact not found.');
+    $db->prepare("DELETE FROM contacts WHERE id = :id")->execute([':id' => $id]);
+    audit($db, 'contact.delete', 'contact', $id, 'name=' . to_str($row['name']));
+    http_response_code(204);
+    api_json(['deleted' => true]);
 }
 
 function api_history(PDO $db): never
@@ -920,6 +1306,7 @@ function api_subnets_bulk_create(PDO $db, array $apiKey, array $body, int $bulkL
         $description = trim(to_str($item['description'] ?? ''));
         $siteId      = isset($item['site_id']) ? to_int($item['site_id']) : null;
         $vlanId      = isset($item['vlan_id']) ? to_int($item['vlan_id']) : null;
+        $vrfId       = isset($item['vrf_id'])  ? to_int($item['vrf_id'])  : null;
 
         if ($cidr === '') { $results[] = ['success' => false, 'error' => 'cidr is required.']; continue; }
 
@@ -938,17 +1325,17 @@ function api_subnets_bulk_create(PDO $db, array $apiKey, array $body, int $bulkL
         }
 
         $normalized = $p['network'] . '/' . $p['prefix'];
-        $dupSt = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr");
-        $dupSt->execute([':cidr' => $normalized]);
+        $dupSt = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr AND vrf_id IS :vrf");
+        $dupSt->execute([':cidr' => $normalized, ':vrf' => $vrfId]);
         if ($dupSt->fetch()) { $results[] = ['success' => false, 'error' => "Subnet $normalized already exists."]; continue; }
 
-        $inheritedSiteId = find_parent_site_id($db, $normalized);
+        $inheritedSiteId = find_parent_site_id($db, $normalized, null, $vrfId);
         if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
         try {
             $db->prepare(
-                "INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id)
-                 VALUES (:cidr, :ver, :net, :nbin, :pfx, :desc, :sid, :vlan)"
+                "INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id, vrf_id)
+                 VALUES (:cidr, :ver, :net, :nbin, :pfx, :desc, :sid, :vlan, :vrf)"
             )->execute([
                 ':cidr' => $normalized,
                 ':ver'  => $p['version'],
@@ -958,6 +1345,7 @@ function api_subnets_bulk_create(PDO $db, array $apiKey, array $body, int $bulkL
                 ':desc' => $description,
                 ':sid'  => $siteId,
                 ':vlan' => $vlanId,
+                ':vrf'  => $vrfId,
             ]);
             $newId = (int)$db->lastInsertId();
 
@@ -984,16 +1372,24 @@ function api_subnets_bulk_create(PDO $db, array $apiKey, array $body, int $bulkL
  */
 function api_sites_create(PDO $db, array $apiKey, array $body): never
 {
-    $name = trim(to_str($body['name'] ?? ''));
-    $desc = trim(to_str($body['description'] ?? ''));
+    $name     = trim(to_str($body['name'] ?? ''));
+    $desc     = trim(to_str($body['description'] ?? ''));
+    $parentId = array_key_exists('parent_id', $body) && $body['parent_id'] !== null
+        ? to_int($body['parent_id']) : null;
     if ($name === '') api_error(400, 'name is required.');
+
+    if ($parentId !== null) {
+        $pSt = $db->prepare("SELECT id FROM sites WHERE id = :id");
+        $pSt->execute([':id' => $parentId]);
+        if (!$pSt->fetch()) api_error(400, 'parent_id refers to a non-existent site.');
+    }
 
     $dup = $db->prepare("SELECT id FROM sites WHERE name = :n");
     $dup->execute([':n' => $name]);
     if ($dup->fetch()) api_error(409, 'A site with this name already exists.');
 
-    $db->prepare("INSERT INTO sites (name, description) VALUES (:n, :d)")
-       ->execute([':n' => $name, ':d' => $desc]);
+    $db->prepare("INSERT INTO sites (name, description, parent_id) VALUES (:n, :d, :p)")
+       ->execute([':n' => $name, ':d' => $desc, ':p' => $parentId]);
     $newId = (int)$db->lastInsertId();
     api_audit($db, $apiKey, 'site.create', 'site', $newId, "name=$name");
     http_response_code(201);
@@ -1007,23 +1403,33 @@ function api_sites_create(PDO $db, array $apiKey, array $body): never
 function api_sites_update(PDO $db, array $apiKey, int $id, array $body): never
 {
     if ($id <= 0) api_error(400, 'id is required as a query parameter.');
-    $st = $db->prepare("SELECT id, name, description FROM sites WHERE id = :id");
+    $st = $db->prepare("SELECT id, name, description, parent_id FROM sites WHERE id = :id");
     $st->execute([':id' => $id]);
     /** @var array<string, mixed>|false $site */
     $site = $st->fetch();
     if (!$site) api_error(404, 'Site not found.');
 
-    $name = array_key_exists('name', $body) ? trim(to_str($body['name'])) : to_str($site['name']);
-    $desc = array_key_exists('description', $body) ? trim(to_str($body['description'])) : to_str($site['description']);
+    $name     = array_key_exists('name', $body) ? trim(to_str($body['name'])) : to_str($site['name']);
+    $desc     = array_key_exists('description', $body) ? trim(to_str($body['description'])) : to_str($site['description']);
+    $parentId = array_key_exists('parent_id', $body)
+        ? ($body['parent_id'] !== null ? to_int($body['parent_id']) : null)
+        : ($site['parent_id'] !== null ? to_int($site['parent_id']) : null);
     if ($name === '') api_error(400, 'name cannot be empty.');
+
+    if ($parentId !== null) {
+        if ($parentId === $id) api_error(400, 'A site cannot be its own parent.');
+        $pSt = $db->prepare("SELECT id FROM sites WHERE id = :id");
+        $pSt->execute([':id' => $parentId]);
+        if (!$pSt->fetch()) api_error(400, 'parent_id refers to a non-existent site.');
+    }
 
     // Check for duplicate name (excluding self)
     $dupSt = $db->prepare("SELECT id FROM sites WHERE name = :n AND id != :id");
     $dupSt->execute([':n' => $name, ':id' => $id]);
     if ($dupSt->fetch()) api_error(409, 'A site with this name already exists.');
 
-    $db->prepare("UPDATE sites SET name = :n, description = :d WHERE id = :id")
-       ->execute([':n' => $name, ':d' => $desc, ':id' => $id]);
+    $db->prepare("UPDATE sites SET name = :n, description = :d, parent_id = :p WHERE id = :id")
+       ->execute([':n' => $name, ':d' => $desc, ':p' => $parentId, ':id' => $id]);
     api_audit($db, $apiKey, 'site.update', 'site', $id, "name=$name");
     api_json(['id' => $id]);
 }
@@ -1055,14 +1461,15 @@ function api_sites_delete(PDO $db, array $apiKey, int $id): never
  */
 function api_addresses_create(PDO $db, array $apiKey, array $body): never
 {
-    $subnetId = isset($body['subnet_id']) ? to_int($body['subnet_id']) : 0;
-    $ip       = trim(to_str($body['ip'] ?? ''));
-    $hostname  = trim(to_str($body['hostname']   ?? ''));
-    $owner     = trim(to_str($body['owner']     ?? ''));
-    $note      = trim(to_str($body['note']      ?? ''));
-    $grp       = trim(to_str($body['group']     ?? ''));
-    $mac       = substr(trim(to_str($body['mac'] ?? '')), 0, 64);
-    $expiresAt = trim(to_str($body['expires_at'] ?? ''));
+    $subnetId       = isset($body['subnet_id'])       ? to_int($body['subnet_id'])       : 0;
+    $ip             = trim(to_str($body['ip'] ?? ''));
+    $hostname       = trim(to_str($body['hostname']        ?? ''));
+    $owner          = trim(to_str($body['owner']           ?? ''));
+    $ownerContactId = isset($body['owner_contact_id']) ? to_int($body['owner_contact_id']) : null;
+    $note           = trim(to_str($body['note']            ?? ''));
+    $grp            = trim(to_str($body['group']           ?? ''));
+    $mac            = substr(trim(to_str($body['mac'] ?? '')), 0, 64);
+    $expiresAt      = trim(to_str($body['expires_at'] ?? ''));
     if ($expiresAt !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiresAt)) {
         $expiresAt = '';
     }
@@ -1072,6 +1479,12 @@ function api_addresses_create(PDO $db, array $apiKey, array $body): never
     if ($ip === '')      api_error(400, 'ip is required.');
     if (!in_array($status, ['used', 'reserved', 'free'], true)) {
         api_error(400, 'status must be used, reserved, or free.');
+    }
+
+    if ($ownerContactId !== null) {
+        $cSt = $db->prepare("SELECT id FROM contacts WHERE id = :id");
+        $cSt->execute([':id' => $ownerContactId]);
+        if (!$cSt->fetch()) api_error(404, 'Contact not found.');
     }
 
     $subnetSt = $db->prepare("SELECT id, cidr, ip_version FROM subnets WHERE id = :id");
@@ -1097,12 +1510,12 @@ function api_addresses_create(PDO $db, array $apiKey, array $body): never
     if ($dupSt->fetch()) api_error(409, 'An address record for this IP already exists in the subnet.');
 
     $db->prepare(
-        "INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, note, grp, mac, expires_at, status)
-         VALUES (:sid, :ip, :b, :hn, :ow, :nt, :grp, :mac, :exp, :st)"
+        "INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, owner_contact_id, note, grp, mac, expires_at, status)
+         VALUES (:sid, :ip, :b, :hn, :ow, :cid, :nt, :grp, :mac, :exp, :st)"
     )->execute([
         ':sid' => $subnetId, ':ip' => $n['ip'], ':b' => $n['bin'],
-        ':hn'  => $hostname,  ':ow' => $owner,   ':nt' => $note,
-        ':grp' => $grp,       ':mac' => $mac,
+        ':hn'  => $hostname,  ':ow' => $owner,  ':cid' => $ownerContactId,
+        ':nt'  => $note,      ':grp' => $grp,   ':mac' => $mac,
         ':exp' => $expiresAt !== '' ? $expiresAt : null,
         ':st'  => $status,
     ]);
@@ -1214,6 +1627,7 @@ function api_subnets_create(PDO $db, array $apiKey, array $body): never
     $description = trim(to_str($body['description'] ?? ''));
     $siteId      = isset($body['site_id']) ? to_int($body['site_id']) : null;
     $vlanId      = isset($body['vlan_id']) ? to_int($body['vlan_id']) : null;
+    $vrfId       = isset($body['vrf_id'])  ? to_int($body['vrf_id'])  : null;
 
     if ($cidr === '') api_error(400, 'cidr is required.');
 
@@ -1230,19 +1644,25 @@ function api_subnets_create(PDO $db, array $apiKey, array $body): never
         if (!$siteSt->fetch()) api_error(404, 'Site not found.');
     }
 
-    // Check duplicate CIDR
+    if ($vrfId !== null) {
+        $vrfSt = $db->prepare("SELECT id FROM vrfs WHERE id = :id");
+        $vrfSt->execute([':id' => $vrfId]);
+        if (!$vrfSt->fetch()) api_error(404, 'VRF not found.');
+    }
+
+    // Check duplicate CIDR within the same VRF (uses IS for NULL-safe comparison)
     $normalized = $p['network'] . '/' . $p['prefix'];
-    $dupSt = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr");
-    $dupSt->execute([':cidr' => $normalized]);
+    $dupSt = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr AND vrf_id IS :vrf");
+    $dupSt->execute([':cidr' => $normalized, ':vrf' => $vrfId]);
     if ($dupSt->fetch()) api_error(409, 'A subnet with this CIDR already exists.');
 
     // Inherit site from tightest parent if one exists
-    $inheritedSiteId = find_parent_site_id($db, $normalized);
+    $inheritedSiteId = find_parent_site_id($db, $normalized, null, $vrfId);
     if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
     $db->prepare(
-        "INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id)
-         VALUES (:cidr, :ver, :net, :nbin, :pfx, :desc, :sid, :vlan)"
+        "INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id, vrf_id)
+         VALUES (:cidr, :ver, :net, :nbin, :pfx, :desc, :sid, :vlan, :vrf)"
     )->execute([
         ':cidr' => $p['network'] . '/' . $p['prefix'],
         ':ver'  => $p['version'],
@@ -1252,6 +1672,7 @@ function api_subnets_create(PDO $db, array $apiKey, array $body): never
         ':desc' => $description,
         ':sid'  => $siteId,
         ':vlan' => $vlanId,
+        ':vrf'  => $vrfId,
     ]);
     $newId = (int)$db->lastInsertId();
 
@@ -1259,7 +1680,7 @@ function api_subnets_create(PDO $db, array $apiKey, array $body): never
         "cidr={$p['network']}/{$p['prefix']}");
 
     // Non-blocking overlap warnings
-    $overlaps = detect_subnet_overlaps($db, $normalized);
+    $overlaps = detect_subnet_overlaps($db, $normalized, null, $vrfId);
     $warnings = [];
     if (!empty($overlaps['parents']) || !empty($overlaps['children'])) {
         $warnings[] = subnet_overlap_warning_text($overlaps);
@@ -1279,7 +1700,7 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
 {
     if ($id <= 0) api_error(400, 'id is required as a query parameter.');
 
-    $st = $db->prepare("SELECT id, cidr, description, site_id, vlan_id FROM subnets WHERE id = :id");
+    $st = $db->prepare("SELECT id, cidr, description, site_id, vlan_id, vlan_fk FROM subnets WHERE id = :id");
     $st->execute([':id' => $id]);
     /** @var array<string, mixed>|false $subnet */
     $subnet = $st->fetch();
@@ -1292,9 +1713,18 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
     $vlanId = array_key_exists('vlan_id', $body)
         ? ($body['vlan_id'] !== null ? to_int($body['vlan_id']) : null)
         : ($subnet['vlan_id'] !== null ? to_int($subnet['vlan_id']) : null);
+    $vlanFk = array_key_exists('vlan_fk', $body)
+        ? ($body['vlan_fk'] !== null ? to_int($body['vlan_fk']) : null)
+        : ($subnet['vlan_fk'] !== null ? to_int($subnet['vlan_fk']) : null);
 
     if ($vlanId !== null && ($vlanId < 1 || $vlanId > 4094)) {
         api_error(400, 'vlan_id must be between 1 and 4094.');
+    }
+
+    if ($vlanFk !== null) {
+        $vfSt = $db->prepare("SELECT id FROM vlans WHERE id = :id");
+        $vfSt->execute([':id' => $vlanFk]);
+        if (!$vfSt->fetch()) api_error(400, 'vlan_fk refers to a non-existent VLAN.');
     }
 
     if ($siteId !== null) {
@@ -1308,8 +1738,8 @@ function api_subnets_update(PDO $db, array $apiKey, int $id, array $body): never
     if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
     $db->prepare(
-        "UPDATE subnets SET description = :desc, site_id = :sid, vlan_id = :vlan WHERE id = :id"
-    )->execute([':desc' => $description, ':sid' => $siteId, ':vlan' => $vlanId, ':id' => $id]);
+        "UPDATE subnets SET description = :desc, site_id = :sid, vlan_id = :vlan, vlan_fk = :vfk WHERE id = :id"
+    )->execute([':desc' => $description, ':sid' => $siteId, ':vlan' => $vlanId, ':vfk' => $vlanFk, ':id' => $id]);
 
     api_audit($db, $apiKey, 'subnet.update', 'subnet', $id, 'cidr=' . to_str($subnet['cidr']));
 

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -793,3 +793,122 @@ body.drawer-ready .drawer-form-card{display:none}
 .tag-picker{display:flex;flex-wrap:wrap;gap:6px;margin:4px 0;}
 .tag-picker label{display:flex;align-items:center;gap:4px;cursor:pointer;font-size:.85rem;}
 .tag-picker input[type=checkbox]{width:14px;height:14px;cursor:pointer;}
+
+
+/* ---- Contact typeahead suggestions ---- */
+.contact-suggestions{
+  position:absolute;z-index:200;top:100%;left:0;right:0;
+  background:var(--card);border:1px solid var(--border);border-radius:4px;
+  margin:0;padding:0;list-style:none;max-height:200px;overflow-y:auto;
+  box-shadow:0 4px 12px rgba(0,0,0,.15);
+}
+.contact-suggestions li{
+  padding:7px 10px;cursor:pointer;font-size:.9rem;
+  border-bottom:1px solid var(--border);
+}
+.contact-suggestions li:last-child{border-bottom:none}
+.contact-suggestions li:hover{background:var(--btn);color:var(--btnfg);}
+
+/* ---- ⌘K / Ctrl+K search overlay (#253) ---- */
+#search-overlay{
+  display:none;position:fixed;inset:0;z-index:1000;
+  background:rgba(0,0,0,.45);align-items:flex-start;justify-content:center;
+  padding-top:12vh;
+}
+#search-overlay.visible{display:flex;}
+.so-box{
+  width:min(640px,94vw);background:var(--card);border:1px solid var(--border);
+  border-radius:8px;box-shadow:0 8px 32px rgba(0,0,0,.3);overflow:hidden;
+}
+#search-overlay-input{
+  display:block;width:100%;box-sizing:border-box;
+  padding:14px 48px 14px 16px;font-size:1.1rem;
+  background:var(--card);color:var(--fg);border:none;border-bottom:1px solid var(--border);
+  outline:none;
+}
+.so-close{
+  position:absolute;right:10px;top:10px;background:none;border:none;
+  font-size:1.4rem;cursor:pointer;color:var(--muted);line-height:1;
+}
+.so-box{position:relative;}
+#search-overlay-list{
+  list-style:none;margin:0;padding:0;max-height:320px;overflow-y:auto;
+}
+.so-item{
+  padding:10px 14px;cursor:pointer;border-bottom:1px solid var(--border);
+  display:flex;align-items:center;gap:8px;font-size:.95rem;
+}
+.so-item:last-child{border-bottom:none}
+.so-item:hover,.so-item.active{background:var(--btn);color:var(--btnfg);}
+.so-item:hover .so-status,.so-item.active .so-status{
+  background:rgba(255,255,255,.2);color:inherit;
+}
+.so-ip{font-weight:600;font-family:monospace;font-size:1rem;}
+.so-host{color:var(--muted);font-size:.88rem;}
+.so-item:hover .so-host,.so-item.active .so-host{color:inherit;opacity:.8;}
+.so-status{font-size:.78rem;padding:1px 6px;border-radius:3px;margin-left:auto;}
+.so-loading,.so-empty{
+  padding:14px 16px;color:var(--muted);text-align:center;font-size:.92rem;
+}
+.so-hint{
+  padding:6px 14px;font-size:.78rem;color:var(--muted);
+  border-top:1px solid var(--border);text-align:right;
+}
+.so-hint kbd{
+  background:var(--border);border-radius:3px;padding:1px 4px;font-size:.75rem;
+}
+/* ---- Dashboard widgets (#257) ---- */
+.widget-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;}
+.widget-header h2{margin:0;}
+.widget-hide-btn{
+  background:none;border:none;cursor:pointer;color:var(--muted);
+  font-size:1rem;padding:2px 6px;border-radius:4px;line-height:1;
+}
+.widget-hide-btn:hover{background:var(--border);color:var(--fg);}
+
+/* ---- Column visibility (#256) ---- */
+.col-hidden{display:none;}
+.col-vis-wrap{position:relative;display:inline-block;}
+.col-vis-gear{font-size:.82rem;}
+.col-vis-drop{
+  display:none;position:absolute;right:0;top:100%;z-index:300;
+  background:var(--card);border:1px solid var(--border);border-radius:6px;
+  padding:8px 12px;min-width:140px;box-shadow:0 4px 12px rgba(0,0,0,.15);
+}
+.col-vis-drop.visible{display:block;}
+.col-vis-drop label{display:flex;align-items:center;gap:6px;padding:3px 0;cursor:pointer;font-size:.88rem;white-space:nowrap;}
+
+/* ---- Subnet map view (#255) ---- */
+.subnet-view-btn{margin-left:4px;}
+.subnet-view-btn.active{background:var(--btn);color:var(--btnfg);font-weight:600;}
+.map-group{border-left:2px solid var(--border);padding-left:10px;margin-bottom:20px;}
+.map-group-label{font-weight:600;margin-bottom:8px;color:var(--muted);}
+.map-node{position:relative;}
+.map-node-inner{
+  display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+  padding:4px 6px;border-radius:4px;margin-bottom:3px;
+  border-left:2px solid var(--border);
+}
+.map-node-inner:hover{background:rgba(0,0,0,.04);}
+html[data-theme=dark] .map-node-inner:hover{background:rgba(255,255,255,.06);}
+.map-cidr{font-weight:600;font-family:monospace;}
+.map-desc{font-size:.85rem;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.map-util{display:flex;align-items:center;gap:5px;margin-left:auto;}
+.map-util .util-bar{width:60px;}
+.map-pct{font-size:.8rem;min-width:30px;}
+.map-cap{padding:8px 12px;color:var(--muted);font-style:italic;font-size:.9rem;}
+
+/* ---- Inline cell editing (#254) ---- */
+td[data-editable]:hover{background:var(--btn);color:var(--btnfg);border-radius:3px;}
+td[data-editable].cell-saving{opacity:.5;}
+.inline-edit-input{
+  width:100%;box-sizing:border-box;padding:2px 4px;font:inherit;
+  background:var(--bg);color:var(--fg);border:1px solid var(--btn);border-radius:3px;
+  outline:none;
+}
+
+.nav-search-key{
+  font-size:.75rem;padding:2px 7px;background:none;border:1px solid var(--border);
+  border-radius:4px;cursor:pointer;color:var(--muted);line-height:1.6;
+}
+.nav-search-key:hover{background:var(--btn);color:var(--btnfg);border-color:var(--btn);}

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -750,6 +750,15 @@
           overlay.classList.contains("visible") ? closeOverlay() : openOverlay();
         }
       });
+
+      // Delegated handler for the ⌘K nav button (replaces inline onclick removed for CSP compliance)
+      document.addEventListener("click", function(e) {
+        var btn = e.target.closest(".nav-search-key");
+        if (btn) {
+          e.preventDefault();
+          overlay.classList.contains("visible") ? closeOverlay() : openOverlay();
+        }
+      });
     }());
   });
 })();

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -592,11 +592,14 @@
         input.select();
 
         var csrf = document.querySelector("input[name=csrf]");
+        var isSaving = false;
 
         function save() {
+          if (isSaving) return;
           var newVal = input.value;
           if (newVal === origText) { cell.innerHTML = origHtml; return; }
           if (!csrf) { cell.innerHTML = origHtml; return; }
+          isSaving = true;
           var fd = new FormData();
           fd.append("csrf",   csrf.value);
           fd.append("action", "update_cell");
@@ -608,6 +611,7 @@
             .then(function(r) { return r.json(); })
             .then(function(data) {
               cell.classList.remove("cell-saving");
+              isSaving = false;
               if (data.ok) {
                 cell.innerHTML = data.value
                   ? data.value.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")
@@ -619,6 +623,7 @@
             })
             .catch(function() {
               cell.classList.remove("cell-saving");
+              isSaving = false;
               cell.innerHTML = origHtml;
             });
         }
@@ -637,6 +642,7 @@
         });
         input.addEventListener("blur", function() {
           setTimeout(function() {
+            if (isSaving) return;
             if (cell.querySelector("input") === input) save();
           }, 100);
         });

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -736,10 +736,19 @@
             window.location.href = "search.php?q=" + encodeURIComponent(overlayInput.value.trim());
           }
         } else if (e.key === "Escape") { closeOverlay(); }
-        else if (e.key === "Tab") { closeOverlay(); }
+        else if (e.key === "Tab") {
+          e.preventDefault();
+          if (overlayClose) overlayClose.focus();
+        }
       });
 
-      if (overlayClose) overlayClose.addEventListener("click", closeOverlay);
+      if (overlayClose) {
+        overlayClose.addEventListener("click", closeOverlay);
+        overlayClose.addEventListener("keydown", function(e) {
+          if (e.key === "Tab") { e.preventDefault(); overlayInput.focus(); }
+          if (e.key === "Escape") { closeOverlay(); }
+        });
+      }
       overlay.addEventListener("mousedown", function(e) {
         if (e.target === overlay) closeOverlay();
       });

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -347,5 +347,409 @@
         document.body.appendChild(overlay);
       });
     }
+
+    // --- Contact typeahead (data-contact-typeahead) ---
+    document.querySelectorAll("[data-contact-typeahead]").forEach(function(input) {
+      var hiddenInput = input.parentElement.querySelector("input[name=owner_contact_id]");
+      if (!hiddenInput) return;
+      var list = document.createElement("ul");
+      list.className = "contact-suggestions";
+      list.style.display = "none";
+      input.parentElement.style.position = "relative";
+      input.parentElement.appendChild(list);
+      var timer;
+
+      function clearSuggestions() {
+        list.innerHTML = "";
+        list.style.display = "none";
+      }
+
+      input.addEventListener("input", function() {
+        hiddenInput.value = "0";
+        clearTimeout(timer);
+        var q = input.value.trim();
+        if (q.length < 2) { clearSuggestions(); return; }
+        timer = setTimeout(function() {
+          fetch("api.php?resource=contacts&q=" + encodeURIComponent(q) + "&limit=10", {credentials: "same-origin"})
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+              clearSuggestions();
+              if (!data.contacts || !data.contacts.length) return;
+              data.contacts.forEach(function(c) {
+                var li = document.createElement("li");
+                li.textContent = c.name + (c.email ? " <" + c.email + ">" : "");
+                li.dataset.contactId   = c.id;
+                li.dataset.contactName = c.name;
+                li.addEventListener("mousedown", function(e) {
+                  e.preventDefault();
+                  input.value = c.name;
+                  hiddenInput.value = c.id;
+                  clearSuggestions();
+                });
+                list.appendChild(li);
+              });
+              list.style.display = "block";
+            })
+            .catch(function() { clearSuggestions(); });
+        }, 250);
+      });
+
+      input.addEventListener("blur", function() {
+        setTimeout(clearSuggestions, 200);
+      });
+
+      input.addEventListener("keydown", function(e) {
+        if (e.key === "Escape") { clearSuggestions(); }
+      });
+    });
+
+    // --- Dashboard pinnable widgets + site filter (#257) ---
+    (function() {
+      var HIDDEN_KEY = "ipam_hidden_widgets";
+      var SITE_KEY   = "ipam_dash_site";
+
+      function hiddenList() {
+        try { return JSON.parse(localStorage.getItem(HIDDEN_KEY) || "[]"); } catch(e) { return []; }
+      }
+
+      function applyWidgetVisibility() {
+        var hidden = hiddenList();
+        document.querySelectorAll("[data-widget]").forEach(function(el) {
+          el.style.display = hidden.includes(el.dataset.widget) ? "none" : "";
+        });
+      }
+
+      applyWidgetVisibility();
+
+      document.querySelectorAll(".widget-hide-btn").forEach(function(btn) {
+        btn.addEventListener("click", function() {
+          var key    = btn.dataset.widgetKey;
+          var hidden = hiddenList();
+          if (!hidden.includes(key)) hidden.push(key);
+          localStorage.setItem(HIDDEN_KEY, JSON.stringify(hidden));
+          applyWidgetVisibility();
+        });
+      });
+
+      var resetBtn = document.getElementById("dash-reset");
+      if (resetBtn) {
+        resetBtn.addEventListener("click", function(e) {
+          e.preventDefault();
+          // Clear all ipam_ localStorage keys
+          Object.keys(localStorage).filter(function(k) { return k.startsWith("ipam_"); })
+                .forEach(function(k) { localStorage.removeItem(k); });
+          location.reload();
+        });
+      }
+
+      // Site filter on "by-site" table
+      var siteFilter = document.getElementById("dash-site-filter");
+      if (siteFilter) {
+        function applyFilter() {
+          var val = siteFilter.value;
+          localStorage.setItem(SITE_KEY, val);
+          document.querySelectorAll("[data-site-row]").forEach(function(tr) {
+            tr.style.display = (val === "" || tr.dataset.siteRow === val) ? "" : "none";
+          });
+        }
+        siteFilter.addEventListener("change", applyFilter);
+        var saved = localStorage.getItem(SITE_KEY) || "";
+        if (saved) { siteFilter.value = saved; }
+        applyFilter();
+      }
+    }());
+
+    // --- Per-user column visibility (#256) ---
+    document.querySelectorAll("[data-col-table]").forEach(function(table) {
+      var key    = "ipam_cols_" + table.dataset.colTable;
+      var hidden = JSON.parse(localStorage.getItem(key) || "[]");
+      var ths    = Array.from(table.querySelectorAll("thead th[data-col]"));
+      if (!ths.length) return;
+
+      function setColVisible(col, visible) {
+        var idx = ths.findIndex(function(th) { return th.dataset.col === col; });
+        if (idx < 0) return;
+        var allCells = [ths[idx]].concat(
+          Array.from(table.querySelectorAll("tbody tr")).map(function(tr) {
+            return tr.cells[idx];
+          }).filter(Boolean)
+        );
+        allCells.forEach(function(c) { c.classList.toggle("col-hidden", !visible); });
+      }
+
+      function saveAndApply(hiddenArr) {
+        hidden = hiddenArr;
+        localStorage.setItem(key, JSON.stringify(hidden));
+        ths.forEach(function(th) { setColVisible(th.dataset.col, !hidden.includes(th.dataset.col)); });
+        // keep at least one visible
+        var visCount = ths.filter(function(th) { return !hidden.includes(th.dataset.col); }).length;
+        if (visCount === 0 && ths[0]) {
+          hidden = hidden.filter(function(c) { return c !== ths[0].dataset.col; });
+          localStorage.setItem(key, JSON.stringify(hidden));
+          setColVisible(ths[0].dataset.col, true);
+        }
+        syncChecks();
+      }
+
+      // Build gear dropdown
+      var wrapper = document.createElement("div");
+      wrapper.className = "col-vis-wrap";
+      var gear = document.createElement("button");
+      gear.className = "col-vis-gear action-pill";
+      gear.textContent = "\u2699 Columns";
+      gear.setAttribute("aria-expanded", "false");
+      var drop = document.createElement("div");
+      drop.className = "col-vis-drop";
+      ths.forEach(function(th) {
+        var label = document.createElement("label");
+        var cb    = document.createElement("input");
+        cb.type   = "checkbox";
+        cb.dataset.col = th.dataset.col;
+        cb.checked = !hidden.includes(th.dataset.col);
+        cb.addEventListener("change", function() {
+          var newHidden = ths.map(function(t) { return t.dataset.col; })
+            .filter(function(c) {
+              var cbEl = drop.querySelector("input[data-col='" + c + "']");
+              return cbEl && !cbEl.checked;
+            });
+          saveAndApply(newHidden);
+        });
+        label.appendChild(cb);
+        label.appendChild(document.createTextNode(" " + th.textContent.trim()));
+        drop.appendChild(label);
+      });
+      wrapper.appendChild(gear);
+      wrapper.appendChild(drop);
+
+      function syncChecks() {
+        drop.querySelectorAll("input[data-col]").forEach(function(cb) {
+          cb.checked = !hidden.includes(cb.dataset.col);
+        });
+      }
+
+      gear.addEventListener("click", function(e) {
+        e.stopPropagation();
+        var open = drop.classList.toggle("visible");
+        gear.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+      document.addEventListener("click", function() { drop.classList.remove("visible"); gear.setAttribute("aria-expanded","false"); });
+
+      // Insert gear before table or into a toolbar if present
+      var toolbar = table.closest(".card") && table.closest(".card").querySelector(".toolbar");
+      if (toolbar) {
+        toolbar.appendChild(wrapper);
+      } else {
+        table.parentNode.insertBefore(wrapper, table);
+      }
+
+      // Apply persisted hidden columns
+      hidden.forEach(function(col) { setColVisible(col, false); });
+    });
+
+    // --- Subnet list/map view toggle (#255) ---
+    (function() {
+      var listView = document.getElementById("subnet-list-view");
+      var mapView  = document.getElementById("subnet-map-view");
+      var btns     = document.querySelectorAll(".subnet-view-btn");
+      if (!listView || !mapView) return;
+      var storageKey = "ipam_subnet_view";
+
+      function applyView(v) {
+        var isMap = v === "map";
+        listView.style.display = isMap ? "none" : "";
+        mapView.style.display  = isMap ? ""     : "none";
+        btns.forEach(function(b) {
+          b.classList.toggle("active", b.dataset.view === v);
+        });
+        localStorage.setItem(storageKey, v);
+      }
+
+      btns.forEach(function(b) {
+        b.addEventListener("click", function() { applyView(b.dataset.view); });
+      });
+
+      applyView(localStorage.getItem(storageKey) === "map" ? "map" : "list");
+    }());
+
+    // --- Inline cell editing on address rows (#254) ---
+    document.querySelectorAll("[data-editable][data-addr-id]").forEach(function(cell) {
+      cell.title = "Click to edit";
+      cell.style.cursor = "pointer";
+      cell.addEventListener("click", function(e) {
+        if (cell.querySelector("input")) return; // already editing
+        var field   = cell.dataset.editable;
+        var addrId  = cell.dataset.addrId;
+        var origHtml = cell.innerHTML;
+        var origText = cell.textContent.trim();
+
+        var input = document.createElement("input");
+        input.type = "text";
+        input.value = origText;
+        input.className = "inline-edit-input";
+        cell.innerHTML = "";
+        cell.appendChild(input);
+        input.focus();
+        input.select();
+
+        var csrf = document.querySelector("input[name=csrf]");
+
+        function save() {
+          var newVal = input.value;
+          if (newVal === origText) { cell.innerHTML = origHtml; return; }
+          if (!csrf) { cell.innerHTML = origHtml; return; }
+          var fd = new FormData();
+          fd.append("csrf",   csrf.value);
+          fd.append("action", "update_cell");
+          fd.append("id",     addrId);
+          fd.append("field",  field);
+          fd.append("value",  newVal);
+          cell.classList.add("cell-saving");
+          fetch("addresses.php", {method: "POST", body: fd})
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+              cell.classList.remove("cell-saving");
+              if (data.ok) {
+                cell.innerHTML = data.value
+                  ? data.value.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;")
+                  : "";
+              } else {
+                cell.innerHTML = origHtml;
+                cell.title = data.error || "Save failed";
+              }
+            })
+            .catch(function() {
+              cell.classList.remove("cell-saving");
+              cell.innerHTML = origHtml;
+            });
+        }
+
+        input.addEventListener("keydown", function(e) {
+          if (e.key === "Enter")  { e.preventDefault(); save(); }
+          if (e.key === "Escape") { e.preventDefault(); cell.innerHTML = origHtml; }
+          if (e.key === "Tab") {
+            e.preventDefault();
+            save();
+            // Move to next editable cell in the same row
+            var cells = Array.from(cell.closest("tr").querySelectorAll("[data-editable]"));
+            var idx = cells.indexOf(cell);
+            if (idx >= 0 && cells[idx + 1]) cells[idx + 1].click();
+          }
+        });
+        input.addEventListener("blur", function() {
+          setTimeout(function() {
+            if (cell.querySelector("input") === input) save();
+          }, 100);
+        });
+      });
+    });
+
+    // --- Global ⌘K / Ctrl+K search overlay (#253) ---
+    (function() {
+      var overlay = document.getElementById("search-overlay");
+      if (!overlay) return;
+      var overlayInput  = document.getElementById("search-overlay-input");
+      var overlayList   = document.getElementById("search-overlay-list");
+      var overlayClose  = document.getElementById("search-overlay-close");
+      var searchTimer;
+      var activeIdx = -1;
+
+      function openOverlay() {
+        overlay.classList.add("visible");
+        overlayInput.value = "";
+        overlayList.innerHTML = "";
+        activeIdx = -1;
+        overlayInput.focus();
+      }
+
+      function closeOverlay() {
+        overlay.classList.remove("visible");
+        clearTimeout(searchTimer);
+      }
+
+      function setActive(idx) {
+        var items = overlayList.querySelectorAll(".so-item");
+        if (activeIdx >= 0 && items[activeIdx]) items[activeIdx].classList.remove("active");
+        activeIdx = Math.max(-1, Math.min(idx, items.length - 1));
+        if (activeIdx >= 0 && items[activeIdx]) {
+          items[activeIdx].classList.add("active");
+          items[activeIdx].scrollIntoView({block: "nearest"});
+        }
+      }
+
+      function runSearch(q) {
+        overlayList.innerHTML = '<li class="so-loading">Searching\u2026</li>';
+        activeIdx = -1;
+        fetch("search.php?format=json&q=" + encodeURIComponent(q), {credentials: "same-origin"})
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            overlayList.innerHTML = "";
+            if (!data.length) {
+              overlayList.innerHTML = '<li class="so-empty">No results.</li>';
+              return;
+            }
+            data.forEach(function(row) {
+              var li = document.createElement("li");
+              li.className = "so-item";
+              li.innerHTML =
+                '<span class="so-ip">' + escHtml(row.ip) + '</span>'
+                + (row.hostname ? ' <span class="so-host">' + escHtml(row.hostname) + '</span>' : '')
+                + ' <span class="so-status status-' + escHtml(row.status) + '">' + escHtml(row.status) + '</span>';
+              li.dataset.url = row.url;
+              li.addEventListener("mousedown", function(e) {
+                e.preventDefault();
+                window.location.href = row.url;
+              });
+              overlayList.appendChild(li);
+            });
+          })
+          .catch(function() {
+            overlayList.innerHTML = '<li class="so-empty">Search failed.</li>';
+          });
+      }
+
+      function escHtml(s) {
+        return String(s)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;");
+      }
+
+      overlayInput.addEventListener("input", function() {
+        clearTimeout(searchTimer);
+        var q = overlayInput.value.trim();
+        overlayList.innerHTML = "";
+        activeIdx = -1;
+        if (q.length < 2) return;
+        searchTimer = setTimeout(function() { runSearch(q); }, 300);
+      });
+
+      overlayInput.addEventListener("keydown", function(e) {
+        var items = overlayList.querySelectorAll(".so-item");
+        if (e.key === "ArrowDown") { e.preventDefault(); setActive(activeIdx + 1); }
+        else if (e.key === "ArrowUp") { e.preventDefault(); setActive(activeIdx - 1); }
+        else if (e.key === "Enter") {
+          e.preventDefault();
+          if (activeIdx >= 0 && items[activeIdx]) {
+            window.location.href = items[activeIdx].dataset.url;
+          } else if (overlayInput.value.trim() !== "") {
+            window.location.href = "search.php?q=" + encodeURIComponent(overlayInput.value.trim());
+          }
+        } else if (e.key === "Escape") { closeOverlay(); }
+        else if (e.key === "Tab") { closeOverlay(); }
+      });
+
+      if (overlayClose) overlayClose.addEventListener("click", closeOverlay);
+      overlay.addEventListener("mousedown", function(e) {
+        if (e.target === overlay) closeOverlay();
+      });
+
+      document.addEventListener("keydown", function(e) {
+        if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+          e.preventDefault();
+          overlay.classList.contains("visible") ? closeOverlay() : openOverlay();
+        }
+      });
+    }());
   });
 })();

--- a/Simple-PHP-IPAM/contacts.php
+++ b/Simple-PHP-IPAM/contacts.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+/** @var \PDO $db */
+require_role('admin');
+if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
+
+$err = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = to_str($_POST['action'] ?? '');
+
+    if (demo_mode_enabled() && in_array($action, ['create', 'update', 'delete'], true)) {
+        $err = 'This action is disabled in demo mode.';
+        $action = '';
+    }
+
+    if ($action === 'create') {
+        $name  = trim(to_str($_POST['name']  ?? ''));
+        $email = trim(to_str($_POST['email'] ?? ''));
+        $phone = trim(to_str($_POST['phone'] ?? ''));
+        $org   = trim(to_str($_POST['org']   ?? ''));
+        $note  = trim(to_str($_POST['note']  ?? ''));
+
+        if ($name === '') {
+            $err = 'Contact name is required.';
+        } else {
+            $st = $db->prepare("INSERT INTO contacts (name, email, phone, org, note) VALUES (:n,:e,:p,:o,:nt)");
+            $st->execute([':n' => $name, ':e' => $email, ':p' => $phone, ':o' => $org, ':nt' => $note]);
+            $newId = (int)$db->lastInsertId();
+            audit($db, 'contact.create', 'contact', $newId, "name=$name");
+            flash_set("Contact \"$name\" created.");
+            header('Location: contacts.php');
+            exit;
+        }
+    } elseif ($action === 'update') {
+        $id    = to_int($_POST['id']    ?? 0);
+        $name  = trim(to_str($_POST['name']  ?? ''));
+        $email = trim(to_str($_POST['email'] ?? ''));
+        $phone = trim(to_str($_POST['phone'] ?? ''));
+        $org   = trim(to_str($_POST['org']   ?? ''));
+        $note  = trim(to_str($_POST['note']  ?? ''));
+
+        if ($id <= 0 || $name === '') {
+            $err = 'Contact name is required.';
+        } else {
+            $st = $db->prepare("UPDATE contacts SET name=:n, email=:e, phone=:p, org=:o, note=:nt, updated_at=datetime('now') WHERE id=:id");
+            $st->execute([':n' => $name, ':e' => $email, ':p' => $phone, ':o' => $org, ':nt' => $note, ':id' => $id]);
+            audit($db, 'contact.update', 'contact', $id, "name=$name");
+            flash_set("Contact \"$name\" updated.");
+            header('Location: contacts.php');
+            exit;
+        }
+    } elseif ($action === 'delete') {
+        $id = to_int($_POST['id'] ?? 0);
+        if ($id > 0) {
+            $nameSt = $db->prepare("SELECT name FROM contacts WHERE id = :id");
+            $nameSt->execute([':id' => $id]);
+            /** @var array<string, mixed>|false $row */
+            $row = $nameSt->fetch();
+            // ON DELETE SET NULL on addresses.owner_contact_id handles FK cleanup
+            $db->prepare("DELETE FROM contacts WHERE id = :id")->execute([':id' => $id]);
+            audit($db, 'contact.delete', 'contact', $id, $row ? 'name=' . to_str($row['name']) : '');
+            flash_set('Contact deleted.');
+            header('Location: contacts.php');
+            exit;
+        }
+    }
+}
+
+$sortCols = ['name' => 'c.name', 'email' => 'c.email', 'org' => 'c.org', 'created' => 'c.created_at'];
+$sort = parse_sort($sortCols, 'name');
+
+/** @var list<array<string, mixed>> $contacts */
+$contacts = ($db->query("
+    SELECT c.id, c.name, c.email, c.phone, c.org, c.note, c.created_at,
+           (SELECT COUNT(*) FROM addresses a WHERE a.owner_contact_id = c.id) AS address_count
+    FROM contacts c
+    ORDER BY {$sort['sql']}
+") ?: throw new \RuntimeException('Query failed'))->fetchAll();
+
+page_header('Contacts');
+?>
+<div class="breadcrumbs">
+  <a href="dashboard.php">Dashboard</a><span class="sep">›</span>
+  <a href="#">Admin</a><span class="sep">›</span>
+  <span>Contacts</span>
+</div>
+
+<div class="toolbar">
+  <div>
+    <h1>Contacts</h1>
+    <div class="muted">Reusable contact records that can be linked to address entries as the owner.</div>
+  </div>
+</div>
+
+<?php if ($err): ?><p class="danger"><?= e($err) ?></p><?php endif; ?>
+
+<div class="grid cols-2">
+  <div class="card" id="add-contact">
+    <h2>Add Contact</h2>
+    <form method="post" action="contacts.php">
+      <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+      <input type="hidden" name="action" value="create">
+      <div class="row">
+        <label class="flex-1">Name (required)<br><input name="name" required placeholder="e.g. Jane Smith" class="w-full"></label>
+        <label class="flex-1">Email<br><input name="email" type="email" placeholder="jane@example.com" class="w-full"></label>
+      </div>
+      <div class="row">
+        <label class="mw-160">Phone<br><input name="phone" placeholder="+1 555 0100" class="w-full"></label>
+        <label class="flex-1">Organisation<br><input name="org" placeholder="Acme Corp" class="w-full"></label>
+      </div>
+      <div class="row">
+        <label class="flex-1">Note<br><input name="note" class="w-full"></label>
+      </div>
+      <p><button type="submit">Create Contact</button></p>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Overview</h2>
+    <div class="grid cols-2">
+      <div class="metric">
+        <div class="label">Contacts</div>
+        <div class="value"><?= e((string)count($contacts)) ?></div>
+      </div>
+      <div class="metric">
+        <div class="label">Linked addresses</div>
+        <div class="value"><?= e((string)array_sum(array_map(fn($c) => to_int($c['address_count']), $contacts))) ?></div>
+      </div>
+    </div>
+    <p class="muted mt-8">Contacts are linked to addresses via the Owner field. Deleting a contact unlinks it from all addresses (free-text owner value is retained).</p>
+  </div>
+</div>
+
+<div class="card mt-16">
+  <h2>Existing Contacts</h2>
+
+  <?php if (!$contacts): ?>
+    <div class="empty-state">No contacts yet. <a class="action-pill" href="#add-contact">+ Add Contact</a></div>
+  <?php else: ?>
+    <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <?php $qs = '?';
+                echo sort_th('name',    'Name',         $sort['col'], $sort['dir'], $qs);
+                echo sort_th('email',   'Email',        $sort['col'], $sort['dir'], $qs);
+          ?>
+          <th>Phone</th>
+          <?php echo sort_th('org', 'Organisation', $sort['col'], $sort['dir'], $qs); ?>
+          <th>Note</th>
+          <th>Addresses</th>
+          <?php echo sort_th('created', 'Created', $sort['col'], $sort['dir'], $qs); ?>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+      <?php foreach ($contacts as $c): ?>
+        <tr>
+          <td><b><?= e(to_str($c['name'])) ?></b></td>
+          <td><?php if ($c['email'] !== ''): ?><a href="mailto:<?= e(to_str($c['email'])) ?>"><?= e(to_str($c['email'])) ?></a><?php else: ?><span class="muted">—</span><?php endif; ?></td>
+          <td><?= $c['phone'] !== '' ? e(to_str($c['phone'])) : '<span class="muted">—</span>' ?></td>
+          <td><?= $c['org']   !== '' ? e(to_str($c['org']))   : '<span class="muted">—</span>' ?></td>
+          <td><?= $c['note']  !== '' ? e(to_str($c['note']))  : '<span class="muted">—</span>' ?></td>
+          <td><?= to_int($c['address_count']) ?></td>
+          <td class="muted"><?= e(to_str($c['created_at'])) ?></td>
+          <td>
+            <details>
+              <summary>Edit/Delete</summary>
+              <form method="post" action="contacts.php" class="mt-8">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id"     value="<?= to_int($c['id']) ?>">
+                <div class="row">
+                  <label>Name<br><input name="name"  value="<?= e(to_str($c['name'])) ?>" required></label>
+                  <label>Email<br><input name="email" type="email" value="<?= e(to_str($c['email'])) ?>"></label>
+                  <label>Phone<br><input name="phone" value="<?= e(to_str($c['phone'])) ?>"></label>
+                  <label>Organisation<br><input name="org" value="<?= e(to_str($c['org'])) ?>"></label>
+                  <label class="flex-1">Note<br><input name="note" value="<?= e(to_str($c['note'])) ?>" class="w-full"></label>
+                  <button type="submit">Save</button>
+                </div>
+              </form>
+              <form method="post" action="contacts.php" class="mt-8"
+                    data-confirm="Delete this contact? The owner field on linked addresses will be kept but the contact link will be removed.">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="id"     value="<?= to_int($c['id']) ?>">
+                <button type="submit" class="button-danger">Delete</button>
+              </form>
+            </details>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+    </div>
+  <?php endif; ?>
+</div>
+
+<?php page_footer(); ?>

--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -115,9 +115,10 @@ page_header('Dashboard');
   <?php if (current_user()['role'] === 'admin'): ?>
     <a class="action-pill" href="import_csv.php">📥 Import CSV</a>
   <?php endif; ?>
+  <a class="action-pill muted" href="#" id="dash-reset" title="Reset widget layout and filters">↺ Reset widgets</a>
 </div>
 
-<div class="grid cols-3 mt-16">
+<div class="grid cols-3 mt-16" data-widget="metrics">
   <div class="metric"><div class="label">Subnets</div><div class="value"><?= e((string)$totalSubnets) ?></div></div>
   <div class="metric"><div class="label">Addresses (rows)</div><div class="value"><?= e((string)$totalAddrs) ?></div></div>
   <div class="metric"><div class="label">Used</div><div class="value status-used"><?= e(to_str($statusMap['used'])) ?></div></div>
@@ -130,8 +131,11 @@ page_header('Dashboard');
 
 <div class="grid cols-2 mt-16">
 
-  <div class="card">
-    <h2>Top IPv4 Subnets by Usage</h2>
+  <div class="card" data-widget="top-subnets">
+    <div class="widget-header">
+      <h2>Top IPv4 Subnets by Usage</h2>
+      <button class="widget-hide-btn" data-widget-key="top-subnets" title="Hide widget">&#10005;</button>
+    </div>
     <?php if (!$topSubnets): ?>
       <div class="empty-state">No IPv4 subnets in /8–/32 range.</div>
     <?php else: ?>
@@ -169,18 +173,29 @@ page_header('Dashboard');
     <div class="mt-10"><a class="action-pill" href="subnets.php">🌐 All Subnets</a></div>
   </div>
 
-  <div class="card">
-    <h2>Addresses by Site</h2>
+  <div class="card" data-widget="by-site">
+    <div class="widget-header">
+      <h2>Addresses by Site</h2>
+      <button class="widget-hide-btn" data-widget-key="by-site" title="Hide widget">&#10005;</button>
+    </div>
     <?php if (!$bySite): ?>
       <div class="empty-state">No data yet.</div>
     <?php else: ?>
+      <div class="mb-8">
+        <select id="dash-site-filter" class="action-pill">
+          <option value="">(all sites)</option>
+          <?php foreach ($bySite as $r): ?>
+            <option value="<?= e(to_str($r['site_name'])) ?>"><?= e(to_str($r['site_name'])) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </div>
       <table>
         <thead>
           <tr><th>Site</th><th>Used</th><th>Reserved</th><th>Free</th><th>Total</th></tr>
         </thead>
         <tbody>
         <?php foreach ($bySite as $r): ?>
-          <tr>
+          <tr data-site-row="<?= e(to_str($r['site_name'])) ?>">
             <td><?= e(to_str($r['site_name'])) ?></td>
             <td class="status-used"><?= e(to_str($r['used'])) ?></td>
             <td class="status-reserved"><?= e(to_str($r['reserved'])) ?></td>
@@ -198,8 +213,11 @@ page_header('Dashboard');
 
 </div>
 
-<div class="card mt-16">
-  <h2>Recent Activity</h2>
+<div class="card mt-16" data-widget="recent-activity">
+  <div class="widget-header">
+    <h2>Recent Activity</h2>
+    <button class="widget-hide-btn" data-widget-key="recent-activity" title="Hide widget">&#10005;</button>
+  </div>
   <?php if (!$recentAudit): ?>
     <div class="empty-state">No audit events yet.</div>
   <?php else: ?>

--- a/Simple-PHP-IPAM/db_tools.php
+++ b/Simple-PHP-IPAM/db_tools.php
@@ -145,19 +145,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'impor
                         );
                     }
                     // CREATE TRIGGER bodies can contain arbitrary SQL. Only allow
-                    // triggers that match one of two known-safe patterns:
+                    // triggers that match one of three known-safe patterns:
                     //   1. RAISE(ABORT, ...) — append-only guards on audit_log
                     //   2. UPDATE <table> SET updated_at = datetime('now') WHERE id = OLD.id
                     //      — the timestamp maintenance triggers on users/subnets/addresses
-                    // Pattern 2 is matched strictly: the entire trigger body must be that
-                    // single UPDATE statement with no other statements before or after it.
+                    //   3. UPDATE <table> SET <col> = NULL WHERE <col> = OLD.id
+                    //      — FK cleanup triggers (e.g. vlans_before_delete_cleanup_subnets)
+                    // Patterns 2 and 3 are matched strictly: the entire trigger body must be
+                    // that single UPDATE statement with no other statements before or after it.
                     if (preg_match('/^CREATE\s+TRIGGER/i', $exec)) {
                         $isRaise     = preg_match('/RAISE\s*\(\s*ABORT/i', $exec);
                         $isTimestamp = preg_match(
                             '/\bBEGIN\s+UPDATE\s+\w+\s+SET\s+updated_at\s*=\s*datetime\s*\(\s*\'now\'\s*\)\s+WHERE\s+id\s*=\s*OLD\.id\s*;\s*END\b/is',
                             $exec
                         );
-                        if (!$isRaise && !$isTimestamp) {
+                        $isFkCleanup = preg_match(
+                            '/\bBEGIN\s+UPDATE\s+\w+\s+SET\s+\w+\s*=\s*NULL\s+WHERE\s+\w+\s*=\s*OLD\.id\s*;\s*END\b/is',
+                            $exec
+                        );
+                        if (!$isRaise && !$isTimestamp && !$isFkCleanup) {
                             throw new RuntimeException(
                                 'Blocked CREATE TRIGGER with non-RAISE body: ' . substr($exec, 0, 80)
                             );

--- a/Simple-PHP-IPAM/demo_gate.php
+++ b/Simple-PHP-IPAM/demo_gate.php
@@ -71,8 +71,8 @@ $appName = trim(to_str($config['app_name'] ?? '')) ?: 'Simple PHP IPAM';
   <link rel="icon" type="image/webp" sizes="32x32" href="assets/favicon-32.webp">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
-  <link rel="stylesheet" href="assets/app.css?v=2.0.0">
-  <script defer src="assets/app.js?v=2.0.0"></script>
+  <link rel="stylesheet" href="assets/app.css?v=2.1.0">
+  <script defer src="assets/app.js?v=2.1.0"></script>
 </head>
 <body>
 <div class="gate-wrap">

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -2599,7 +2599,7 @@ function page_header(string $title, array $opts = []): void
         echo "<a class='nav-pill' href='subnets.php'>🌐 Subnets</a>";
         echo "<a class='nav-pill' href='addresses.php'>🧾 Addresses</a>";
         echo "<a class='nav-pill' href='search.php'>🔎 Search</a>";
-        echo "<button class='nav-pill nav-search-key' onclick='document.dispatchEvent(new KeyboardEvent(\"keydown\",{key:\"k\",ctrlKey:true,bubbles:true}))' title='Quick search (Ctrl+K / \u2318K)'>\u2318K</button>";
+        echo "<button class='nav-pill nav-search-key' title='Quick search (Ctrl+K / \u2318K)'>\u2318K</button>";
         echo "<a class='nav-pill' href='audit.php'>📜 Audit</a>";
         if ($role === 'admin') {
             echo "<div class='nav-dropdown'>";
@@ -2906,10 +2906,10 @@ function find_parent_site_id(PDO $db, string $cidr, ?int $excludeId = null, ?int
     $placeholders = implode(',', array_fill(0, count($overlaps['parents']), '?'));
     $st = $db->prepare(
         "SELECT site_id FROM subnets
-         WHERE cidr IN ($placeholders) AND site_id IS NOT NULL
+         WHERE cidr IN ($placeholders) AND site_id IS NOT NULL AND vrf_id IS ?
          ORDER BY prefix DESC LIMIT 1"
     );
-    $st->execute($overlaps['parents']);
+    $st->execute(array_merge($overlaps['parents'], [$vrfId]));
     /** @var array<string, mixed>|false $row */
     $row = $st->fetch();
     return $row ? to_int($row['site_id']) : null;

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -15,6 +15,7 @@ function ipam_db(string $path): PDO
     ]);
 
     $pdo->exec("PRAGMA journal_mode = WAL;");
+    $pdo->exec("PRAGMA busy_timeout = 30000;");
     $pdo->exec("PRAGMA foreign_keys = ON;");
     return $pdo;
 }
@@ -1312,15 +1313,16 @@ function parse_sort(array $allowed, string $defaultCol, string $defaultDir = 'as
  * Render a sortable <th> element linking to the current page with sort params applied.
  * $baseQs should be the query string prefix for the page (e.g. '?subnet_id=3&page_size=50').
  */
-function sort_th(string $col, string $label, string $currentCol, string $currentDir, string $baseQs): string
+function sort_th(string $col, string $label, string $currentCol, string $currentDir, string $baseQs, string $dataCol = ''): string
 {
-    $isActive = $col === $currentCol;
-    $nextDir  = ($isActive && $currentDir === 'asc') ? 'desc' : 'asc';
-    $arrow    = $isActive ? ($currentDir === 'asc' ? ' ▲' : ' ▼') : '';
-    $sep      = str_contains($baseQs, '?') ? '&' : '?';
-    $qs       = $baseQs . $sep . 'sort=' . urlencode($col) . '&dir=' . $nextDir;
-    $cls      = $isActive ? ' class="sort-active"' : '';
-    return "<th{$cls}><a href='" . e($qs) . "'>" . e($label) . $arrow . '</a></th>';
+    $isActive  = $col === $currentCol;
+    $nextDir   = ($isActive && $currentDir === 'asc') ? 'desc' : 'asc';
+    $arrow     = $isActive ? ($currentDir === 'asc' ? ' ▲' : ' ▼') : '';
+    $sep       = str_contains($baseQs, '?') ? '&' : '?';
+    $qs        = $baseQs . $sep . 'sort=' . urlencode($col) . '&dir=' . $nextDir;
+    $cls       = $isActive ? ' class="sort-active"' : '';
+    $dataAttr  = $dataCol !== '' ? ' data-col="' . e($dataCol) . '"' : '';
+    return "<th{$cls}{$dataAttr}><a href='" . e($qs) . "'>" . e($label) . $arrow . '</a></th>';
 }
 
 /* ---------------- Login protection (#124) ---------------- */
@@ -2495,7 +2497,7 @@ function cidr_from_ip_and_prefix(array $normIp, int $prefix): string
  *
  * @return array{parents: list<string>, children: list<string>}
  */
-function detect_subnet_overlaps(PDO $db, string $cidr, ?int $excludeId = null): array
+function detect_subnet_overlaps(PDO $db, string $cidr, ?int $excludeId = null, ?int $vrfId = null): array
 {
     $p = parse_cidr($cidr);
     if (!$p) return ['parents' => [], 'children' => []];
@@ -2504,8 +2506,10 @@ function detect_subnet_overlaps(PDO $db, string $cidr, ?int $excludeId = null): 
     $prefix = to_int($p['prefix']);
     $netBin = to_str($p['net_bin']);
 
-    $sql    = "SELECT id, cidr, prefix, network_bin FROM subnets WHERE ip_version = :v";
-    $params = [':v' => $ver];
+    // Scope overlap detection to the same VRF (NULL = global routing table).
+    // SQLite's IS operator handles NULL equality correctly.
+    $sql    = "SELECT id, cidr, prefix, network_bin FROM subnets WHERE ip_version = :v AND vrf_id IS :vrf";
+    $params = [':v' => $ver, ':vrf' => $vrfId];
     if ($excludeId !== null) {
         $sql .= " AND id != :excl";
         $params[':excl'] = $excludeId;
@@ -2577,11 +2581,11 @@ function page_header(string $title, array $opts = []): void
     echo "<link rel='icon' type='image/png' sizes='32x32' href='assets/favicon-32.png'>";
     echo "<link rel='apple-touch-icon' type='image/webp' sizes='180x180' href='assets/apple-touch-icon.webp'>";
     echo "<link rel='apple-touch-icon' sizes='180x180' href='assets/apple-touch-icon.png'>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=2.0.0'>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=2.1.0'>";
     // Expose server-side theme via meta tag so app.js can seed localStorage (CSP-safe)
     $userTheme = to_str($_SESSION['user_theme'] ?? 'auto');
     echo "<meta name='ipam-server-theme' content='" . e($userTheme) . "'>";
-    echo "<script defer src='assets/app.js?v=2.0.0'></script>";
+    echo "<script defer src='assets/app.js?v=2.1.0'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";
@@ -2595,6 +2599,7 @@ function page_header(string $title, array $opts = []): void
         echo "<a class='nav-pill' href='subnets.php'>🌐 Subnets</a>";
         echo "<a class='nav-pill' href='addresses.php'>🧾 Addresses</a>";
         echo "<a class='nav-pill' href='search.php'>🔎 Search</a>";
+        echo "<button class='nav-pill nav-search-key' onclick='document.dispatchEvent(new KeyboardEvent(\"keydown\",{key:\"k\",ctrlKey:true,bubbles:true}))' title='Quick search (Ctrl+K / \u2318K)'>\u2318K</button>";
         echo "<a class='nav-pill' href='audit.php'>📜 Audit</a>";
         if ($role === 'admin') {
             echo "<div class='nav-dropdown'>";
@@ -2603,8 +2608,10 @@ function page_header(string $title, array $opts = []): void
             echo "<a class='nav-dropdown-item' href='dhcp_pool.php'>🔒 DHCP Pools</a>";
             echo "<hr class='nav-dropdown-divider'>";
             echo "<a class='nav-dropdown-item' href='sites.php'>📍 Sites</a>";
+            echo "<a class='nav-dropdown-item' href='vrfs.php'>🌐 VRFs</a>";
             echo "<a class='nav-dropdown-item' href='vlans.php'>🏷 VLANs</a>";
             echo "<a class='nav-dropdown-item' href='tags.php'>🔖 Tags</a>";
+            echo "<a class='nav-dropdown-item' href='contacts.php'>📇 Contacts</a>";
             echo "<a class='nav-dropdown-item' href='users.php'>👤 Users</a>";
             echo "<a class='nav-dropdown-item' href='api_keys.php'>🔑 API Keys</a>";
             echo "<a class='nav-dropdown-item' href='import_csv.php'>⬆ Import CSV</a>";
@@ -2648,8 +2655,10 @@ function page_header(string $title, array $opts = []): void
             echo "<span class='nav-drawer-section'>Admin</span>";
             echo "<a href='dhcp_pool.php'>&#128274; DHCP Pools</a>";
             echo "<a href='sites.php'>&#128205; Sites</a>";
+            echo "<a href='vrfs.php'>&#127760; VRFs</a>";
             echo "<a href='vlans.php'>&#127991; VLANs</a>";
             echo "<a href='tags.php'>&#128278; Tags</a>";
+            echo "<a href='contacts.php'>&#128215; Contacts</a>";
             echo "<a href='users.php'>&#128100; Users</a>";
             echo "<a href='api_keys.php'>&#128273; API Keys</a>";
             echo "<a href='import_csv.php'>&#8679; Import CSV</a>";
@@ -2664,6 +2673,16 @@ function page_header(string $title, array $opts = []): void
     }
     echo "</div>";
     echo "<div class='nav-drawer-overlay'></div>";
+
+    // ⌘K / Ctrl+K search overlay (#253)
+    echo "<div id='search-overlay' role='dialog' aria-modal='true' aria-label='Quick search'>";
+    echo "<div class='so-box'>";
+    echo "<input id='search-overlay-input' type='search' placeholder='Search IPs, hostnames, owners\u2026' autocomplete='off' spellcheck='false'>";
+    echo "<button id='search-overlay-close' class='so-close' aria-label='Close search'>&times;</button>";
+    echo "<ul id='search-overlay-list'></ul>";
+    echo "<div class='so-hint'>&#x23CE; to navigate &nbsp;&middot;&nbsp; &#x2191;&#x2193; to move &nbsp;&middot;&nbsp; <kbd>Esc</kbd> to close</div>";
+    echo "</div>";
+    echo "</div>";
 
     echo "<div class='page'>";
 
@@ -2879,9 +2898,9 @@ function ipam_update_check(array $config): ?array
  * Find the site_id a subnet should inherit from its tightest parent.
  * Returns null if no parent exists or no parent has a site assigned.
  */
-function find_parent_site_id(PDO $db, string $cidr, ?int $excludeId = null): ?int
+function find_parent_site_id(PDO $db, string $cidr, ?int $excludeId = null, ?int $vrfId = null): ?int
 {
-    $overlaps = detect_subnet_overlaps($db, $cidr, $excludeId);
+    $overlaps = detect_subnet_overlaps($db, $cidr, $excludeId, $vrfId);
     if (empty($overlaps['parents'])) return null;
 
     $placeholders = implode(',', array_fill(0, count($overlaps['parents']), '?'));

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -388,7 +388,7 @@ function ipam_migrations(): array
                     site_id     INTEGER,
                     vlan_id     INTEGER,
                     vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,
-                    vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,
+                    vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE RESTRICT,
                     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
                     updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
                     UNIQUE(cidr, vrf_id)

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -372,27 +372,28 @@ function ipam_migrations(): array
                 return;
             }
 
-            // Temporarily disable FK enforcement for the table rebuild
-            $db->exec("PRAGMA foreign_keys = OFF");
-            try {
-                $db->exec("
-                    CREATE TABLE subnets_new (
-                        id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                        cidr        TEXT NOT NULL,
-                        ip_version  INTEGER NOT NULL,
-                        network     TEXT NOT NULL,
-                        network_bin BLOB NOT NULL,
-                        prefix      INTEGER NOT NULL,
-                        description TEXT NOT NULL DEFAULT '',
-                        site_id     INTEGER,
-                        vlan_id     INTEGER,
-                        vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,
-                        vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,
-                        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-                        updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
-                        UNIQUE(cidr, vrf_id)
-                    )
-                ");
+            // Note: PRAGMA foreign_keys is a no-op inside a transaction, but DROP TABLE
+            // in SQLite does not check FK constraints on DDL — only DML triggers FK checks.
+            // All child tables (addresses, subnet_tags, alert_state) use ON DELETE CASCADE,
+            // so the rename-based rebuild is safe without disabling FK enforcement.
+            $db->exec("
+                CREATE TABLE subnets_new (
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    cidr        TEXT NOT NULL,
+                    ip_version  INTEGER NOT NULL,
+                    network     TEXT NOT NULL,
+                    network_bin BLOB NOT NULL,
+                    prefix      INTEGER NOT NULL,
+                    description TEXT NOT NULL DEFAULT '',
+                    site_id     INTEGER,
+                    vlan_id     INTEGER,
+                    vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,
+                    vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,
+                    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(cidr, vrf_id)
+                )
+            ");
                 $db->exec("
                     INSERT INTO subnets_new
                         (id, cidr, ip_version, network, network_bin, prefix, description,
@@ -426,9 +427,6 @@ function ipam_migrations(): array
                       UPDATE subnets SET vlan_id = NULL WHERE vlan_fk = OLD.id;
                     END
                 ");
-            } finally {
-                $db->exec("PRAGMA foreign_keys = ON");
-            }
         },
 
         // 2.1.0-contacts: contacts as first-class objects
@@ -466,6 +464,7 @@ function ipam_migrations(): array
             );
             if (!in_array('owner_contact_id', $addrCols, true)) {
                 $db->exec("ALTER TABLE addresses ADD COLUMN owner_contact_id INTEGER REFERENCES contacts(id) ON DELETE SET NULL");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_addresses_owner_contact_id ON addresses(owner_contact_id)");
             }
         },
     ];

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -330,5 +330,143 @@ function ipam_migrations(): array
                 ");
             }
         },
+
+        // 2.1.0-vrfs: VRF support — overlapping address spaces
+        // SQLite cannot DROP CONSTRAINT, so we rebuild the subnets table to change
+        // UNIQUE(cidr) → UNIQUE(cidr, vrf_id).  All existing subnets get vrf_id = NULL
+        // (= global/default VRF).  Idempotent: guarded by vrf_id column presence.
+        '2.1.0-vrfs' => function(PDO $db): void {
+            $tables = array_column(
+                ($db->query("SELECT name FROM sqlite_master WHERE type='table'") ?: throw new \RuntimeException('Query failed'))->fetchAll(),
+                'name'
+            );
+
+            // Create vrfs table if absent
+            if (!in_array('vrfs', $tables, true)) {
+                $db->exec("
+                    CREATE TABLE vrfs (
+                        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name        TEXT NOT NULL UNIQUE,
+                        description TEXT NOT NULL DEFAULT '',
+                        rd          TEXT NOT NULL DEFAULT '',
+                        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+                    )
+                ");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_vrfs_name ON vrfs(name)");
+                $db->exec("
+                    CREATE TRIGGER IF NOT EXISTS vrfs_updated_at
+                    AFTER UPDATE ON vrfs FOR EACH ROW
+                    BEGIN
+                      UPDATE vrfs SET updated_at = datetime('now') WHERE id = OLD.id;
+                    END
+                ");
+            }
+
+            // Rebuild subnets only if vrf_id column is absent
+            $subnetCols = array_column(
+                ($db->query("PRAGMA table_info(subnets)") ?: throw new \RuntimeException('Query failed'))->fetchAll(),
+                'name'
+            );
+            if (in_array('vrf_id', $subnetCols, true)) {
+                return;
+            }
+
+            // Temporarily disable FK enforcement for the table rebuild
+            $db->exec("PRAGMA foreign_keys = OFF");
+            try {
+                $db->exec("
+                    CREATE TABLE subnets_new (
+                        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                        cidr        TEXT NOT NULL,
+                        ip_version  INTEGER NOT NULL,
+                        network     TEXT NOT NULL,
+                        network_bin BLOB NOT NULL,
+                        prefix      INTEGER NOT NULL,
+                        description TEXT NOT NULL DEFAULT '',
+                        site_id     INTEGER,
+                        vlan_id     INTEGER,
+                        vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,
+                        vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,
+                        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+                        UNIQUE(cidr, vrf_id)
+                    )
+                ");
+                $db->exec("
+                    INSERT INTO subnets_new
+                        (id, cidr, ip_version, network, network_bin, prefix, description,
+                         site_id, vlan_id, vlan_fk, vrf_id, created_at, updated_at)
+                    SELECT id, cidr, ip_version, network, network_bin, prefix, description,
+                           site_id, vlan_id, vlan_fk, NULL, created_at, updated_at
+                    FROM subnets
+                ");
+                $db->exec("DROP TABLE subnets");
+                $db->exec("ALTER TABLE subnets_new RENAME TO subnets");
+
+                // Recreate indexes
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_ver_prefix_netbin ON subnets(ip_version, prefix, network_bin)");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id)");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_vrf_id ON subnets(vrf_id)");
+
+                // Recreate subnets_updated_at trigger (dropped with the old table)
+                $db->exec("
+                    CREATE TRIGGER IF NOT EXISTS subnets_updated_at
+                    AFTER UPDATE ON subnets FOR EACH ROW
+                    BEGIN
+                      UPDATE subnets SET updated_at = datetime('now') WHERE id = OLD.id;
+                    END
+                ");
+
+                // Recreate vlans cleanup trigger (also dropped with old subnets table)
+                $db->exec("
+                    CREATE TRIGGER IF NOT EXISTS vlans_before_delete_cleanup_subnets
+                    BEFORE DELETE ON vlans FOR EACH ROW
+                    BEGIN
+                      UPDATE subnets SET vlan_id = NULL WHERE vlan_fk = OLD.id;
+                    END
+                ");
+            } finally {
+                $db->exec("PRAGMA foreign_keys = ON");
+            }
+        },
+
+        // 2.1.0-contacts: contacts as first-class objects
+        '2.1.0-contacts' => function(PDO $db): void {
+            $tables = array_column(
+                ($db->query("SELECT name FROM sqlite_master WHERE type='table'") ?: throw new \RuntimeException('Query failed'))->fetchAll(),
+                'name'
+            );
+            if (!in_array('contacts', $tables, true)) {
+                $db->exec("
+                    CREATE TABLE contacts (
+                        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                        name       TEXT NOT NULL,
+                        email      TEXT NOT NULL DEFAULT '',
+                        phone      TEXT NOT NULL DEFAULT '',
+                        org        TEXT NOT NULL DEFAULT '',
+                        note       TEXT NOT NULL DEFAULT '',
+                        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    )
+                ");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)");
+                $db->exec("CREATE INDEX IF NOT EXISTS idx_contacts_email ON contacts(email)");
+                $db->exec("
+                    CREATE TRIGGER IF NOT EXISTS contacts_updated_at
+                    AFTER UPDATE ON contacts FOR EACH ROW
+                    BEGIN
+                      UPDATE contacts SET updated_at = datetime('now') WHERE id = OLD.id;
+                    END
+                ");
+            }
+            $addrCols = array_column(
+                ($db->query("PRAGMA table_info(addresses)") ?: throw new \RuntimeException('Query failed'))->fetchAll(),
+                'name'
+            );
+            if (!in_array('owner_contact_id', $addrCols, true)) {
+                $db->exec("ALTER TABLE addresses ADD COLUMN owner_contact_id INTEGER REFERENCES contacts(id) ON DELETE SET NULL");
+            }
+        },
     ];
 }

--- a/Simple-PHP-IPAM/schema.sql
+++ b/Simple-PHP-IPAM/schema.sql
@@ -37,9 +37,28 @@ CREATE TABLE IF NOT EXISTS sites (
 
 CREATE INDEX IF NOT EXISTS idx_sites_parent_id ON sites(parent_id);
 
+-- v2.1.0: VRFs (defined before subnets for FK clarity)
+CREATE TABLE IF NOT EXISTS vrfs (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  name        TEXT NOT NULL UNIQUE,
+  description TEXT NOT NULL DEFAULT '',
+  rd          TEXT NOT NULL DEFAULT '',             -- Route Distinguisher, free-form (e.g. "65000:1")
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_vrfs_name ON vrfs(name);
+
+CREATE TRIGGER IF NOT EXISTS vrfs_updated_at
+AFTER UPDATE ON vrfs
+FOR EACH ROW
+BEGIN
+  UPDATE vrfs SET updated_at = datetime('now') WHERE id = OLD.id;
+END;
+
 CREATE TABLE IF NOT EXISTS subnets (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
-  cidr        TEXT NOT NULL UNIQUE,
+  cidr        TEXT NOT NULL,
   ip_version  INTEGER NOT NULL,
   network     TEXT NOT NULL,
   network_bin BLOB NOT NULL,
@@ -48,12 +67,15 @@ CREATE TABLE IF NOT EXISTS subnets (
   site_id     INTEGER,
   vlan_id     INTEGER,                              -- 802.1Q VLAN ID (1–4094), legacy integer field
   vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,  -- v2.0.0: FK to vlans table
+  vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,   -- v2.1.0: FK to vrfs table
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(cidr, vrf_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_subnets_ver_prefix_netbin ON subnets(ip_version, prefix, network_bin);
 CREATE INDEX IF NOT EXISTS idx_subnets_site_id ON subnets(site_id);
+CREATE INDEX IF NOT EXISTS idx_subnets_vrf_id ON subnets(vrf_id);
 
 CREATE TRIGGER IF NOT EXISTS subnets_updated_at
 AFTER UPDATE ON subnets
@@ -62,20 +84,43 @@ BEGIN
   UPDATE subnets SET updated_at = datetime('now') WHERE id = OLD.id;
 END;
 
-CREATE TABLE IF NOT EXISTS addresses (
+-- v2.1.0: Contacts as first-class objects (defined before addresses for FK clarity)
+CREATE TABLE IF NOT EXISTS contacts (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
-  subnet_id  INTEGER NOT NULL,
-  ip         TEXT NOT NULL,
-  ip_bin     BLOB NOT NULL,
-  hostname   TEXT NOT NULL DEFAULT '',
-  owner      TEXT NOT NULL DEFAULT '',
+  name       TEXT NOT NULL,
+  email      TEXT NOT NULL DEFAULT '',
+  phone      TEXT NOT NULL DEFAULT '',
+  org        TEXT NOT NULL DEFAULT '',
   note       TEXT NOT NULL DEFAULT '',
-  grp        TEXT NOT NULL DEFAULT '',              -- group label (group is a SQL reserved word)
-  mac        TEXT NOT NULL DEFAULT '',              -- MAC address (optional, free-form)
-  expires_at TEXT,                                  -- optional expiration date (YYYY-MM-DD), NULL = no expiry
-  status     TEXT NOT NULL DEFAULT 'used',
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name);
+CREATE INDEX IF NOT EXISTS idx_contacts_email ON contacts(email);
+
+CREATE TRIGGER IF NOT EXISTS contacts_updated_at
+AFTER UPDATE ON contacts
+FOR EACH ROW
+BEGIN
+  UPDATE contacts SET updated_at = datetime('now') WHERE id = OLD.id;
+END;
+
+CREATE TABLE IF NOT EXISTS addresses (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  subnet_id        INTEGER NOT NULL,
+  ip               TEXT NOT NULL,
+  ip_bin           BLOB NOT NULL,
+  hostname         TEXT NOT NULL DEFAULT '',
+  owner            TEXT NOT NULL DEFAULT '',
+  note             TEXT NOT NULL DEFAULT '',
+  grp              TEXT NOT NULL DEFAULT '',              -- group label (group is a SQL reserved word)
+  mac              TEXT NOT NULL DEFAULT '',              -- MAC address (optional, free-form)
+  expires_at       TEXT,                                  -- optional expiration date (YYYY-MM-DD), NULL = no expiry
+  status           TEXT NOT NULL DEFAULT 'used',
+  owner_contact_id INTEGER REFERENCES contacts(id) ON DELETE SET NULL,  -- v2.1.0: FK to contacts
+  created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at       TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(subnet_id, ip),
   FOREIGN KEY(subnet_id) REFERENCES subnets(id) ON DELETE CASCADE
 );

--- a/Simple-PHP-IPAM/schema.sql
+++ b/Simple-PHP-IPAM/schema.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS subnets (
   site_id     INTEGER,
   vlan_id     INTEGER,                              -- 802.1Q VLAN ID (1–4094), legacy integer field
   vlan_fk     INTEGER REFERENCES vlans(id) ON DELETE SET NULL,  -- v2.0.0: FK to vlans table
-  vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE SET NULL,   -- v2.1.0: FK to vrfs table
+  vrf_id      INTEGER REFERENCES vrfs(id) ON DELETE RESTRICT,   -- v2.1.0: FK to vrfs table; RESTRICT prevents orphaned subnets moving to global VRF
   created_at  TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
   UNIQUE(cidr, vrf_id)
@@ -130,6 +130,7 @@ CREATE INDEX IF NOT EXISTS idx_addresses_hostname ON addresses(hostname);
 CREATE INDEX IF NOT EXISTS idx_addresses_owner ON addresses(owner);
 CREATE INDEX IF NOT EXISTS idx_addresses_status ON addresses(status);
 CREATE INDEX IF NOT EXISTS idx_addresses_grp ON addresses(grp);
+CREATE INDEX IF NOT EXISTS idx_addresses_owner_contact_id ON addresses(owner_contact_id);
 
 CREATE TRIGGER IF NOT EXISTS addresses_updated_at
 AFTER UPDATE ON addresses

--- a/Simple-PHP-IPAM/search.php
+++ b/Simple-PHP-IPAM/search.php
@@ -22,18 +22,6 @@ $allowedStatus = ['', 'used', 'reserved', 'free'];
 if (!in_array($status, $allowedStatus, true)) $status = '';
 if (!in_array($ipVersion, [0, 4, 6], true)) $ipVersion = 0;
 
-/* Fetch sites for filter dropdown */
-$st = $db->prepare("SELECT id, name FROM sites ORDER BY name ASC");
-$st->execute();
-/** @var list<array<string, mixed>> $siteList */
-$siteList = $st->fetchAll();
-
-/* Fetch subnets for filter dropdown (include site_id for JS filtering) */
-$st = $db->prepare("SELECT id, cidr, ip_version, site_id FROM subnets ORDER BY ip_version ASC, cidr ASC");
-$st->execute();
-/** @var list<array<string, mixed>> $subnets */
-$subnets = $st->fetchAll();
-
 /* Build WHERE clause — all conditions reference `a` or `s` (subnets already joined) */
 $where  = [];
 $params = [];
@@ -61,7 +49,7 @@ if ($ipVersion > 0) {
 
 $whereSql = $where ? ("WHERE " . implode(" AND ", $where)) : "";
 
-/* --- format=json branch: used by the ⌘K overlay --- */
+/* --- format=json branch: used by the ⌘K overlay — exits before loading dropdown data --- */
 if ($format === 'json') {
     header('Content-Type: application/json; charset=utf-8');
     $st = $db->prepare("
@@ -90,6 +78,17 @@ if ($format === 'json') {
     echo json_encode($out, JSON_UNESCAPED_SLASHES);
     exit;
 }
+
+/* Fetch sites and subnets for filter dropdowns (HTML path only) */
+$st = $db->prepare("SELECT id, name FROM sites ORDER BY name ASC");
+$st->execute();
+/** @var list<array<string, mixed>> $siteList */
+$siteList = $st->fetchAll();
+
+$st = $db->prepare("SELECT id, cidr, ip_version, site_id FROM subnets ORDER BY ip_version ASC, cidr ASC");
+$st->execute();
+/** @var list<array<string, mixed>> $subnets */
+$subnets = $st->fetchAll();
 
 /* Count query — must JOIN subnets when site/version filters are active */
 $st = $db->prepare("

--- a/Simple-PHP-IPAM/search.php
+++ b/Simple-PHP-IPAM/search.php
@@ -10,6 +10,7 @@ $subnetId   = to_int($_GET['subnet_id'] ?? 0);
 $siteId     = to_int($_GET['site_id'] ?? 0);
 $ipVersion  = to_int($_GET['ip_version'] ?? 0);
 
+$format   = trim(to_str($_GET['format'] ?? ''));
 $page     = q_int('page', 1, 1, 1000000);
 $pageSize = q_int('page_size', 254, 1, 500);
 
@@ -59,6 +60,36 @@ if ($ipVersion > 0) {
 }
 
 $whereSql = $where ? ("WHERE " . implode(" AND ", $where)) : "";
+
+/* --- format=json branch: used by the ⌘K overlay --- */
+if ($format === 'json') {
+    header('Content-Type: application/json; charset=utf-8');
+    $st = $db->prepare("
+        SELECT a.id, a.subnet_id, a.ip, a.hostname, a.status
+        FROM addresses a
+        JOIN subnets s ON s.id = a.subnet_id
+        $whereSql
+        ORDER BY a.ip_bin ASC
+        LIMIT 20
+    ");
+    foreach ($params as $k => $v) $st->bindValue($k, $v);
+    $st->execute();
+    /** @var list<array<string, mixed>> $jRows */
+    $jRows = $st->fetchAll();
+    $out = [];
+    foreach ($jRows as $jr) {
+        $out[] = [
+            'ip'          => to_str($jr['ip']),
+            'hostname'    => to_str($jr['hostname']),
+            'status'      => to_str($jr['status']),
+            'url'         => 'addresses.php?subnet_id=' . to_int($jr['subnet_id'])
+                             . '&highlight=' . to_int($jr['id'])
+                             . '#addr-' . to_int($jr['id']),
+        ];
+    }
+    echo json_encode($out, JSON_UNESCAPED_SLASHES);
+    exit;
+}
 
 /* Count query — must JOIN subnets when site/version filters are active */
 $st = $db->prepare("

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -496,10 +496,11 @@ uasort($siteGroups, fn($a, $b) => strcasecmp($a['label'], $b['label']));
 /**
  * @param array{byId: array<int, array<string, mixed>>, children: array<int, list<int>>} $tree
  * @param array<int, array{used: int, reserved: int, free: int, total: int}> $agg
+ * @param array<int, array{assignable_total: int, assigned_assignable: int, unassigned_assignable: int}> $unassignedAgg
  * @param list<int> $roots
  * @param array{0: int} &$count
  */
-function render_subnet_map_nodes(array $tree, array $agg, array $roots, int $depth, array &$count): void
+function render_subnet_map_nodes(array $tree, array $agg, array $unassignedAgg, array $roots, int $depth, array &$count): void
 {
     foreach ($roots as $id) {
         if ($count[0] >= 200) {
@@ -512,9 +513,13 @@ function render_subnet_map_nodes(array $tree, array $agg, array $roots, int $dep
         $count[0]++;
         /** @var array<string, mixed> $row */
         $row = $tree['byId'][$id];
-        $a   = $agg[$id] ?? ['used' => 0, 'reserved' => 0, 'free' => 0, 'total' => 0];
-        $tot = max(1, to_int($a['total']));
-        $pct = (int)round((to_int($a['used']) + to_int($a['reserved'])) / $tot * 100);
+        $u = $unassignedAgg[$id] ?? null;
+        if ($u !== null && to_int($u['assignable_total']) > 0) {
+            $pct = (int)round(to_int($u['assigned_assignable']) / to_int($u['assignable_total']) * 100);
+        } else {
+            $a   = $agg[$id] ?? ['used' => 0, 'reserved' => 0, 'free' => 0, 'total' => 0];
+            $pct = (int)round((to_int($a['used']) + to_int($a['reserved'])) / max(1, to_int($a['total'])) * 100);
+        }
         $cls = $pct >= 90 ? 'util-bar-fill--crit' : ($pct >= 75 ? 'util-bar-fill--warn' : '');
         $indent = $depth * 22;
         echo "<div class='map-node' data-indent='{$indent}'>";
@@ -526,7 +531,7 @@ function render_subnet_map_nodes(array $tree, array $agg, array $roots, int $dep
         echo "</div>";
         $children = $tree['children'][$id] ?? [];
         if ($children !== []) {
-            render_subnet_map_nodes($tree, $agg, $children, $depth + 1, $count);
+            render_subnet_map_nodes($tree, $agg, $unassignedAgg, $children, $depth + 1, $count);
         }
     }
 }
@@ -825,7 +830,7 @@ page_header('Subnets');
     <?php $mapCount = [0]; foreach ($siteGroups as $group): ?>
       <div class="map-group mb-24">
         <div class="map-group-label"><?= e(to_str($group['label'])) ?></div>
-        <?php render_subnet_map_nodes($tree, $agg, array_map('intval', $group['roots']), 0, $mapCount); ?>
+        <?php render_subnet_map_nodes($tree, $agg, $ipv4UnassignedAgg, array_map('intval', $group['roots']), 0, $mapCount); ?>
       </div>
     <?php endforeach; ?>
     </div>

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -164,31 +164,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'site_id' => $siteId ?? 0, 'vlan_fk' => $vlanFk ?? 0, 'vrf_id' => $vrfId ?? 0,
                 ];
             } else {
-                try {
-                    $st = $db->prepare("UPDATE subnets
-                                        SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site, vlan_id=:vlan, vlan_fk=:vfk, vrf_id=:vrf
-                                        WHERE id=:id");
-                    $st->execute([
-                        ':cidr' => $normalized,
-                        ':ver'  => $p['version'],
-                        ':net'  => $p['network'],
-                        ':nb'   => $p['net_bin'],
-                        ':pre'  => $p['prefix'],
-                        ':d'    => $desc,
-                        ':site' => $siteId,
-                        ':vlan' => $vlanId,
-                        ':vfk'  => $vlanFk,
-                        ':vrf'  => $vrfId,
-                        ':id'   => $id,
-                    ]);
-                    audit($db, 'subnet.update', 'subnet', $id, $normalized);
-                    $msg = 'Subnet updated.';
-                    if ($inheritedSiteId !== null) {
-                        $inheritedName = $siteMap[$inheritedSiteId] ?? "site #$inheritedSiteId";
-                        $warn = 'Site set to "' . $inheritedName . '" inherited from parent subnet.';
+                $dupChk = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr AND vrf_id IS :vrf AND id != :self");
+                $dupChk->execute([':cidr' => $normalized, ':vrf' => $vrfId, ':self' => $id]);
+                if ($dupChk->fetch()) {
+                    $err = 'A subnet with this CIDR already exists.';
+                } else {
+                    try {
+                        $st = $db->prepare("UPDATE subnets
+                                            SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site, vlan_id=:vlan, vlan_fk=:vfk, vrf_id=:vrf
+                                            WHERE id=:id");
+                        $st->execute([
+                            ':cidr' => $normalized,
+                            ':ver'  => $p['version'],
+                            ':net'  => $p['network'],
+                            ':nb'   => $p['net_bin'],
+                            ':pre'  => $p['prefix'],
+                            ':d'    => $desc,
+                            ':site' => $siteId,
+                            ':vlan' => $vlanId,
+                            ':vfk'  => $vlanFk,
+                            ':vrf'  => $vrfId,
+                            ':id'   => $id,
+                        ]);
+                        audit($db, 'subnet.update', 'subnet', $id, $normalized);
+                        $msg = 'Subnet updated.';
+                        if ($inheritedSiteId !== null) {
+                            $inheritedName = $siteMap[$inheritedSiteId] ?? "site #$inheritedSiteId";
+                            $warn = 'Site set to "' . $inheritedName . '" inherited from parent subnet.';
+                        }
+                    } catch (PDOException $e) {
+                        $err = 'Could not update subnet (duplicate?).';
                     }
-                } catch (PDOException $e) {
-                    $err = 'Could not update subnet (duplicate?).';
                 }
             }
         }
@@ -237,9 +243,13 @@ function build_subnet_tree_local(array $rows): array
     $byId = [];
     foreach ($rows as $r) $byId[to_int($r['id'])] = $r;
 
-    // Sort by ip_version ASC, prefix ASC (broadest first), network_bin ASC
+    // Sort by vrf_id ASC (NULL=0), then ip_version ASC, prefix ASC (broadest first), network_bin ASC.
+    // VRF grouping ensures subnets from different VRFs never become parents of each other.
     $sorted = $byId;
     uasort($sorted, function(array $a, array $b): int {
+        $vrfa = $a['vrf_id'] !== null ? to_int($a['vrf_id']) : 0;
+        $vrfb = $b['vrf_id'] !== null ? to_int($b['vrf_id']) : 0;
+        if ($vrfa !== $vrfb) return $vrfa <=> $vrfb;
         $va = to_int($a['ip_version']); $vb = to_int($b['ip_version']);
         if ($va !== $vb) return $va <=> $vb;
         $pa = to_int($a['prefix']); $pb = to_int($b['prefix']);
@@ -258,11 +268,14 @@ function build_subnet_tree_local(array $rows): array
         $ver    = to_int($row['ip_version']);
         $prefix = to_int($row['prefix']);
         $netBin = to_str($row['network_bin']);
+        $curVrf = $row['vrf_id'] !== null ? to_int($row['vrf_id']) : 0;
 
         // Pop entries that cannot be a parent of this subnet
         while (!empty($stack)) {
-            $top = end($stack);
-            if (to_int($top['ip_version']) !== $ver) {
+            $top    = end($stack);
+            $topVrf = $top['vrf_id'] !== null ? to_int($top['vrf_id']) : 0;
+            // Different VRF or IP version: start a fresh stack
+            if ($topVrf !== $curVrf || to_int($top['ip_version']) !== $ver) {
                 $stack = [];
                 break;
             }
@@ -280,7 +293,7 @@ function build_subnet_tree_local(array $rows): array
             $roots[] = $id;
         }
 
-        $stack[] = ['id' => $id, 'ip_version' => $ver, 'prefix' => $prefix, 'network_bin' => $netBin];
+        $stack[] = ['id' => $id, 'ip_version' => $ver, 'prefix' => $prefix, 'network_bin' => $netBin, 'vrf_id' => $row['vrf_id']];
     }
 
     $cmpFn = function(int $a, int $b) use ($byId): int {
@@ -809,10 +822,10 @@ page_header('Subnets');
 
     <!-- Map view (#255) -->
     <div id="subnet-map-view" style="display:none">
-    <?php foreach ($siteGroups as $group): ?>
+    <?php $mapCount = [0]; foreach ($siteGroups as $group): ?>
       <div class="map-group mb-24">
         <div class="map-group-label"><?= e(to_str($group['label'])) ?></div>
-        <?php $mapCount = [0]; render_subnet_map_nodes($tree, $agg, array_map('intval', $group['roots']), 0, $mapCount); ?>
+        <?php render_subnet_map_nodes($tree, $agg, array_map('intval', $group['roots']), 0, $mapCount); ?>
       </div>
     <?php endforeach; ?>
     </div>

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -30,6 +30,9 @@ foreach ($vlanList as $vl) {
     $vlanMap[to_int($vl['id'])] = $vl;
 }
 
+/** @var list<array<string, mixed>> $vrfList */
+$vrfList = ($db->query("SELECT id, name FROM vrfs ORDER BY name ASC") ?: throw new \RuntimeException('Query failed'))->fetchAll();
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = to_str($_POST['action'] ?? '');
 
@@ -47,6 +50,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $vlanId = to_int($vlanMap[$vlanFk]['vlan_id']);
         }
 
+        $vrfId = to_int($_POST['vrf_id'] ?? 0) ?: null;
+
         $doAutoReserve = !empty($_POST['auto_reserve']);
         $gateway       = trim(to_str($_POST['gateway'] ?? '')) ?: null;
 
@@ -56,9 +61,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         if (!$err) {
             $normalized = $p['network'] . '/' . $p['prefix'];
-            $overlaps = detect_subnet_overlaps($db, $normalized);
+            $overlaps = detect_subnet_overlaps($db, $normalized, null, $vrfId);
             // Inherit site from tightest parent if one exists
-            $inheritedSiteId = find_parent_site_id($db, $normalized);
+            $inheritedSiteId = find_parent_site_id($db, $normalized, null, $vrfId);
             if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
             // Pre-save overlap confirmation
@@ -71,13 +76,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'description'  => $desc,
                     'site_id'      => $siteId ?? 0,
                     'vlan_fk'      => $vlanFk ?? 0,
+                    'vrf_id'       => $vrfId ?? 0,
                     'auto_reserve' => $doAutoReserve ? '1' : '0',
                     'gateway'      => $gateway ?? '',
                 ];
             } else {
                 try {
-                    $st = $db->prepare("INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id, vlan_fk)
-                                        VALUES (:cidr,:ver,:net,:nb,:pre,:d,:site,:vlan,:vfk)");
+                    // UNIQUE(cidr, vrf_id) treats NULL as distinct from NULL in SQLite,
+                    // so check for duplicates explicitly before inserting.
+                    $dupChk = $db->prepare("SELECT id FROM subnets WHERE cidr = :cidr AND vrf_id IS :vrf");
+                    $dupChk->execute([':cidr' => $normalized, ':vrf' => $vrfId]);
+                    if ($dupChk->fetch()) {
+                        $err = 'A subnet with this CIDR already exists.';
+                    } else {
+                    $st = $db->prepare("INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description, site_id, vlan_id, vlan_fk, vrf_id)
+                                        VALUES (:cidr,:ver,:net,:nb,:pre,:d,:site,:vlan,:vfk,:vrf)");
                     $st->execute([
                         ':cidr' => $normalized,
                         ':ver'  => $p['version'],
@@ -88,6 +101,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         ':site' => $siteId,
                         ':vlan' => $vlanId,
                         ':vfk'  => $vlanFk,
+                        ':vrf'  => $vrfId,
                     ]);
                     $newSubnetId = (int)$db->lastInsertId();
                     audit($db, 'subnet.create', 'subnet', $newSubnetId, $normalized);
@@ -105,6 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     else flash_set('Subnet created.');
                     header('Location: subnets.php');
                     exit;
+                    }
                 } catch (PDOException $e) {
                     $err = str_contains($e->getMessage(), 'UNIQUE')
                         ? 'A subnet with this CIDR already exists.'
@@ -126,15 +141,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $vlanId = to_int($vlanMap[$vlanFk]['vlan_id']);
         }
 
+        $vrfId = to_int($_POST['vrf_id'] ?? 0) ?: null;
+
         $p = parse_cidr($cidr);
         if (!$p) {
             $err = 'Invalid CIDR.';
         }
         if (!$err) {
             $normalized = $p['network'] . '/' . $p['prefix'];
-            $overlaps = detect_subnet_overlaps($db, $normalized, $id);
+            $overlaps = detect_subnet_overlaps($db, $normalized, $id, $vrfId);
             // Inherit site from tightest parent if one exists
-            $inheritedSiteId = find_parent_site_id($db, $normalized, $id);
+            $inheritedSiteId = find_parent_site_id($db, $normalized, $id, $vrfId);
             if ($inheritedSiteId !== null) $siteId = $inheritedSiteId;
 
             // Pre-save overlap confirmation
@@ -144,12 +161,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $pendingAction = 'update';
                 $pendingData = [
                     'id' => $id, 'cidr' => $cidr, 'description' => $desc,
-                    'site_id' => $siteId ?? 0, 'vlan_fk' => $vlanFk ?? 0,
+                    'site_id' => $siteId ?? 0, 'vlan_fk' => $vlanFk ?? 0, 'vrf_id' => $vrfId ?? 0,
                 ];
             } else {
                 try {
                     $st = $db->prepare("UPDATE subnets
-                                        SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site, vlan_id=:vlan, vlan_fk=:vfk
+                                        SET cidr=:cidr, ip_version=:ver, network=:net, network_bin=:nb, prefix=:pre, description=:d, site_id=:site, vlan_id=:vlan, vlan_fk=:vfk, vrf_id=:vrf
                                         WHERE id=:id");
                     $st->execute([
                         ':cidr' => $normalized,
@@ -161,6 +178,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         ':site' => $siteId,
                         ':vlan' => $vlanId,
                         ':vfk'  => $vlanFk,
+                        ':vrf'  => $vrfId,
                         ':id'   => $id,
                     ]);
                     audit($db, 'subnet.update', 'subnet', $id, $normalized);
@@ -193,10 +211,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $st = $db->prepare("
-    SELECT s.id, s.cidr, s.ip_version, s.network, s.network_bin, s.prefix, s.description, s.updated_at, s.site_id, s.vlan_id, s.vlan_fk,
-           v.name AS vlan_name
+    SELECT s.id, s.cidr, s.ip_version, s.network, s.network_bin, s.prefix, s.description, s.updated_at, s.site_id, s.vlan_id, s.vlan_fk, s.vrf_id,
+           v.name AS vlan_name, vr.name AS vrf_name
     FROM subnets s
     LEFT JOIN vlans v ON v.id = s.vlan_fk
+    LEFT JOIN vrfs vr ON vr.id = s.vrf_id
     ORDER BY s.ip_version ASC, s.prefix ASC, s.network_bin ASC
 ");
 $st->execute();
@@ -461,6 +480,46 @@ uasort($siteGroups, fn($a, $b) => strcasecmp($a['label'], $b['label']));
 
 /**
  * @param array{roots: list<int>, children: array<int, list<int>>, byId: array<int, array<string, mixed>>} $tree
+/**
+ * @param array{byId: array<int, array<string, mixed>>, children: array<int, list<int>>} $tree
+ * @param array<int, array{used: int, reserved: int, free: int, total: int}> $agg
+ * @param list<int> $roots
+ * @param array{0: int} &$count
+ */
+function render_subnet_map_nodes(array $tree, array $agg, array $roots, int $depth, array &$count): void
+{
+    foreach ($roots as $id) {
+        if ($count[0] >= 200) {
+            if ($count[0] === 200) {
+                echo "<div class='map-node map-cap'>More than 200 nodes — remaining nodes not shown.</div>";
+            }
+            $count[0]++;
+            continue;
+        }
+        $count[0]++;
+        /** @var array<string, mixed> $row */
+        $row = $tree['byId'][$id];
+        $a   = $agg[$id] ?? ['used' => 0, 'reserved' => 0, 'free' => 0, 'total' => 0];
+        $tot = max(1, to_int($a['total']));
+        $pct = (int)round((to_int($a['used']) + to_int($a['reserved'])) / $tot * 100);
+        $cls = $pct >= 90 ? 'util-bar-fill--crit' : ($pct >= 75 ? 'util-bar-fill--warn' : '');
+        $indent = $depth * 22;
+        echo "<div class='map-node' data-indent='{$indent}'>";
+        echo "<div class='map-node-inner' style='margin-left:{$indent}px'>";
+        echo "<a class='map-cidr' href='addresses.php?subnet_id=" . to_int($row['id']) . "'>" . e(to_str($row['cidr'])) . "</a>";
+        if (to_str($row['description']) !== '') echo " <span class='map-desc muted'>" . e(to_str($row['description'])) . "</span>";
+        echo "<span class='map-util'><span class='util-bar'><span class='util-bar-fill {$cls}' data-pct='{$pct}'></span></span><span class='map-pct muted'>{$pct}%</span></span>";
+        echo "</div>";
+        echo "</div>";
+        $children = $tree['children'][$id] ?? [];
+        if ($children !== []) {
+            render_subnet_map_nodes($tree, $agg, $children, $depth + 1, $count);
+        }
+    }
+}
+
+/**
+ * @param array{byId: array<int, array<string, mixed>>, children: array<int, list<int>>} $tree
  * @param array<int, array{used: int, reserved: int, free: int, total: int}> $direct
  * @param array<int, array{used: int, reserved: int, free: int, total: int}> $agg
  * @param array<int, array{assignable_total: int, assigned_assignable: int, unassigned_assignable: int}> $ipv4Unassigned
@@ -468,8 +527,9 @@ uasort($siteGroups, fn($a, $b) => strcasecmp($a['label'], $b['label']));
  * @param array<int, string> $siteMap
  * @param array<int, array<string, mixed>> $siteList
  * @param list<array<string, mixed>> $vlanList
+ * @param list<array<string, mixed>> $vrfList
  */
-function render_subnet_node_local(array $tree, array $direct, array $agg, array $ipv4Unassigned, array $ipv4UnassignedAgg, array $siteMap, array $siteList, array $vlanList, int $id, int $depth = 0): void
+function render_subnet_node_local(array $tree, array $direct, array $agg, array $ipv4Unassigned, array $ipv4UnassignedAgg, array $siteMap, array $siteList, array $vlanList, array $vrfList, int $id, int $depth = 0): void
 {
     $row = $tree['byId'][$id];
     $pad = $depth * 18;
@@ -494,6 +554,8 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
         $vlanLabel = 'VLAN ' . to_int($row['vlan_id']);
     }
     if ($vlanLabel !== '') echo " <span class='badge'>" . e($vlanLabel) . "</span>";
+    $vrfName = to_str($row['vrf_name'] ?? '');
+    if ($vrfName !== '') echo " <span class='badge'>VRF: " . e($vrfName) . "</span>";
     if (($row['description'] ?? '') !== '') echo " - " . e(to_str($row['description']));
     // Address count badges — direct counts on this subnet, aggregated in parens if children differ
     $countHtml = "<span class='status-used'>" . $d['used'] . " used</span>"
@@ -564,6 +626,17 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
         echo "</select></label>";
     }
 
+    if ($vrfList) {
+        $curVrfId = to_int($row['vrf_id'] ?? 0);
+        echo "<label>VRF<br><select name='vrf_id'><option value='0'>(global)</option>";
+        foreach ($vrfList as $vr) {
+            $vrId = to_int($vr['id']);
+            $sel  = $vrId === $curVrfId ? " selected" : "";
+            echo "<option value='" . $vrId . "'" . $sel . ">" . e(to_str($vr['name'])) . "</option>";
+        }
+        echo "</select></label>";
+    }
+
     if ($depth > 0) {
         // Child subnet: site is inherited from parent and cannot be changed here
         $lockedSiteName = ($siteId > 0 && isset($siteMap[$siteId])) ? $siteMap[$siteId] : '(none)';
@@ -595,7 +668,7 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
     }
 
     foreach (($tree['children'][$id] ?? []) as $cid) {
-        render_subnet_node_local($tree, $direct, $agg, $ipv4Unassigned, $ipv4UnassignedAgg, $siteMap, $siteList, $vlanList, (int)$cid, $depth + 1);
+        render_subnet_node_local($tree, $direct, $agg, $ipv4Unassigned, $ipv4UnassignedAgg, $siteMap, $siteList, $vlanList, $vrfList, (int)$cid, $depth + 1);
     }
 
     echo "</div></details></div>";
@@ -644,6 +717,7 @@ page_header('Subnets');
       <input type="hidden" name="description" value="<?= e(to_str($pendingData['description'])) ?>">
       <input type="hidden" name="site_id" value="<?= to_int($pendingData['site_id']) ?>">
       <input type="hidden" name="vlan_fk" value="<?= to_int($pendingData['vlan_fk'] ?? 0) ?>">
+      <input type="hidden" name="vrf_id" value="<?= to_int($pendingData['vrf_id'] ?? 0) ?>">
       <?php if (isset($pendingData['auto_reserve'])): ?>
         <input type="hidden" name="auto_reserve" value="<?= to_int($pendingData['auto_reserve']) ?>">
         <input type="hidden" name="gateway" value="<?= e(to_str($pendingData['gateway'] ?? '')) ?>">
@@ -673,6 +747,16 @@ page_header('Subnets');
         </select>
       </label>
       <?php endif; ?>
+      <?php if ($vrfList): ?>
+      <label>VRF<br>
+        <select name="vrf_id">
+          <option value="0">(global)</option>
+          <?php foreach ($vrfList as $vr): ?>
+            <option value="<?= to_int($vr['id']) ?>"><?= e(to_str($vr['name'])) ?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <?php endif; ?>
       <label>Site<br>
         <select name="site_id">
           <option value="0">(none)</option>
@@ -696,11 +780,19 @@ page_header('Subnets');
 </div>
 
 <div class="card mt-16">
-  <h2>Grouped Hierarchy</h2>
+  <div class="toolbar mb-8">
+    <h2 class="mb-0">Grouped Hierarchy</h2>
+    <div>
+      <button class="action-pill subnet-view-btn" data-view="list" id="btn-view-list">&#9776; List</button>
+      <button class="action-pill subnet-view-btn" data-view="map"  id="btn-view-map">&#9644; Map</button>
+    </div>
+  </div>
 
   <?php if (empty($siteGroups)): ?>
     <div class="empty-state">No subnets yet. <a class="action-pill" href="#add-subnet">+ Add Subnet</a></div>
   <?php else: ?>
+    <!-- List view -->
+    <div id="subnet-list-view">
     <?php foreach ($siteGroups as $key => $group): ?>
       <div class="site-group mb-24">
         <button type="button" class="site-group-toggle" aria-expanded="true" data-sg-key="<?= e((string)$key) ?>">
@@ -708,11 +800,22 @@ page_header('Subnets');
         </button>
         <div class="site-group-body">
           <?php foreach ($group['roots'] as $rid): ?>
-            <?php render_subnet_node_local($tree, $direct, $agg, $ipv4Unassigned, $ipv4UnassignedAgg, $siteMap, $siteList, $vlanList, (int)$rid, 0); ?>
+            <?php render_subnet_node_local($tree, $direct, $agg, $ipv4Unassigned, $ipv4UnassignedAgg, $siteMap, $siteList, $vlanList, $vrfList, (int)$rid, 0); ?>
           <?php endforeach; ?>
         </div>
       </div>
     <?php endforeach; ?>
+    </div>
+
+    <!-- Map view (#255) -->
+    <div id="subnet-map-view" style="display:none">
+    <?php foreach ($siteGroups as $group): ?>
+      <div class="map-group mb-24">
+        <div class="map-group-label"><?= e(to_str($group['label'])) ?></div>
+        <?php $mapCount = [0]; render_subnet_map_nodes($tree, $agg, array_map('intval', $group['roots']), 0, $mapCount); ?>
+      </div>
+    <?php endforeach; ?>
+    </div>
   <?php endif; ?>
 </div>
 

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -492,8 +492,6 @@ foreach ($tree['roots'] as $rid) {
 uasort($siteGroups, fn($a, $b) => strcasecmp($a['label'], $b['label']));
 
 /**
- * @param array{roots: list<int>, children: array<int, list<int>>, byId: array<int, array<string, mixed>>} $tree
-/**
  * @param array{byId: array<int, array<string, mixed>>, children: array<int, list<int>>} $tree
  * @param array<int, array{used: int, reserved: int, free: int, total: int}> $agg
  * @param array<int, array{assignable_total: int, assigned_assignable: int, unassigned_assignable: int}> $unassignedAgg

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 if (!defined('IPAM_VERSION')) {
-    define('IPAM_VERSION', '2.0.0');
+    define('IPAM_VERSION', '2.1.0');
 }

--- a/Simple-PHP-IPAM/vrfs.php
+++ b/Simple-PHP-IPAM/vrfs.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+/** @var \PDO $db */
+require_role('admin');
+if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
+
+$err = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = to_str($_POST['action'] ?? '');
+
+    if (demo_mode_enabled() && in_array($action, ['create', 'update', 'delete'], true)) {
+        $err = 'This action is disabled in demo mode.';
+        $action = '';
+    }
+
+    if ($action === 'create') {
+        $name = trim(to_str($_POST['name'] ?? ''));
+        $desc = trim(to_str($_POST['description'] ?? ''));
+        $rd   = trim(to_str($_POST['rd'] ?? ''));
+
+        if ($name === '') {
+            $err = 'VRF name is required.';
+        } else {
+            try {
+                $st = $db->prepare("INSERT INTO vrfs (name, description, rd) VALUES (:n,:d,:rd)");
+                $st->execute([':n' => $name, ':d' => $desc, ':rd' => $rd]);
+                $newId = (int)$db->lastInsertId();
+                audit($db, 'vrf.create', 'vrf', $newId, "name=$name");
+                flash_set("VRF \"$name\" created.");
+                header('Location: vrfs.php');
+                exit;
+            } catch (PDOException $e) {
+                $err = 'Could not create VRF (a VRF with that name already exists?).';
+            }
+        }
+    } elseif ($action === 'update') {
+        $id   = to_int($_POST['id'] ?? 0);
+        $name = trim(to_str($_POST['name'] ?? ''));
+        $desc = trim(to_str($_POST['description'] ?? ''));
+        $rd   = trim(to_str($_POST['rd'] ?? ''));
+
+        if ($id <= 0 || $name === '') {
+            $err = 'VRF name is required.';
+        } else {
+            try {
+                $st = $db->prepare("UPDATE vrfs SET name=:n, description=:d, rd=:rd, updated_at=datetime('now') WHERE id=:id");
+                $st->execute([':n' => $name, ':d' => $desc, ':rd' => $rd, ':id' => $id]);
+                audit($db, 'vrf.update', 'vrf', $id, "name=$name");
+                flash_set("VRF \"$name\" updated.");
+                header('Location: vrfs.php');
+                exit;
+            } catch (PDOException $e) {
+                $err = 'Could not update VRF (duplicate name?).';
+            }
+        }
+    } elseif ($action === 'delete') {
+        $id = to_int($_POST['id'] ?? 0);
+        if ($id > 0) {
+            // Block delete if subnets are assigned
+            $countSt = $db->prepare("SELECT COUNT(*) FROM subnets WHERE vrf_id = :id");
+            $countSt->execute([':id' => $id]);
+            $count = (int)$countSt->fetchColumn();
+            if ($count > 0) {
+                $err = "Cannot delete: $count subnet(s) are assigned to this VRF. Reassign or delete them first.";
+            } else {
+                $nameSt = $db->prepare("SELECT name FROM vrfs WHERE id = :id");
+                $nameSt->execute([':id' => $id]);
+                /** @var array<string,mixed>|false $row */
+                $row = $nameSt->fetch();
+                $db->prepare("DELETE FROM vrfs WHERE id = :id")->execute([':id' => $id]);
+                audit($db, 'vrf.delete', 'vrf', $id, $row ? 'name=' . to_str($row['name']) : '');
+                flash_set('VRF deleted.');
+                header('Location: vrfs.php');
+                exit;
+            }
+        }
+    }
+}
+
+$sortCols = ['name' => 'v.name', 'rd' => 'v.rd', 'created' => 'v.created_at'];
+$sort = parse_sort($sortCols, 'name');
+
+/** @var list<array<string, mixed>> $vrfs */
+$vrfs = ($db->query("
+    SELECT v.id, v.name, v.description, v.rd, v.created_at,
+           (SELECT COUNT(*) FROM subnets sn WHERE sn.vrf_id = v.id) AS subnet_count
+    FROM vrfs v
+    ORDER BY {$sort['sql']}
+") ?: throw new \RuntimeException('Query failed'))->fetchAll();
+
+page_header('VRFs');
+?>
+<div class="breadcrumbs">
+  <a href="dashboard.php">Dashboard</a><span class="sep">›</span>
+  <a href="#">Admin</a><span class="sep">›</span>
+  <span>VRFs</span>
+</div>
+
+<div class="toolbar">
+  <div>
+    <h1>VRFs</h1>
+    <div class="muted">Virtual Routing and Forwarding instances allow overlapping address spaces across separate routing domains.</div>
+  </div>
+</div>
+
+<?php if ($err): ?><p class="danger"><?= e($err) ?></p><?php endif; ?>
+
+<div class="grid cols-2">
+  <div class="card" id="add-vrf">
+    <h2>Add VRF</h2>
+    <form method="post" action="vrfs.php">
+      <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+      <input type="hidden" name="action" value="create">
+      <div class="row">
+        <label class="flex-1">Name (unique)<br><input name="name" required placeholder="e.g. Customer-A" class="w-full"></label>
+        <label class="mw-160">Route Distinguisher<br><input name="rd" placeholder="e.g. 65000:1" class="w-full"></label>
+      </div>
+      <div class="row">
+        <label class="flex-1">Description<br><input name="description" class="w-full"></label>
+      </div>
+      <p><button type="submit">Create VRF</button></p>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Overview</h2>
+    <div class="grid cols-2">
+      <div class="metric">
+        <div class="label">VRFs</div>
+        <div class="value"><?= e((string)count($vrfs)) ?></div>
+      </div>
+      <div class="metric">
+        <div class="label">Subnets assigned</div>
+        <div class="value"><?= e((string)array_sum(array_map(fn($v) => to_int($v['subnet_count']), $vrfs))) ?></div>
+      </div>
+    </div>
+    <p class="muted mt-8">Subnets with no VRF assigned belong to the global routing table.</p>
+  </div>
+</div>
+
+<div class="card mt-16">
+  <h2>Existing VRFs</h2>
+
+  <?php if (!$vrfs): ?>
+    <div class="empty-state">No VRFs yet. <a class="action-pill" href="#add-vrf">+ Add VRF</a></div>
+  <?php else: ?>
+    <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <?php $qs = '?';
+                echo sort_th('name',    'Name',    $sort['col'], $sort['dir'], $qs);
+                echo sort_th('rd',      'Route Distinguisher', $sort['col'], $sort['dir'], $qs);
+          ?>
+          <th>Description</th>
+          <th>Subnets</th>
+          <?php echo sort_th('created', 'Created', $sort['col'], $sort['dir'], $qs); ?>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+      <?php foreach ($vrfs as $v): ?>
+        <tr>
+          <td><b><?= e(to_str($v['name'])) ?></b></td>
+          <td><?= $v['rd'] !== '' ? e(to_str($v['rd'])) : '<span class="muted">—</span>' ?></td>
+          <td><?= $v['description'] !== '' ? e(to_str($v['description'])) : '<span class="muted">—</span>' ?></td>
+          <td><?= to_int($v['subnet_count']) ?></td>
+          <td class="muted"><?= e(to_str($v['created_at'])) ?></td>
+          <td>
+            <details>
+              <summary>Edit/Delete</summary>
+              <form method="post" action="vrfs.php" class="row mt-8">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="id"     value="<?= to_int($v['id']) ?>">
+                <label>Name<br><input name="name" value="<?= e(to_str($v['name'])) ?>" required></label>
+                <label>Route Distinguisher<br><input name="rd" value="<?= e(to_str($v['rd'])) ?>"></label>
+                <label class="flex-1">Description<br><input name="description" value="<?= e(to_str($v['description'])) ?>"></label>
+                <button type="submit">Save</button>
+              </form>
+              <form method="post" action="vrfs.php" class="mt-8"
+                    data-confirm="Delete this VRF? All subnets must be reassigned first.">
+                <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="id"     value="<?= to_int($v['id']) ?>">
+                <button type="submit" class="button-danger"
+                  <?= to_int($v['subnet_count']) > 0 ? 'disabled title="Reassign subnets before deleting"' : '' ?>>Delete</button>
+              </form>
+            </details>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+    </div>
+  <?php endif; ?>
+</div>
+
+<?php page_footer(); ?>

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,6 +225,7 @@ Returns a paginated list of address records.
 | `site_id` | integer | — | Filter to addresses in subnets belonging to this site |
 | `status` | string | — | Filter by status: `used`, `reserved`, or `free` |
 | `tag` | string | — | Filter to addresses with the given tag name attached |
+| `contact_id` | integer | — | Filter to addresses linked to this contact (v2.1.0+) |
 | `expired` | flag | — | Pass `?expired=1` to return only addresses where `expires_at` is in the past |
 | `page` | integer | `1` | Page number (1-based) |
 | `limit` | integer | `100` | Records per page (max `500`) |
@@ -265,12 +266,15 @@ Results are ordered by IP address (binary sort — correct numerical order withi
 | `subnet_id` | integer | ID of the containing subnet |
 | `ip` | string | IP address |
 | `hostname` | string | Hostname (may be empty) |
-| `owner` | string | Owner/team (may be empty) |
+| `owner` | string | Owner/team free-text (may be empty) |
+| `owner_contact_id` | integer\|null | FK to `contacts.id` if linked, else `null` (v2.1.0+) |
+| `owner_contact_name` | string\|null | Contact name when `owner_contact_id` is set, else `null` (v2.1.0+) |
 | `status` | string | `used`, `reserved`, or `free` |
 | `note` | string | Free-text note (may be empty) |
 | `group` | string | Group/tag label (may be empty) |
 | `mac` | string | MAC address (free-form, max 64 chars, may be empty) |
 | `expires_at` | string\|null | Lease expiry date (`YYYY-MM-DD`), or `null` if not set |
+| `tags` | array | Tag objects attached to this address (`[{"id":1,"name":"prod","colour":"#28a745"}]`) |
 | `created_at` | string | UTC timestamp (`YYYY-MM-DD HH:MM:SS`) |
 | `updated_at` | string | UTC timestamp of last modification |
 
@@ -388,6 +392,110 @@ DELETE /api.php?resource=vlans&id=<id>  — delete a VLAN (→ 204)
 
 ---
 
+---
+
+### VRFs
+
+```
+GET /api.php?resource=vrfs
+```
+
+Returns all VRF (Virtual Routing and Forwarding) objects. Added in v2.1.0.
+
+**Query parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `id` | integer | — | Get a single VRF by database ID |
+
+**Response**
+
+```json
+{
+  "vrfs": [
+    {
+      "id": 1,
+      "name": "Corporate",
+      "description": "Main corporate VRF",
+      "rd": "65000:1",
+      "created_at": "2026-01-01 12:00:00",
+      "updated_at": "2026-01-01 12:00:00"
+    }
+  ]
+}
+```
+
+When fetching a single VRF (`?id=N`), the response is `{"vrf": {...}}`.
+
+**VRF object fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Internal database ID |
+| `name` | string | Unique VRF name |
+| `description` | string | Free-text description (may be empty) |
+| `rd` | string | Route Distinguisher, free-form (e.g. `65000:1`); may be empty |
+| `created_at` | string | UTC timestamp |
+| `updated_at` | string | UTC timestamp |
+
+**Write operations** (requires write-access API key):
+
+```
+POST   /api.php?resource=vrfs          — create a VRF (body: {"name":"...","rd":"65000:1"})
+PUT    /api.php?resource=vrfs&id=<id>  — update a VRF
+DELETE /api.php?resource=vrfs&id=<id>  — delete a VRF (→ 204; blocked if subnets assigned)
+```
+
+A duplicate `name` returns `409 Conflict`. Deleting a VRF that has subnets assigned returns `409 Conflict`.
+
+---
+
+### Contacts
+
+```
+GET /api.php?resource=contacts
+```
+
+Returns all contact records. Added in v2.1.0.
+
+**Query parameters**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `id` | integer | — | Get a single contact by database ID |
+| `q` | string | — | Fuzzy search — matches against name and email (case-insensitive LIKE) |
+
+**Response**
+
+```json
+{
+  "contacts": [
+    {
+      "id": 1,
+      "name": "Alice Smith",
+      "email": "alice@example.com",
+      "phone": "555-1234",
+      "org": "Example Corp",
+      "note": "Primary network admin",
+      "created_at": "2026-01-01 12:00:00",
+      "updated_at": "2026-01-01 12:00:00"
+    }
+  ]
+}
+```
+
+**Write operations** (requires write-access API key):
+
+```
+POST   /api.php?resource=contacts          — create a contact (body: {"name":"...",...})
+PUT    /api.php?resource=contacts&id=<id>  — update a contact
+DELETE /api.php?resource=contacts&id=<id>  — delete a contact (→ 204)
+```
+
+`name` is required. All other fields are optional (default empty string).
+
+---
+
 ### History
 
 ```
@@ -459,8 +567,32 @@ Search addresses by IP, hostname, owner, note, or group.
 | `status` | string | — | Filter by status: `used`, `reserved`, or `free` |
 | `site_id` | integer | — | Filter to addresses in subnets belonging to this site |
 | `ip_version` | integer | — | Filter by IP version: `4` or `6` |
+| `tag` | string | — | Filter to results with the given tag name |
+| `vrf_id` | integer | — | Filter to results in subnets belonging to this VRF (v2.1.0+) |
 | `page` | integer | `1` | Page number |
 | `limit` | integer | `100` | Records per page (max `500`) |
+
+**JSON format for ⌘K overlay** (v2.1.0+)
+
+The web app's `⌘K`/`Ctrl+K` search overlay calls `search.php?q=<term>&format=json` directly. You can also call this URL (with session cookies) to get a compact array of up to 20 results for autocomplete use cases:
+
+```
+GET /search.php?q=<term>&format=json
+```
+
+Response (session-authenticated, not API key):
+
+```json
+[
+  {
+    "ip": "10.1.0.10",
+    "hostname": "server01.example.com",
+    "subnet_cidr": "10.1.0.0/24",
+    "status": "used",
+    "url": "/addresses.php?subnet_id=3#addr-99"
+  }
+]
+```
 
 **Response**
 
@@ -589,16 +721,18 @@ POST /api.php?resource=subnets
   "cidr": "10.1.0.0/24",
   "description": "Office LAN",
   "site_id": 2,
-  "vlan_id": 100
+  "vlan_id": 100,
+  "vrf_id": 1
 }
 ```
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `cidr` | yes | CIDR notation; must be unique |
+| `cidr` | yes | CIDR notation; must be unique within the same VRF |
 | `description` | no | Free-text description |
 | `site_id` | no | Integer ID of an existing site, or `null` |
 | `vlan_id` | no | Integer 1–4094, or `null` |
+| `vrf_id` | no | Integer ID of an existing VRF, or `null` (global/default) |
 
 **Response** — HTTP `201`
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -87,6 +87,57 @@ The backup is left in place after a successful upgrade. You can remove it manual
 
 ---
 
+## Version-specific upgrade notes
+
+### v2.1.0
+
+**New database tables:** `vrfs`, `contacts`
+
+**Modified tables:**
+- `subnets`: the `UNIQUE(cidr)` constraint is replaced with `UNIQUE(cidr, vrf_id)` to support the same CIDR in different VRFs. Existing subnets get `vrf_id = NULL` (global VRF) — no data is lost.
+- `addresses`: new nullable column `owner_contact_id` (FK → `contacts.id`).
+
+These changes are applied automatically by `upgrade.sh` via `php migrate.php`.
+
+**New admin pages:** `vrfs.php` (VRF management), `contacts.php` (Contacts management) — both accessible from the Admin dropdown.
+
+**New config keys** added automatically by `config_auto_populate` on first boot after upgrade:
+- `api_max_attempts` (default 20)
+- `api_lockout_seconds` (default 300)
+- `api_bulk_limit` (default 500)
+- `recaptcha_enterprise` block (disabled by default)
+
+**API additions:** `resource=vrfs` (full CRUD), `resource=contacts` (CRUD + `?q=` search), `?vrf_id=` filter on subnets, `?contact_id=` filter on addresses, `owner_contact_id`/`owner_contact_name` fields in address responses, `vrf_id`/`vrf_name` fields in subnet responses, `search.php?format=json` for the ⌘K overlay.
+
+---
+
+### v2.0.0
+
+**New database tables:** `vlans`, `tags`, `subnet_tags`, `address_tags`, `alert_state`
+
+**Modified tables:**
+- `subnets`: new columns `vlan_fk` (FK → `vlans.id`), `tags` (via join table `subnet_tags`).
+- `addresses`: new columns `mac`, `expires_at`, `tags` (via join table `address_tags`).
+- `sites`: new column `parent_id` (nullable FK → `sites.id`, self-referential for region/site hierarchy).
+- `users`: new columns `name`, `email`, `last_login_at`, `password_changed_at`, `theme`.
+
+These changes are applied automatically by `upgrade.sh` via `php migrate.php`.
+
+**New admin pages:** `vlans.php` (VLAN management), `tags.php` (Tag management) — both accessible from the Admin dropdown.
+
+**New config keys** added automatically on first boot after upgrade:
+- `utilization_warn`, `utilization_critical` (subnet utilization thresholds)
+- `auto_reserve_network_broadcast` (default `true`)
+- `alert_email`, `alert_util_warn_pct`, `alert_util_crit_pct` (email alerts, disabled by default)
+- `password_policy` block
+- `login_protection` block (bot protection, disabled by default)
+- `demo_mode` block (disabled by default)
+- `oidc` block (disabled by default)
+
+**API additions:** `vlan_name` and `tags[]` on subnet responses, `tags[]` on address responses, `resource=vlans` (full CRUD), `?tag=` / `?vlan_id=` / `?parent_id=` / `?site_id=` / `?ip_version=` / `?expired=1` filters, bulk write (`POST ?resource=addresses&bulk=1` / `POST ?resource=subnets&bulk=1`).
+
+---
+
 ## CLI utilities
 
 These scripts are run from the application directory using the PHP CLI.

--- a/testing/playwright/tests/db-tools.spec.ts
+++ b/testing/playwright/tests/db-tools.spec.ts
@@ -97,7 +97,7 @@ test('db import round-trip succeeds and data survives', async () => {
 
   // Verify data survived the round-trip
   await page.goto('subnets.php');
-  await expect(page.getByText(TEST_CIDR1)).toBeVisible();
+  await expect(page.getByText(TEST_CIDR1).first()).toBeVisible();
 });
 
 test('db_tools security warning banner is present', async () => {

--- a/testing/playwright/tests/subnets.spec.ts
+++ b/testing/playwright/tests/subnets.spec.ts
@@ -60,7 +60,7 @@ test('create subnet appears in list', async () => {
     action: 'create', cidr: TEST_CIDR1, description: 'PW test subnet 1',
   });
   await page.goto('subnets.php');
-  await expect(page.getByText(TEST_CIDR1)).toBeVisible();
+  await expect(page.getByText(TEST_CIDR1).first()).toBeVisible();
   subnetId = await subnetIdFor(page, TEST_CIDR1);
   expect(subnetId, 'subnet ID extractable').not.toBeNull();
 });
@@ -81,7 +81,7 @@ test('update subnet description', async () => {
     cidr: TEST_CIDR1, description: 'PW test subnet 1 — EDITED',
   });
   await page.goto('subnets.php');
-  await expect(page.getByText('EDITED')).toBeVisible();
+  await expect(page.getByText('EDITED').first()).toBeVisible();
 });
 
 test('deep-link from subnet row leads to addresses page (#246)', async () => {

--- a/testing/scripts/test_api.sh
+++ b/testing/scripts/test_api.sh
@@ -758,6 +758,131 @@ else
 fi
 
 # ====================================================================
+log "=== VRFs ==="
+# ====================================================================
+
+call_api GET vrfs
+assert_http 200 "GET vrfs → 200"
+VRFS_ARRAY=$(python3 -c "import sys,json; print(type(json.load(sys.stdin).get('vrfs',[])).__name__)" <<< "$BODY" 2>/dev/null || echo "")
+[[ "$VRFS_ARRAY" == "list" ]] && pass "vrfs array is a list" || fail "vrfs response missing 'vrfs' array"
+
+# Create a VRF
+call_api POST vrfs '{"name":"API-Test-VRF","description":"API test","rd":"65000:1"}'
+assert_http 201 "Create VRF → 201"
+API_VRF_ID=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+[[ -n "$API_VRF_ID" && "$API_VRF_ID" != "None" ]] && pass "Create VRF returns id=$API_VRF_ID" || fail "Create VRF — no id in response"
+
+# Get VRF
+call_api GET "vrfs&id=$API_VRF_ID"
+assert_http 200 "GET single VRF → 200"
+VRF_NAME=$(python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('vrf',d).get('name',''))" <<< "$BODY" 2>/dev/null || echo "")
+[[ "$VRF_NAME" == "API-Test-VRF" ]] && pass "VRF name matches" || fail "VRF name mismatch: $VRF_NAME"
+
+# Update VRF
+call_api PUT "vrfs&id=$API_VRF_ID" '{"name":"API-Test-VRF-UPDATED","description":"updated","rd":"65000:2"}'
+assert_http 200 "Update VRF → 200"
+
+# VRF overlap: same CIDR in different VRFs should succeed
+call_api POST subnets '{"cidr":"10.200.0.0/24","description":"VRF overlap test 1"}'
+assert_http 201 "Create subnet (global VRF) → 201"
+OVERLAP_SUBNET1=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+
+call_api POST subnets "{\"cidr\":\"10.200.0.0/24\",\"description\":\"VRF overlap test 2\",\"vrf_id\":$API_VRF_ID}"
+assert_http 201 "Create same CIDR in different VRF → 201 (overlap allowed)"
+OVERLAP_SUBNET2=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+
+# Subnet response includes vrf_id and vrf_name
+call_api GET "subnets&id=$OVERLAP_SUBNET2"
+VRF_NAME_IN_SUBNET=$(python3 -c "import sys,json; d=json.load(sys.stdin); s=d.get('subnet',{}); print(s.get('vrf_name','MISSING'))" <<< "$BODY" 2>/dev/null || echo "")
+[[ "$VRF_NAME_IN_SUBNET" == "API-Test-VRF-UPDATED" ]] && pass "Subnet response includes vrf_name" || fail "Subnet vrf_name mismatch: $VRF_NAME_IN_SUBNET"
+
+# vrf_id filter on subnets
+call_api GET "subnets&vrf_id=$API_VRF_ID"
+assert_http 200 "GET subnets with ?vrf_id= → 200"
+VRF_FILTER_COUNT=$(python3 -c "import sys,json; print(len(json.load(sys.stdin).get('subnets',[])))" <<< "$BODY" 2>/dev/null || echo "0")
+[[ "$VRF_FILTER_COUNT" -ge 1 ]] && pass "?vrf_id= filter: $VRF_FILTER_COUNT subnet(s)" || fail "?vrf_id= filter returned no subnets"
+
+# Cleanup overlap test subnets
+[[ -n "$OVERLAP_SUBNET2" && "$OVERLAP_SUBNET2" != "None" ]] && { call_api DELETE "subnets&id=$OVERLAP_SUBNET2"; assert_http 204 "Delete VRF-scoped subnet → 204"; }
+[[ -n "$OVERLAP_SUBNET1" && "$OVERLAP_SUBNET1" != "None" ]] && { call_api DELETE "subnets&id=$OVERLAP_SUBNET1"; assert_http 204 "Delete global-VRF subnet → 204"; }
+
+# Delete VRF
+[[ -n "$API_VRF_ID" && "$API_VRF_ID" != "None" ]] && {
+    call_api DELETE "vrfs&id=$API_VRF_ID"
+    assert_http 204 "Delete VRF → 204"
+}
+
+# ====================================================================
+log "=== Contacts ==="
+# ====================================================================
+
+call_api GET contacts
+assert_http 200 "GET contacts → 200"
+CONTACTS_ARRAY=$(python3 -c "import sys,json; print(type(json.load(sys.stdin).get('contacts',[])).__name__)" <<< "$BODY" 2>/dev/null || echo "")
+[[ "$CONTACTS_ARRAY" == "list" ]] && pass "contacts array is a list" || fail "contacts response missing 'contacts' array"
+
+# Create a contact
+call_api POST contacts '{"name":"API Test Contact","email":"api@example.com","phone":"555-1234","org":"Test Org","note":"API test"}'
+assert_http 201 "Create contact → 201"
+API_CONTACT_ID=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+[[ -n "$API_CONTACT_ID" && "$API_CONTACT_ID" != "None" ]] && pass "Create contact returns id=$API_CONTACT_ID" || fail "Create contact — no id in response"
+
+# Search contacts with ?q=
+call_api GET "contacts&q=API+Test"
+assert_http 200 "GET contacts with ?q= → 200"
+CONTACT_SEARCH_COUNT=$(python3 -c "import sys,json; print(len(json.load(sys.stdin).get('contacts',[])))" <<< "$BODY" 2>/dev/null || echo "0")
+[[ "$CONTACT_SEARCH_COUNT" -ge 1 ]] && pass "?q= contact search: $CONTACT_SEARCH_COUNT result(s)" || fail "?q= contact search returned no results"
+
+# Update contact
+call_api PUT "contacts&id=$API_CONTACT_ID" '{"name":"API Test Contact UPDATED","email":"updated@example.com","phone":"555-5678","org":"Updated Org","note":"updated"}'
+assert_http 200 "Update contact → 200"
+
+# Verify owner_contact_id in address response after linking
+# Create a subnet + address to test contact_id filter
+call_api POST subnets '{"cidr":"10.201.0.0/24","description":"contact test subnet"}'
+assert_http 201 "Create contact-test subnet → 201"
+CONTACT_SUBNET_ID=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+
+if [[ -n "$CONTACT_SUBNET_ID" && "$CONTACT_SUBNET_ID" != "None" ]]; then
+    call_api POST addresses "{\"subnet_id\":$CONTACT_SUBNET_ID,\"ip\":\"10.201.0.10\",\"hostname\":\"contact-test\",\"owner_contact_id\":$API_CONTACT_ID}"
+    assert_http 201 "Create address with owner_contact_id → 201"
+    CONTACT_ADDR_ID=$(python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" <<< "$BODY" 2>/dev/null || echo "")
+
+    # Verify owner_contact_name in address response
+    if [[ -n "$CONTACT_ADDR_ID" && "$CONTACT_ADDR_ID" != "None" ]]; then
+        call_api GET "addresses&subnet_id=$CONTACT_SUBNET_ID"
+        CONTACT_NAME_IN_ADDR=$(python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for a in d.get('addresses', []):
+    if str(a.get('id','')) == '${CONTACT_ADDR_ID}':
+        print(a.get('owner_contact_name','MISSING'))
+        break
+else:
+    print('NOT_FOUND')
+" <<< "$BODY" 2>/dev/null || echo "MISSING")
+        [[ "$CONTACT_NAME_IN_ADDR" == "API Test Contact UPDATED" ]] && pass "Address response includes owner_contact_name" || fail "owner_contact_name mismatch: $CONTACT_NAME_IN_ADDR"
+
+        # contact_id filter on addresses
+        call_api GET "addresses&contact_id=$API_CONTACT_ID"
+        assert_http 200 "GET addresses with ?contact_id= → 200"
+        CONTACT_ADDR_COUNT=$(python3 -c "import sys,json; print(len(json.load(sys.stdin).get('addresses',[])))" <<< "$BODY" 2>/dev/null || echo "0")
+        [[ "$CONTACT_ADDR_COUNT" -ge 1 ]] && pass "?contact_id= filter: $CONTACT_ADDR_COUNT address(es)" || fail "?contact_id= filter returned no addresses"
+
+        call_api DELETE "addresses&id=$CONTACT_ADDR_ID"
+        assert_http 204 "Delete contact-test address → 204"
+    fi
+    call_api DELETE "subnets&id=$CONTACT_SUBNET_ID"
+    assert_http 204 "Delete contact-test subnet → 204"
+fi
+
+# Delete contact
+[[ -n "$API_CONTACT_ID" && "$API_CONTACT_ID" != "None" ]] && {
+    call_api DELETE "contacts&id=$API_CONTACT_ID"
+    assert_http 204 "Delete contact → 204"
+}
+
+# ====================================================================
 log "=== Health Check ==="
 # ====================================================================
 


### PR DESCRIPTION
## Summary

- **#271 VRF support** — `vrfs` table, `UNIQUE(cidr, vrf_id)`, per-VRF overlap detection, admin CRUD page (`vrfs.php`), API `resource=vrfs`, `?vrf_id=` filter, `vrf_id`/`vrf_name` in subnet response
- **#272 Contacts** — first-class contact records; `contacts.php` admin CRUD; owner typeahead on address form; `owner_contact_id` FK on addresses; API `resource=contacts` with `?q=` search; `?contact_id=` filter; `owner_contact_name` in address response
- **#253 ⌘K / Ctrl+K search overlay** — debounced JSON fetch from `search.php?format=json`, keyboard nav (↑↓ Enter Escape), focus trap, backdrop click
- **#254 Inline cell editing** — click hostname/owner/note/group in address list; `action=update_cell` handler; Tab moves to next editable cell
- **#255 Subnet visual hierarchy map** — List/Map toggle; server-rendered indented tree with utilization bars; capped at 200 nodes; persisted to localStorage
- **#256 Column visibility** — gear dropdown on address table hides/shows columns; persisted per browser via localStorage
- **#257 Dashboard widgets** — hide/show stat cards and panels; site filter on "Addresses by Site"; all preferences in localStorage with Reset link

Also fixes a critical correctness bug: SQLite's `UNIQUE(cidr, vrf_id)` treats two NULLs as distinct, so same CIDR with global VRF (NULL) was not deduplicated. Fixed with an explicit `IS NULL` pre-check in both `subnets.php` and `api.php`.

## Test plan

- [x] PHPStan level 9 — 0 errors
- [x] PHPCS — 0 violations
- [x] PHPUnit 56/56
- [x] Semgrep 0 findings
- [x] API tests 134/134 pass (includes new VRF CRUD, VRF overlap, Contacts CRUD, owner_contact_name sections)
- [x] Playwright 149/154 (5 skipped — reCAPTCHA not configured, as expected)
- [x] Fresh install: migrations apply; vrfs/contacts tables created
- [x] Same CIDR in two VRFs → both 201; same CIDR same VRF → 409
- [x] DB import round-trip with new `vlans_before_delete_cleanup_subnets` trigger passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VRF support with VRF-scoped overlap checks and admin CRUD
  * Contacts as first-class objects with admin CRUD, typeahead and address linking
  * Global search overlay (Ctrl/Cmd+K) with JSON autocomplete (up to 20 results)
  * Inline address cell editing with save/revert and keyboard navigation
  * Subnet List/Map toggle (persisted view, 200-node cap)
  * Per-user column visibility, dashboard widget hide/pin, site filter and reset
* **Documentation**
  * README, changelog, upgrade notes and API docs updated for v2.1.0
* **Tests**
  * Added/updated API and UI tests covering VRFs, Contacts, and UI assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->