### PR TITLE
fix: v2.2.1 — prevent address data loss during migration from v1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
+## [2.2.1] - 2026-04-12
+
+### Fixed
+- **Critical data-loss bug** — Upgrading from any v1.x release directly to v2.1.0 or later wiped all IP addresses. Root cause: the `2.1.0-vrfs` migration rebuilds the `subnets` table (SQLite cannot drop a UNIQUE constraint in-place) by creating a new table, copying rows, dropping the old table, then renaming. With `PRAGMA foreign_keys = ON` active, SQLite executes an implicit row-by-row DELETE before dropping the parent table, which triggers `ON DELETE CASCADE` on the `addresses` table — deleting every address. Fix: `apply_migrations()` now disables FK enforcement (`PRAGMA foreign_keys = OFF`) before each migration's `BEGIN EXCLUSIVE` transaction and unconditionally re-enables it afterwards. Users already on v2.1.x are unaffected (the migration's idempotency guard exits early if the `vrf_id` column already exists); users upgrading directly from v1.x to v2.2.1 will now preserve all address data.
+
 ## [2.2.0] - 2026-04-12
 
 ### Fixed
@@ -478,6 +483,7 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[2.2.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.1.5...v2.2.0
 [2.1.5]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.1.3...v2.1.4

--- a/Simple-PHP-IPAM/demo_gate.php
+++ b/Simple-PHP-IPAM/demo_gate.php
@@ -71,8 +71,8 @@ $appName = trim(to_str($config['app_name'] ?? '')) ?: 'Simple PHP IPAM';
   <link rel="icon" type="image/webp" sizes="32x32" href="assets/favicon-32.webp">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
-  <link rel="stylesheet" href="assets/app.css?v=2.2.0">
-  <script defer src="assets/app.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="assets/app.css?v=2.2.1">
+  <script defer src="assets/app.js?v=2.2.1"></script>
 </head>
 <body>
 <div class="gate-wrap">

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -468,9 +468,18 @@ function apply_migrations(PDO $db): array
                 sleep(1);
             }
 
+            // PRAGMA foreign_keys cannot be changed inside a transaction — it must
+            // be set here, outside BEGIN. When it is ON, SQLite executes an implicit
+            // DELETE on every row before DROP TABLE, which triggers ON DELETE CASCADE
+            // on all child tables (addresses, subnet_tags, etc.), wiping all data.
+            // Disabling it for the duration of each migration prevents that cascade.
+            // FK enforcement is restored unconditionally after the transaction ends.
+            $db->exec("PRAGMA foreign_keys = OFF");
+
             try {
                 $db->exec("BEGIN EXCLUSIVE");
             } catch (Throwable $e) {
+                $db->exec("PRAGMA foreign_keys = ON");
                 $lastErr = $e;
                 if (stripos($e->getMessage(), 'locked') !== false || stripos($e->getMessage(), 'busy') !== false) {
                     continue;
@@ -488,12 +497,14 @@ function apply_migrations(PDO $db): array
                 $lastErr = null;
             } catch (Throwable $e) {
                 try { $db->exec("ROLLBACK"); } catch (Throwable) {}
+                $db->exec("PRAGMA foreign_keys = ON");
                 $lastErr = $e;
                 if (stripos($e->getMessage(), 'locked') !== false || stripos($e->getMessage(), 'busy') !== false) {
                     continue;
                 }
                 throw $e;
             }
+            $db->exec("PRAGMA foreign_keys = ON");
         }
 
         if ($lastErr !== null) {
@@ -2666,11 +2677,11 @@ function page_header(string $title, array $opts = []): void
     echo "<link rel='icon' type='image/png' sizes='32x32' href='assets/favicon-32.png'>";
     echo "<link rel='apple-touch-icon' type='image/webp' sizes='180x180' href='assets/apple-touch-icon.webp'>";
     echo "<link rel='apple-touch-icon' sizes='180x180' href='assets/apple-touch-icon.png'>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=2.2.0'>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=2.2.1'>";
     // Expose server-side theme via meta tag so app.js can seed localStorage (CSP-safe)
     $userTheme = to_str($_SESSION['user_theme'] ?? 'auto');
     echo "<meta name='ipam-server-theme' content='" . e($userTheme) . "'>";
-    echo "<script defer src='assets/app.js?v=2.2.0'></script>";
+    echo "<script defer src='assets/app.js?v=2.2.1'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -372,10 +372,9 @@ function ipam_migrations(): array
                 return;
             }
 
-            // Note: PRAGMA foreign_keys is a no-op inside a transaction, but DROP TABLE
-            // in SQLite does not check FK constraints on DDL — only DML triggers FK checks.
-            // All child tables (addresses, subnet_tags, alert_state) use ON DELETE CASCADE,
-            // so the rename-based rebuild is safe without disabling FK enforcement.
+            // FK enforcement is disabled by apply_migrations() before this transaction
+            // so that DROP TABLE subnets below does not cascade-delete child rows
+            // (addresses, subnet_tags, alert_state all have ON DELETE CASCADE on subnet_id).
             $db->exec("
                 CREATE TABLE subnets_new (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 if (!defined('IPAM_VERSION')) {
-    define('IPAM_VERSION', '2.2.0');
+    define('IPAM_VERSION', '2.2.1');
 }


### PR DESCRIPTION
## Summary

- Fixes critical data-loss bug (#347) where upgrading from v1.x to v2.1.0+ wiped all IP addresses

## Root cause

`PRAGMA foreign_keys = ON` causes SQLite to perform an implicit row-by-row DELETE before `DROP TABLE`. The `2.1.0-vrfs` migration drops the `subnets` table as part of a table rebuild; this cascade deletes every row in `addresses` (via `ON DELETE CASCADE`).

## Fix

`apply_migrations()` now sets `PRAGMA foreign_keys = OFF` before each migration's `BEGIN EXCLUSIVE` transaction and restores it unconditionally after. The PRAGMA cannot be changed inside a transaction, so it must be toggled at this boundary.

## Who is affected

- Users upgrading **directly from v1.x → v2.1.x or v2.2.0** would lose all address data
- Users already on v2.1.x are **not affected** (migration idempotency guard exits early)

## Test plan
- [x] PHP syntax check passes
- [x] PHPStan level 9 — no errors
- [x] PHPCS — no errors  
- [x] PHPUnit — 56 tests, 99 assertions, OK
- [x] Minimal SQLite reproduction confirms bug and fix

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical issue that caused IP address records to be unexpectedly deleted during system upgrades from version 2.2.0 to v2.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->