### PR TITLE
Release v2.5.1 — cron.php self-lock fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
+## [2.5.1] - 2026-04-14
+
+### Fixed
+- **`cron.php` self-lock** — concurrent cron invocations now exit cleanly instead of stacking. A new `data/cron.lock` file is held with `flock(LOCK_EX | LOCK_NB)` for the lifetime of each run; a second invocation that finds the lock held emits `{"task":"cron","skipped":true,"reason":"another cron.php instance is still running"}` and exits 0. This prevents the runaway scenario observed on a misconfigured `* * * * *` testing host where 30+ overlapping cron processes hammered the same `scan_results` table, eventually exhausted SQLite's `busy_timeout=30000`, and caused user-facing writes (e.g. `clear_login_failures()` on login) to fail with `database is locked`. Also covers the case where a single scan run takes longer than the configured cron interval and the next tick fires before the previous one exits. Released by `register_shutdown_function()` so it covers normal exit, fatal errors, and uncaught throws alike.
+
 ## [2.5.0] - 2026-04-13
 
 ### Added
@@ -543,6 +548,7 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[2.5.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.3.0...v2.4.0

--- a/README.md
+++ b/README.md
@@ -8,13 +8,9 @@ No Composer, no npm, no external dependencies — just PHP and a web server.
 
 ---
 
-## What's new in v2.5.0
+## What's new in v2.5.1
 
-- **Scanner broadcast exclusion** (#363) — network and IPv4 broadcast addresses are now skipped during scan runs. Some hosts respond to broadcast ICMP, which previously produced misleading up/down results. `/31` (RFC 3021) and `/32` have no reserved addresses; IPv6 only skips the network address.
-- **cron.php demo reset** (#364) — demo mode database reset is now an integrated task in the unified cron runner (throttled to once every 24 hours). `demo_reset.php` remains available as an unthrottled manual runner.
-- **docs/install.md** — new *Step 6: Register the cron runner* post-install section with the recommended crontab entry.
-- **Testing hardening** — new Playwright specs for CSP compliance, console cleanliness, and CSS regression (theme switching, sticky headers, status badge tokens, utilisation bar width). Extended tooltip and JS behaviour specs (fleet-wide `[data-tooltip]`/`[title]` non-empty sweep, CSRF-token-on-every-POST-form check, theme persistence). 329 Playwright tests, 96 PHPUnit tests.
-- Full QA gate (lint, PHPStan level 9, PHPCS, PHPUnit, Semgrep, Playwright) green.
+- **`cron.php` self-lock** — concurrent cron invocations now exit cleanly instead of stacking. Prevents the runaway scenario where a misconfigured `* * * * *` crontab (or a scan that takes longer than the cron interval) starts a new `cron.php` before the previous one finishes, eventually exhausting SQLite's busy_timeout and causing user-facing writes (e.g. login) to fail with `database is locked`.
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history.
 

--- a/Simple-PHP-IPAM/cron.php
+++ b/Simple-PHP-IPAM/cron.php
@@ -43,6 +43,45 @@ date_default_timezone_set(is_string($config['timezone'] ?? null) && $config['tim
 
 require $scriptDir . '/lib.php';
 
+// ---------------------------------------------------------------------------
+// Self-lock — refuse to run if another cron.php is still in progress.
+//
+// This prevents the runaway-stacking scenario where a misconfigured `* * * * *`
+// crontab (or a scan that takes longer than the cron interval) starts a new
+// invocation before the previous one has finished. Concurrent runs all hammer
+// the same scan_results table and inevitably exhaust the SQLite busy_timeout,
+// failing user-facing writes elsewhere with "database is locked".
+//
+// Uses LOCK_EX | LOCK_NB so the second invocation exits cleanly instead of
+// blocking. A separate lock file (data/cron.lock) keeps this independent of
+// the demo_reset stamp lock used in Task 7.
+// ---------------------------------------------------------------------------
+$cronLockFile = $scriptDir . '/data/cron.lock';
+$cronLockHandle = fopen($cronLockFile, 'c');
+if ($cronLockHandle === false) {
+    fwrite(STDERR, "[cron] ERROR: unable to open cron lock file: $cronLockFile\n");
+    exit(1);
+}
+if (!flock($cronLockHandle, LOCK_EX | LOCK_NB)) {
+    // Another cron.php instance already holds the lock — exit cleanly. This
+    // is normal/expected, not an error, so exit code 0.
+    echo json_encode([
+        'task'    => 'cron',
+        'skipped' => true,
+        'reason'  => 'another cron.php instance is still running',
+        'ts'      => date('c'),
+    ], JSON_UNESCAPED_SLASHES) . "\n";
+    fclose($cronLockHandle);
+    exit(0);
+}
+// Release on shutdown — covers normal exit, fatal errors, and uncaught throws.
+register_shutdown_function(static function () use ($cronLockHandle): void {
+    if (is_resource($cronLockHandle)) {
+        @flock($cronLockHandle, LOCK_UN);
+        @fclose($cronLockHandle);
+    }
+});
+
 $db       = ipam_db(to_str($config['db_path']));
 $now      = date('c');
 $exitCode = 0;

--- a/Simple-PHP-IPAM/demo_gate.php
+++ b/Simple-PHP-IPAM/demo_gate.php
@@ -71,8 +71,8 @@ $appName = trim(to_str($config['app_name'] ?? '')) ?: 'Simple PHP IPAM';
   <link rel="icon" type="image/webp" sizes="32x32" href="assets/favicon-32.webp">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
-  <link rel="stylesheet" href="assets/app.css?v=2.5.0">
-  <script defer src="assets/app.js?v=2.5.0"></script>
+  <link rel="stylesheet" href="assets/app.css?v=2.5.1">
+  <script defer src="assets/app.js?v=2.5.1"></script>
 </head>
 <body>
 <div class="gate-wrap">

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -2742,11 +2742,11 @@ function page_header(string $title, array $opts = []): void
     echo "<link rel='icon' type='image/png' sizes='32x32' href='assets/favicon-32.png'>";
     echo "<link rel='apple-touch-icon' type='image/webp' sizes='180x180' href='assets/apple-touch-icon.webp'>";
     echo "<link rel='apple-touch-icon' sizes='180x180' href='assets/apple-touch-icon.png'>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=2.5.0'>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=2.5.1'>";
     // Expose server-side theme via meta tag so app.js can seed localStorage (CSP-safe)
     $userTheme = to_str($_SESSION['user_theme'] ?? 'auto');
     echo "<meta name='ipam-server-theme' content='" . e($userTheme) . "'>";
-    echo "<script defer src='assets/app.js?v=2.5.0'></script>";
+    echo "<script defer src='assets/app.js?v=2.5.1'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 if (!defined('IPAM_VERSION')) {
-    define('IPAM_VERSION', '2.5.0');
+    define('IPAM_VERSION', '2.5.1');
 }


### PR DESCRIPTION
## Summary

**Bug fix release.** Adds a `flock(LOCK_EX | LOCK_NB)` self-lock on `data/cron.lock` at the top of `cron.php` so concurrent invocations exit cleanly instead of stacking.

## Why this matters

A misconfigured testing host (crontab `* * * * *` instead of `*/15 * * * *`) created 30+ overlapping `cron.php` processes hammering the same `scan_results` table. SQLite's `busy_timeout=30000` was eventually exhausted and user-facing writes started failing with `database is locked`:

```
Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: 5 database is locked
  in lib.php:346
  #0 lib.php(346): PDOStatement->execute(Array)
  #1 login.php(95): clear_login_failures(...)
```

The fix also covers the legitimate case where a single scan run takes longer than the configured cron interval and the next tick fires before the previous run exits.

## Behaviour

- A second invocation that finds the lock held emits `{"task":"cron","skipped":true,"reason":"another cron.php instance is still running"}` and exits 0 (normal, not an error).
- The lock is released via `register_shutdown_function()` so it covers normal exit, fatal errors, and uncaught throws alike.
- `data/cron.lock` is a separate file from `data/demo_last_reset.txt` (the per-task lock from v2.5.0 PR #365); the two locks don't interfere.

## QA

- `php -l` ✅
- PHPStan level 9 ✅
- PHPCS ✅
- PHPUnit 96/96 ✅
- Semgrep ✅
- Smoke test on dev:
  ```bash
  flock -x data/cron.lock -c "sleep 3" &
  sleep 0.5
  php cron.php          # → emits skipped, exit 0
  wait                  # → next normal run emits all 7 tasks cleanly
  ```

## Test plan
- [ ] CI green (php-qa.yml + semgrep.yml)
- [ ] CodeRabbit review clean
- [ ] After merge: tag v2.5.1, build release bundle, create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cron jobs now use a self-locking mechanism to prevent concurrent execution attempts, cleanly skipping duplicate runs that would previously cause database lock errors.

* **Chores**
  * Version bumped to 2.5.1 with asset cache updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->