### PR TITLE
fix(migrations): drop vlans trigger before subnets rebuild in 2.1.0-vrfs

### DIFF
--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -402,6 +402,12 @@ function ipam_migrations(): array
                            site_id, vlan_id, vlan_fk, NULL, created_at, updated_at
                     FROM subnets
                 ");
+                // vlans_before_delete_cleanup_subnets fires ON vlans (not subnets), so
+                // it is NOT auto-dropped when subnets is dropped. SQLite validates trigger
+                // bodies during ALTER TABLE RENAME and will error if subnets doesn't exist
+                // at that point. Drop it explicitly here; it is recreated below.
+                $db->exec("DROP TRIGGER IF EXISTS vlans_before_delete_cleanup_subnets");
+
                 $db->exec("DROP TABLE subnets");
                 $db->exec("ALTER TABLE subnets_new RENAME TO subnets");
 
@@ -419,7 +425,7 @@ function ipam_migrations(): array
                     END
                 ");
 
-                // Recreate vlans cleanup trigger (also dropped with old subnets table)
+                // Recreate vlans cleanup trigger
                 $db->exec("
                     CREATE TRIGGER IF NOT EXISTS vlans_before_delete_cleanup_subnets
                     BEFORE DELETE ON vlans FOR EACH ROW


### PR DESCRIPTION
## Summary
- `vlans_before_delete_cleanup_subnets` fires ON `vlans`, not `subnets` — SQLite does not auto-drop it when `subnets` is dropped
- When `ALTER TABLE subnets_new RENAME TO subnets` runs, SQLite validates all dependent trigger bodies; at that moment `subnets` no longer exists → fatal `PDOException` on upgrade from v2.0.0
- Fix: explicitly `DROP TRIGGER IF EXISTS vlans_before_delete_cleanup_subnets` before the `DROP TABLE subnets` step; trigger is already recreated immediately after the rename

## Test plan
- [ ] Run `upgrade.sh` from v2.0.0 → v2.1.0 and confirm migration completes without error
- [ ] Verify `vlans_before_delete_cleanup_subnets` trigger exists after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of the database migration by improving trigger management during subnets table reconstruction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->