### PR TITLE
chore(release): v2.5.2 containerized Playwright harness

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -1,0 +1,132 @@
+name: Playwright (nightly)
+
+# Nightly containerized Playwright harness for Simple PHP IPAM.
+#
+# - `containerized-playwright` runs the full suite against a Dockerized Apache+PHP
+#   instance seeded from demo_seed.php. SQLite is the only driver in v2.5.2;
+#   v2.10.0 adds mysql and v2.11.0 adds pgsql to the matrix.
+# - `htaccess-subset` runs a small HTTP-level test that verifies .htaccess deny
+#   rules work correctly against the same image.
+#
+# Both jobs use testing/playwright/Dockerfile.apache so the realism gap between
+# `php -S` and production Apache does not exist.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # 07:00 UTC daily
+  workflow_dispatch:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'Simple-PHP-IPAM/**'
+      - 'testing/playwright/**'
+      - '.github/workflows/playwright-nightly.yml'
+
+concurrency:
+  group: playwright-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  containerized-playwright:
+    name: Playwright (${{ matrix.driver }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        driver: [sqlite]   # v2.10.0 adds 'mysql'; v2.11.0 adds 'pgsql'
+    env:
+      DRIVER: ${{ matrix.driver }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: testing/playwright/package-lock.json
+
+      - name: Install Playwright dependencies
+        working-directory: testing/playwright
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: testing/playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Bootstrap containerized IPAM
+        run: bash testing/playwright/bootstrap-app.sh "$DRIVER"
+
+      - name: Run Playwright suite
+        working-directory: testing/playwright
+        env:
+          IPAM_BASE_URL: https://127.0.0.1:8443
+          IPAM_ADMIN_USER: demo
+          IPAM_ADMIN_PASS: demo
+          CI: 'true'
+        run: npx playwright test
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs ipam-pw-test || true
+
+      - name: Tear down containerized IPAM
+        if: always()
+        run: bash testing/playwright/teardown-app.sh
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.driver }}
+          path: testing/playwright/playwright-report/
+          retention-days: 7
+
+  htaccess-subset:
+    name: .htaccess coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: testing/playwright/package-lock.json
+
+      - name: Install Playwright dependencies
+        working-directory: testing/playwright
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: testing/playwright
+        run: npx playwright install --with-deps chromium
+
+      - name: Bootstrap containerized IPAM
+        run: bash testing/playwright/bootstrap-app.sh sqlite
+
+      - name: Run .htaccess spec only
+        working-directory: testing/playwright
+        env:
+          IPAM_BASE_URL: https://127.0.0.1:8443
+          CI: 'true'
+        run: npx playwright test tests/htaccess.spec.ts
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs ipam-pw-test || true
+
+      - name: Tear down containerized IPAM
+        if: always()
+        run: bash testing/playwright/teardown-app.sh
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-htaccess
+          path: testing/playwright/playwright-report/
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
+## [2.5.2] - 2026-04-14
+
+**Internal tooling release. No user-facing changes.** Application code, schema, and config are unchanged from v2.5.1 — end users can skip this release and go straight from v2.5.1 to v2.6.0. There is no release tarball and no GitHub release; v2.5.2 exists only as a git tag marking the milestone boundary for contributors.
+
+### Internal
+- **#428** — Playwright suite audit. The CDP → `@playwright/test` rewrite was already complete in earlier releases; this pass verified no dev-direct-only assumptions remain in `playwright.config.ts`, `fixtures/ipam.ts`, or the 32 spec files. Findings documented in `testing/playwright/MIGRATION_NOTES.md`.
+- **#429** — New containerized Playwright harness. `testing/playwright/bootstrap-app.sh` boots a Dockerized Apache+PHP instance with a self-signed cert on `https://127.0.0.1:8443`, seeds from `demo_seed.php`, and is ready for `npx playwright test`. New `.github/workflows/playwright-nightly.yml` nightly job runs the full suite against the SQLite matrix slot. v2.10.0 adds `mysql` and v2.11.0 adds `pgsql` to the same matrix.
+- **#430** — New Apache `.htaccess` coverage subset. `testing/playwright/tests/htaccess.spec.ts` (~13 tests) runs against the same Dockerized image as a separate CI job, verifying that the root and `data/` `.htaccess` deny rules block direct access to `config.php`, `lib.php`, `init.php`, schema files, `data/*`, CLI-only scripts, and `SHA256SUMS`. Future-gated skips for `vendor/` and `dialects/` that land in v2.9.0.
+- **#431** — Flake policy and contributor docs. `playwright.config.ts` now sets `retries: 2` in CI (0 locally), 60s test timeout, 10s expect timeout, 15s action timeout, and `trace: 'retain-on-failure'` for CI failure diagnosis. New `testing/playwright/scripts/flake-rate.mjs` aggregates the JSON reporter output into a green/yellow/red exit code. New `testing/playwright/README.md` documents running the suite, writing tests, debugging CI failures, and the flake budget. `CLAUDE.md` "Running the test suites" section rewritten to lead with the containerized path and keep dev-direct as a fallback for real-IdP OIDC and timezone tests.
+- **#432** — `demo_seed.php` audit. Added a header comment listing every fixture the seed produces (3 users, 6 sites, 2 VRFs, 4 VLANs, 3 contacts, 4 tags, 13 subnets, 50+ addresses, pre-populated audit log) so contributors can see what test data already exists before extending it. New `testing/playwright/SEED_AUDIT.md` serves as the running log of seed/test mismatches to be populated once nightly CI produces its first 7-run baseline.
+
 ## [2.5.1] - 2026-04-14
 
 ### Fixed
@@ -548,6 +559,7 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[2.5.2]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.5.1...v2.5.2
 [2.5.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v2.4.0...v2.4.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Developer guide for AI assistants working on this repository.
 
 ## Project overview
 
-Simple PHP IPAM is a lightweight IPv4/IPv6 address management web application built with **PHP 8.2+ and SQLite**. It has no Composer dependencies and no npm build step — everything is vanilla PHP, CSS, and JavaScript. The web root is `Simple-PHP-IPAM/` (the subdirectory, not the repo root).
+Simple PHP IPAM is a lightweight IPv4/IPv6 address management web application built with **PHP 8.2+ and SQLite**. It has **no npm build step** — all CSS and JavaScript are vanilla. Starting in v2.8.0, the application ships a small, carefully curated set of Composer-managed runtime dependencies bundled into the release tarball, so end users still deploy by extracting the tarball with no build step. The web root is `Simple-PHP-IPAM/` (the subdirectory, not the repo root).
 
 ---
 
@@ -179,6 +179,52 @@ Migrations remain the source of truth for schema evolution. The three schema fil
 **Dialect helpers** (the `Ipam\Db\Dialect` abstraction from v2.8.0) are used inside migration closures for portable SQL — `$dialect->now()`, `$dialect->upsert()`, `$dialect->autoincrement()`, `$dialect->binary_type()`, etc. The schema files themselves are hand-written per engine and do not go through the dialect layer, because they are engine-specific by definition.
 
 **Do not introduce a schema templating system.** This was evaluated during v2.8.0 planning and rejected: three plain SQL files are easier to review, easier to debug against a live database, and aligned with the project's vanilla-PHP ethos. The parity test plus migration-replay test is sufficient drift protection.
+
+### Runtime dependencies
+
+Adopted in v2.8.0. The project uses Composer-managed runtime dependencies under a narrow, curated policy. The goals are (1) to avoid hand-rolling security-sensitive network protocols and cryptography and (2) to preserve the "rsync and run" deployment story for end users.
+
+**Deployment model:**
+
+- `vendor/` is gitignored and never committed
+- `releases/make_releases.sh` runs `composer install --no-dev --optimize-autoloader` against the working tree before building the tarball
+- The tarball includes `vendor/` with all production deps pre-built
+- End users extract the tarball and run — no `composer install` on the server, no network access to packagist required at install time
+- `.htaccess` inside `vendor/` denies all web access to bundled library source
+- Security advisories are tracked via `composer audit` in CI (scheduled nightly and on every PR)
+
+**When a runtime dependency is acceptable:**
+
+A new dep must meet **all** of the following criteria:
+
+1. **Narrow purpose.** It solves a security-sensitive protocol or standards compliance problem where hand-rolling is error-prone. Canonical examples: SMTP, SAML, OAuth/OIDC/JWT verification, LDAP, TOTP.
+2. **Mature.** >5 years of active maintenance, with visible security advisories and a track record of prompt response.
+3. **Widely used.** Big enough user base that bugs get found by someone else first. "Thousands of GitHub stars" is not a metric but "used by WordPress, Drupal, Joomla" is.
+4. **Minimal dependency tree.** Prefer libraries with zero or few transitive deps. A 300KB lib with 20 transitive deps is worse than a 500KB lib with none.
+5. **Liberal license.** MIT, BSD, Apache 2.0. No GPL-family licenses (viral), no LGPL (complicated for bundled distribution).
+6. **Maintainer justification.** Adding a new dep requires a PR that updates this section with the dep name, version constraint, purpose, and a one-paragraph justification explaining why vanilla PHP is a poor fit.
+
+**When a runtime dependency is NOT acceptable:**
+
+- **IPAM business logic.** Subnet math, CIDR parsing, address allocation, audit logging, permission checks, etc. All of this is bespoke to the project and has no library equivalent worth pulling in.
+- **UI and rendering.** All HTML is hand-authored PHP. No templating engines, no frontend frameworks, no CSS preprocessors.
+- **Simple utilities.** If it can be done in 20 lines of vanilla PHP, it should be done in 20 lines of vanilla PHP. Do not pull in a library for one function.
+- **"Nice to have" conveniences.** Libraries that make code 5% cleaner are not worth the dep. The bar is "hand-rolling is meaningfully dangerous or expensive," not "this API is nicer."
+
+**Current runtime dependency whitelist:**
+
+| Package | Version | Purpose | Justified in |
+|---|---|---|---|
+| (none yet — policy introduced in v2.8.0 as infrastructure; first dep lands in v3.1.0) | — | — | — |
+
+First dep expected to land in v3.1.0 (#415, PHPMailer for SMTP). Future candidates to be evaluated on a case-by-case basis as feature work surfaces them.
+
+**Explicitly not adopted (deliberate choices):**
+
+- No HTTP client library yet. `ext-curl` + careful wrapping is the current path for webhook dispatch (#399, v3.3.0). May revisit if curl wrapping proves painful at implementation time — Guzzle or symfony/http-client would be the likely candidates.
+- No JWT / JWK library yet. The hand-rolled OIDC in `lib.php` works and is not being retrofitted on speculation. May revisit if a security-sensitive bug surfaces or if the RFC tracking burden becomes obviously not worth it.
+- No JSON Schema validator. Custom fields (#313, v3.5.0) use a bespoke lightweight type system, not JSON Schema.
+- No templating engine, no DI container, no service locator, no ORM. These are architectural departures that do not fit this project's philosophy.
 
 ### When to use classes vs functions
 
@@ -584,7 +630,8 @@ Include `https://claude.ai/code/session_...` in commit body.
 
 ## Key constraints and gotchas
 
-- **No Composer, no npm in production** — the application itself has zero runtime dependencies. Everything must be implemented in vanilla PHP using only standard extensions (`pdo`, `pdo_sqlite`, `openssl`). Composer is used for *dev tooling only* (`vendor/` is gitignored and never deployed).
+- **Runtime dependencies are allowed but curated** — see the "Runtime dependencies" section below for the policy and current whitelist. Historical note: this project shipped with zero runtime deps through v2.7.0 and adopted a curated dep policy in v2.8.0 to avoid hand-rolling security-sensitive protocols. The `vendor/` directory is gitignored in the repo but **is shipped in the release tarball** — end users still deploy by extracting the tarball with no build step. `composer install --no-dev` runs at release bundle time, not at install time on the target.
+- **No npm in production** — all frontend CSS and JavaScript is vanilla. No bundlers, no build step, no node_modules. This rule is separate from the Composer rule and is not being relaxed.
 - **`addresses` has no `ip_version`** — that column exists only on `subnets`. Do not add it to address INSERTs.
 - **`addresses.grp` is a SQL reserved word** — stored as `grp` in the DB, exposed as `group` in the UI, API responses, and CSV headers.
 - **`addresses.mac`** — free-form MAC address string, `NOT NULL DEFAULT ''`. Never validate the format server-side; users may enter any notation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,13 +217,13 @@ A new dep must meet **all** of the following criteria:
 |---|---|---|---|
 | (none yet — policy introduced in v2.8.0 as infrastructure; first dep lands in v3.1.0) | — | — | — |
 
-First dep expected to land in v3.1.0 (#415, PHPMailer for SMTP). Future candidates to be evaluated on a case-by-case basis as feature work surfaces them.
+First dep expected to land in v3.2.0 (#415, PHPMailer for SMTP). Future candidates to be evaluated on a case-by-case basis as feature work surfaces them.
 
 **Explicitly not adopted (deliberate choices):**
 
-- No HTTP client library yet. `ext-curl` + careful wrapping is the current path for webhook dispatch (#399, v3.3.0). May revisit if curl wrapping proves painful at implementation time — Guzzle or symfony/http-client would be the likely candidates.
+- No HTTP client library yet. `ext-curl` + careful wrapping is the current path for webhook dispatch (#399, v3.4.0). May revisit if curl wrapping proves painful at implementation time — Guzzle or symfony/http-client would be the likely candidates.
 - No JWT / JWK library yet. The hand-rolled OIDC in `lib.php` works and is not being retrofitted on speculation. May revisit if a security-sensitive bug surfaces or if the RFC tracking burden becomes obviously not worth it.
-- No JSON Schema validator. Custom fields (#313, v3.5.0) use a bespoke lightweight type system, not JSON Schema.
+- No JSON Schema validator. Custom fields (#313, v3.6.0) use a bespoke lightweight type system, not JSON Schema.
 - No templating engine, no DI container, no service locator, no ORM. These are architectural departures that do not fit this project's philosophy.
 
 ### When to use classes vs functions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,22 @@ The `audit_log` table is **append-only** — SQLite triggers raise an abort on a
 
 IPs are stored as raw binary blobs (`inet_pton()` output) for correct sort order and fast range queries. Never store text IPs in `ip_bin`/`network_bin`. Use `inet_pton()` to encode and `inet_ntop()` to decode.
 
+**Storage format: native length, never padded.** IPv4 is stored as 4 bytes and IPv6 as 16 bytes, matching the output of `inet_pton()` directly. Do not left-pad IPv4 to 16 bytes. All three supported engines (SQLite, MySQL `VARBINARY(16)`, Postgres `BYTEA`) do byte-wise memcmp comparison on native-length values, so sort order is equivalent across engines without padding. This was evaluated during v2.8.0 planning and locked in as the storage convention — if you are tempted to change it, read the discussion on #410 and #379 first.
+
+**All binding goes through `ipam_bind_binary()`** (introduced in v2.8.0, #379), which uses `PDO::PARAM_LOB` on every driver. This is non-negotiable:
+
+- On **SQLite**, `PARAM_LOB` is required so the column stores with BLOB affinity rather than TEXT affinity. SQLite's comparison rules state that any BLOB sorts greater than any TEXT regardless of byte content, so mixing affinities in the same column breaks `ORDER BY ip_bin` and every range query. Pre-v2.8.0 data was inadvertently stored with TEXT affinity because the default `PARAM_STR` binding was used. The migration in #410 normalizes existing rows to BLOB on upgrade.
+- On **MySQL**, `PARAM_LOB` is required for `VARBINARY(16)` columns. `PARAM_STR` would string-escape high bytes and truncate at null bytes, corrupting every stored IP.
+- On **Postgres**, `PARAM_LOB` is required for `BYTEA` columns. The pgsql driver may also need an explicit bytea type hint on prepare — verify during the v2.10.0 implementation.
+
+**Round-trip test vectors** that any new driver binding must handle correctly:
+
+- `inet_pton('10.0.0.0')` — `\x0A\x00\x00\x00`, null bytes after the first byte
+- `inet_pton('2001:db8::')` — `\x20\x01\x0D\xB8\x00...\x00`, mostly null bytes
+- `inet_pton('255.255.255.255')` — `\xFF\xFF\xFF\xFF`, all high bytes
+
+These three values catch the most common string-escape bugs immediately. If a binding round-trips any of them incorrectly, the driver is broken and must not ship.
+
 Key helpers in `lib.php`:
 - `parse_cidr(string $cidr): ?array` — validates and normalises a CIDR, returns `['version', 'network', 'prefix', 'net_bin']`
 - `normalize_ip(string $ip): ?array` — returns `['ip', 'bin', 'version']`
@@ -137,6 +153,42 @@ Key helpers in `lib.php`:
 Migrations live in `migrations.php` as an associative array of version string → closure returned by `ipam_migrations()`. `apply_migrations()` in `lib.php` calls `ksort($migs, SORT_NATURAL)` before iterating, so **array order does not matter** — migrations always execute in natural version order. Each migration runs in a transaction and is recorded in `schema_migrations`. Always guard `ALTER TABLE` with `PRAGMA table_info()` checks to make new migrations idempotent.
 
 **When adding a new version:** add the migration closure, bump `version.php`, update `CHANGELOG.md` (keepachangelog format).
+
+### Creating new data tables in post-v4.0.0 releases
+
+Once v4.0.0 has shipped and the tenancy migration has run, every data table in the IPAM schema has a `tenant_id` column pointing at the `tenants` table. **Any migration in a release numbered greater than v4.0.0 that creates a new data table must include `tenant_id` in the `CREATE TABLE` statement from day one**, with `NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT` and an index on `tenant_id`.
+
+This rule exists because the v4.0.0 tenancy migration only backfills tables that existed at the time it ran. A table created in v4.1.0, v5.0.0, or any later release is outside that migration's reach and must carry its own tenant scoping from creation.
+
+Pre-v4.0.0 migrations do not need to worry about this — they predate tenancy and are handled automatically by v4.0.0's runtime table enumeration (see #406 for implementation). The rule applies strictly to migrations whose version key sorts greater than v4.0.0 under natural-sort ordering.
+
+**Exception:** tables that are explicitly global and not tenant-scoped (e.g. `users`, `tenants` itself, future `system_health` or similar) do not take `tenant_id`. When adding such a table, document in the migration closure why it is global, and update `docs/tenancy.md` to list it as an exception.
+
+### Modifying the schema (multi-engine, from v2.8.0 onward)
+
+Once v2.8.0 lands, the project ships three schema files that must stay in sync:
+
+- `schema.sql` — SQLite (authoritative for fresh SQLite installs)
+- `schema.mysql.sql` — MySQL 8.0+ (lands in v2.9.0)
+- `schema.pgsql.sql` — PostgreSQL 14+ (lands in v2.10.0)
+
+**When adding or modifying a table, column, index, or constraint:** update all three files in the same PR. No exceptions. The `SchemaParityTest` in CI will fail the build if the three files diverge on any structural element (table set, column set, type class, nullability, default kind, FK target, FK on-delete action). Type classes are normalised — `BLOB` / `VARBINARY(16)` / `BYTEA` all map to `"binary"`, so you do not need to match exact type names, only semantic equivalents.
+
+Migrations remain the source of truth for schema evolution. The three schema files are a fast path for fresh installs; the migration chain is what existing installs run through. `MigrationTest` asserts that applying every migration from v1.0 on an empty database converges to the same structural state as the matching `schema.X.sql` file, so drift between "what migrations produce" and "what the schema file says" is also caught.
+
+**Dialect helpers** (the `Ipam\Db\Dialect` abstraction from v2.8.0) are used inside migration closures for portable SQL — `$dialect->now()`, `$dialect->upsert()`, `$dialect->autoincrement()`, `$dialect->binary_type()`, etc. The schema files themselves are hand-written per engine and do not go through the dialect layer, because they are engine-specific by definition.
+
+**Do not introduce a schema templating system.** This was evaluated during v2.8.0 planning and rejected: three plain SQL files are easier to review, easier to debug against a live database, and aligned with the project's vanilla-PHP ethos. The parity test plus migration-replay test is sufficient drift protection.
+
+### When to use classes vs functions
+
+The project's application code is predominantly procedural — `lib.php` is a bag of top-level functions, and most pages are procedural PHP. The one deliberate exception is the `Dialect` family of classes under `dialects/` (introduced in v2.8.0), which encapsulates per-engine SQL differences.
+
+**Classes are appropriate for polymorphic contracts with a small, closed set of implementations.** The `Dialect` interface with `SqliteDialect` / `MysqlDialect` / `PgsqlDialect` is the canonical example: the contract says "every DB engine must implement these methods with these signatures," and PHPStan level 9 enforces that at compile time. Without an interface, we would have to reinvent the same guarantee with array shape annotations or runtime dispatch, both of which are worse.
+
+**Classes are not appropriate for utility functions, request handlers, or anything that would otherwise be a plain function.** Do not OO-ify `lib.php`. Do not wrap handlers in controller classes. Do not introduce a service locator or DI container. When in doubt, write a function.
+
+**Namespaces are not used.** The project has zero namespaces today and a hand-rolled autoloader is not worth the complexity for the small number of classes we expect to introduce. Keep class names unambiguous (`Dialect`, `SqliteDialect`, etc.) and `require_once` explicitly in `init.php` or `lib.php`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,11 +469,24 @@ php -l Simple-PHP-IPAM/users.php
 # etc.
 ```
 
-### Running the test suites against dev-direct
+### Running the test suites
 
-The dev environment is shared, stateful, and has multiple footguns that have caused repeated false failures. Read this whole section before invoking the suites. All commands assume cwd is the repo root.
+Two paths exist as of v2.5.2:
 
-See the dedicated subsections below: **Local PHP tools**, **Deploy**, **Pre-flight cleanup**, **Verify admin login**, **test_api.sh**, **Playwright**.
+1. **Containerized** — a fully self-contained Dockerized Apache+PHP instance on `https://127.0.0.1:8443` seeded from `demo_seed.php`. No SSH, no dev-direct dependencies, no shared state. Use this for Playwright unless you need something that only a real deployment can test (real-IdP OIDC, the `timezone.spec.ts` remote-config flow). See `testing/playwright/README.md` for full instructions. In short:
+   ```bash
+   (cd testing/playwright && npm ci && npx playwright install chromium)
+   bash testing/playwright/bootstrap-app.sh sqlite
+   (cd testing/playwright && \
+     IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+     npx playwright test)
+   bash testing/playwright/teardown-app.sh
+   ```
+   The nightly `.github/workflows/playwright-nightly.yml` CI job runs the same commands against the same image; a failing CI run can almost always be reproduced locally verbatim.
+
+2. **Manual against dev-direct** — the shared test server at `https://dev-direct.seanmousseau.com:8343/claude/ipam`. Needed for `test_api.sh`, real-IdP OIDC scenarios, and any quick verification against a "real" install. The dev environment is shared, stateful, and has multiple footguns that have caused repeated false failures — read this whole section before invoking the suites. All commands assume cwd is the repo root.
+
+See the dedicated subsections below: **Local PHP tools**, **Deploy**, **Pre-flight cleanup**, **Verify admin login**, **test_api.sh**, **Playwright (dev-direct)**.
 
 #### Local PHP tools
 
@@ -573,7 +586,9 @@ bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; \
 - **`SSH_HOST` + `SSH_DB_PATH`** let the script auto-create an API key on the dev server. Without them you must pass `API_KEY=...`.
 - Expect ~150 PASS, 0 FAIL, possibly 1 SKIP. A `database is locked` error means a stray cron is holding the lock — re-run pre-flight cleanup.
 
-#### Playwright
+#### Playwright (dev-direct)
+
+Prefer the containerized local path described at the top of this section. Use dev-direct only when you need something that only a real deployment can test (real-IdP OIDC, `timezone.spec.ts` which SSHes to patch remote config, etc.). Most timezone and OIDC specs self-skip against non-dev-direct targets via an `isDevServer()` guard.
 
 ```bash
 bash -c 'set -a; source ~/.claude/dev-secrets.env; set +a; \
@@ -599,7 +614,7 @@ Before building a release bundle, **always** complete these steps in order:
 3. Update `testing/scripts/test_api.sh` if API endpoints were added or changed
 4. Update `testing/scripts/cdp_test.py` if UI features were added or changed
 5. Run `php -l` on every changed PHP file
-6. Run the full QA suite using the commands in *Running the test suites against dev-direct* above (Local PHP tools → Deploy → Pre-flight cleanup → Verify admin login → test_api.sh → Playwright). All must pass.
+6. Run the full QA suite using the commands in *Running the test suites* above: Local PHP tools → containerized Playwright (fast, hermetic) → dev-direct pipeline if needed for test_api.sh or real-IdP/timezone coverage (Deploy → Pre-flight cleanup → Verify admin login → test_api.sh → Playwright dev-direct). All must pass.
 7. Run CodeRabbit review and address any Critical findings:
    ```bash
    coderabbit review --plain -t all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Developer guide for AI assistants working on this repository.
 
 ## Project overview
 
-Simple PHP IPAM is a lightweight IPv4/IPv6 address management web application built with **PHP 8.2+ and SQLite**. It has **no npm build step** — all CSS and JavaScript are vanilla. Starting in v2.8.0, the application ships a small, carefully curated set of Composer-managed runtime dependencies bundled into the release tarball, so end users still deploy by extracting the tarball with no build step. The web root is `Simple-PHP-IPAM/` (the subdirectory, not the repo root).
+Simple PHP IPAM is a lightweight IPv4/IPv6 address management web application built with **PHP 8.2+ and SQLite**. It has **no npm build step** — all CSS and JavaScript are vanilla. Starting in v2.9.0, the application ships a small, carefully curated set of Composer-managed runtime dependencies bundled into the release tarball, so end users still deploy by extracting the tarball with no build step. The web root is `Simple-PHP-IPAM/` (the subdirectory, not the repo root).
 
 ---
 
@@ -123,11 +123,11 @@ IPs are stored as raw binary blobs (`inet_pton()` output) for correct sort order
 
 **Storage format: native length, never padded.** IPv4 is stored as 4 bytes and IPv6 as 16 bytes, matching the output of `inet_pton()` directly. Do not left-pad IPv4 to 16 bytes. All three supported engines (SQLite, MySQL `VARBINARY(16)`, Postgres `BYTEA`) do byte-wise memcmp comparison on native-length values, so sort order is equivalent across engines without padding. This was evaluated during v2.8.0 planning and locked in as the storage convention — if you are tempted to change it, read the discussion on #410 and #379 first.
 
-**All binding goes through `ipam_bind_binary()`** (introduced in v2.8.0, #379), which uses `PDO::PARAM_LOB` on every driver. This is non-negotiable:
+**All binding goes through `ipam_bind_binary()`** (introduced in v2.9.0, #379), which uses `PDO::PARAM_LOB` on every driver. This is non-negotiable:
 
-- On **SQLite**, `PARAM_LOB` is required so the column stores with BLOB affinity rather than TEXT affinity. SQLite's comparison rules state that any BLOB sorts greater than any TEXT regardless of byte content, so mixing affinities in the same column breaks `ORDER BY ip_bin` and every range query. Pre-v2.8.0 data was inadvertently stored with TEXT affinity because the default `PARAM_STR` binding was used. The migration in #410 normalizes existing rows to BLOB on upgrade.
+- On **SQLite**, `PARAM_LOB` is required so the column stores with BLOB affinity rather than TEXT affinity. SQLite's comparison rules state that any BLOB sorts greater than any TEXT regardless of byte content, so mixing affinities in the same column breaks `ORDER BY ip_bin` and every range query. Pre-v2.9.0 data was inadvertently stored with TEXT affinity because the default `PARAM_STR` binding was used. The migration in #410 normalizes existing rows to BLOB on upgrade.
 - On **MySQL**, `PARAM_LOB` is required for `VARBINARY(16)` columns. `PARAM_STR` would string-escape high bytes and truncate at null bytes, corrupting every stored IP.
-- On **Postgres**, `PARAM_LOB` is required for `BYTEA` columns. The pgsql driver may also need an explicit bytea type hint on prepare — verify during the v2.10.0 implementation.
+- On **Postgres**, `PARAM_LOB` is required for `BYTEA` columns. The pgsql driver may also need an explicit bytea type hint on prepare — verify during the v2.11.0 implementation.
 
 **Round-trip test vectors** that any new driver binding must handle correctly:
 
@@ -164,25 +164,25 @@ Pre-v4.0.0 migrations do not need to worry about this — they predate tenancy a
 
 **Exception:** tables that are explicitly global and not tenant-scoped (e.g. `users`, `tenants` itself, future `system_health` or similar) do not take `tenant_id`. When adding such a table, document in the migration closure why it is global, and update `docs/tenancy.md` to list it as an exception.
 
-### Modifying the schema (multi-engine, from v2.8.0 onward)
+### Modifying the schema (multi-engine, from v2.9.0 onward)
 
-Once v2.8.0 lands, the project ships three schema files that must stay in sync:
+Once v2.9.0 lands, the project ships three schema files that must stay in sync:
 
 - `schema.sql` — SQLite (authoritative for fresh SQLite installs)
-- `schema.mysql.sql` — MySQL 8.0+ (lands in v2.9.0)
-- `schema.pgsql.sql` — PostgreSQL 14+ (lands in v2.10.0)
+- `schema.mysql.sql` — MySQL 8.0+ (lands in v2.10.0)
+- `schema.pgsql.sql` — PostgreSQL 14+ (lands in v2.11.0)
 
 **When adding or modifying a table, column, index, or constraint:** update all three files in the same PR. No exceptions. The `SchemaParityTest` in CI will fail the build if the three files diverge on any structural element (table set, column set, type class, nullability, default kind, FK target, FK on-delete action). Type classes are normalised — `BLOB` / `VARBINARY(16)` / `BYTEA` all map to `"binary"`, so you do not need to match exact type names, only semantic equivalents.
 
 Migrations remain the source of truth for schema evolution. The three schema files are a fast path for fresh installs; the migration chain is what existing installs run through. `MigrationTest` asserts that applying every migration from v1.0 on an empty database converges to the same structural state as the matching `schema.X.sql` file, so drift between "what migrations produce" and "what the schema file says" is also caught.
 
-**Dialect helpers** (the `Ipam\Db\Dialect` abstraction from v2.8.0) are used inside migration closures for portable SQL — `$dialect->now()`, `$dialect->upsert()`, `$dialect->autoincrement()`, `$dialect->binary_type()`, etc. The schema files themselves are hand-written per engine and do not go through the dialect layer, because they are engine-specific by definition.
+**Dialect helpers** (the `Dialect` abstraction from v2.9.0) are used inside migration closures for portable SQL — `$dialect->now()`, `$dialect->upsert()`, `$dialect->autoincrement()`, `$dialect->binary_type()`, etc. The schema files themselves are hand-written per engine and do not go through the dialect layer, because they are engine-specific by definition.
 
-**Do not introduce a schema templating system.** This was evaluated during v2.8.0 planning and rejected: three plain SQL files are easier to review, easier to debug against a live database, and aligned with the project's vanilla-PHP ethos. The parity test plus migration-replay test is sufficient drift protection.
+**Do not introduce a schema templating system.** This was evaluated during v2.9.0 planning and rejected: three plain SQL files are easier to review, easier to debug against a live database, and aligned with the project's vanilla-PHP ethos. The parity test plus migration-replay test is sufficient drift protection.
 
 ### Runtime dependencies
 
-Adopted in v2.8.0. The project uses Composer-managed runtime dependencies under a narrow, curated policy. The goals are (1) to avoid hand-rolling security-sensitive network protocols and cryptography and (2) to preserve the "rsync and run" deployment story for end users.
+Adopted in v2.9.0. The project uses Composer-managed runtime dependencies under a narrow, curated policy. The goals are (1) to avoid hand-rolling security-sensitive network protocols and cryptography and (2) to preserve the "rsync and run" deployment story for end users.
 
 **Deployment model:**
 
@@ -215,20 +215,20 @@ A new dep must meet **all** of the following criteria:
 
 | Package | Version | Purpose | Justified in |
 |---|---|---|---|
-| (none yet — policy introduced in v2.8.0 as infrastructure; first dep lands in v3.1.0) | — | — | — |
+| (none yet — policy introduced in v2.9.0 as infrastructure; first dep lands in v3.1.0) | — | — | — |
 
-First dep expected to land in v3.2.0 (#415, PHPMailer for SMTP). Future candidates to be evaluated on a case-by-case basis as feature work surfaces them.
+First dep expected to land in v3.1.0 (#415, PHPMailer for SMTP). Future candidates to be evaluated on a case-by-case basis as feature work surfaces them.
 
 **Explicitly not adopted (deliberate choices):**
 
-- No HTTP client library yet. `ext-curl` + careful wrapping is the current path for webhook dispatch (#399, v3.4.0). May revisit if curl wrapping proves painful at implementation time — Guzzle or symfony/http-client would be the likely candidates.
+- No HTTP client library yet. `ext-curl` + careful wrapping is the current path for webhook dispatch (#399, v3.3.0). May revisit if curl wrapping proves painful at implementation time — Guzzle or symfony/http-client would be the likely candidates.
 - No JWT / JWK library yet. The hand-rolled OIDC in `lib.php` works and is not being retrofitted on speculation. May revisit if a security-sensitive bug surfaces or if the RFC tracking burden becomes obviously not worth it.
-- No JSON Schema validator. Custom fields (#313, v3.6.0) use a bespoke lightweight type system, not JSON Schema.
+- No JSON Schema validator. Custom fields (#313, v3.5.0) use a bespoke lightweight type system, not JSON Schema.
 - No templating engine, no DI container, no service locator, no ORM. These are architectural departures that do not fit this project's philosophy.
 
 ### When to use classes vs functions
 
-The project's application code is predominantly procedural — `lib.php` is a bag of top-level functions, and most pages are procedural PHP. The one deliberate exception is the `Dialect` family of classes under `dialects/` (introduced in v2.8.0), which encapsulates per-engine SQL differences.
+The project's application code is predominantly procedural — `lib.php` is a bag of top-level functions, and most pages are procedural PHP. The one deliberate exception is the `Dialect` family of classes under `dialects/` (introduced in v2.9.0), which encapsulates per-engine SQL differences.
 
 **Classes are appropriate for polymorphic contracts with a small, closed set of implementations.** The `Dialect` interface with `SqliteDialect` / `MysqlDialect` / `PgsqlDialect` is the canonical example: the contract says "every DB engine must implement these methods with these signatures," and PHPStan level 9 enforces that at compile time. Without an interface, we would have to reinvent the same guarantee with array shape annotations or runtime dispatch, both of which are worse.
 

--- a/Simple-PHP-IPAM/demo_seed.php
+++ b/Simple-PHP-IPAM/demo_seed.php
@@ -5,6 +5,38 @@
  *
  * This script truncates all data tables and seeds fresh demo data.
  * Only intended for development/demo environments.
+ *
+ * This fixture is also the canonical test data for the containerized Playwright
+ * harness (testing/playwright/bootstrap-app.sh). Seed contents, maintained in
+ * demo_seed_data() in lib.php:
+ *
+ *   Users   — 3:  demo/demo (admin), readonly-user + netops-user (locked accounts,
+ *                 password_hash='!disabled' — for UI display only; tests that need
+ *                 a working readonly login create pw-readonly via ensureRoUser()
+ *                 in fixtures/ipam.ts).
+ *   Sites   — 6:  2 regions (EMEA, Americas) and 4 sites under them, exercising
+ *                 the parent-site hierarchy.
+ *   VRFs    — 2:  DEFAULT and MGMT-VRF, both with RDs.
+ *   VLANs   — 4:  Management, Servers, DMZ, Cloud-Connect.
+ *   Contacts— 3:  Alice/Bob/Carol, linked to addresses below.
+ *   Tags    — 4:  Production, Development, Critical, Monitored.
+ *   Subnets — 13: 10 IPv4 (including /8 supernet, /16 corporate, /24 segments,
+ *                 /27 DMZ) and 3 IPv6 (2001:db8::/32 hierarchy).
+ *   Subnet tags — 5 tag attachments covering Production/Critical/Monitored/Dev.
+ *   Addresses — 50+ across 6 subnets with a mix of used/reserved/free statuses,
+ *                 hostnames, owner strings, contact links, MAC addresses, and a
+ *                 handful of expiry dates (some future, some already expired for
+ *                 the "expired addresses" UI test).
+ *   Audit log — pre-populated historical entries spanning auth and CRUD actions.
+ *
+ * When adding a new Playwright test that needs specific data, first try to use
+ * existing fixtures from this list; only extend demo_seed_data() in lib.php if
+ * there is no alternative. Keep the seed fast (<2s total). Tests that create
+ * their own fixtures use the 10.99.0.0/24, 10.88.0.0/24, 10.77.99.0/24,
+ * 10.66.0.0/24, 10.55.0.0/24 and 10.44.0.0/28 ranges, none of which overlap
+ * the seeded subnets above. The IPv6 range 2001:db8:1::/120 used by tests
+ * falls under the seeded 2001:db8:1::/48 parent; the hierarchy view test
+ * accounts for this.
  */
 declare(strict_types=1);
 

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 if (!defined('IPAM_VERSION')) {
-    define('IPAM_VERSION', '2.5.1');
+    define('IPAM_VERSION', '2.5.2');
 }

--- a/testing/playwright/Dockerfile.apache
+++ b/testing/playwright/Dockerfile.apache
@@ -1,0 +1,25 @@
+# Containerized Apache+PHP image used by the Playwright harness (see bootstrap-app.sh).
+# Mirrors the production deployment closely enough that .htaccess deny rules,
+# session cookies, and HTTPS-only enforcement all work as they would in a real install.
+FROM php:8.2-apache
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsqlite3-dev openssl ca-certificates \
+    && docker-php-ext-install pdo_sqlite \
+    && a2enmod rewrite ssl headers \
+    && a2ensite default-ssl \
+    && openssl req -x509 -nodes -days 3650 \
+         -newkey rsa:2048 \
+         -keyout /etc/ssl/private/ssl-cert-snakeoil.key \
+         -out /etc/ssl/certs/ssl-cert-snakeoil.pem \
+         -subj "/CN=ipam-pw-test" \
+    && printf '%s\n' \
+       '<Directory /var/www/html>' \
+       '    AllowOverride All' \
+       '    Require all granted' \
+       '</Directory>' \
+       > /etc/apache2/conf-available/ipam-override.conf \
+    && a2enconf ipam-override \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 443

--- a/testing/playwright/MIGRATION_NOTES.md
+++ b/testing/playwright/MIGRATION_NOTES.md
@@ -1,0 +1,76 @@
+# Playwright suite — migration and portability notes
+
+Context: during v2.5.2 planning (issue #428) the suite was audited for dev-direct-only
+assumptions in preparation for the containerized CI harness (#429, #430). The CDP →
+`@playwright/test` rewrite originally scoped into #428 was found to already be
+complete — the suite is on `@playwright/test` v1.52 and has been since an earlier
+release. This file records what the audit actually found and what contributors need
+to know when running against different targets.
+
+## Targets the suite supports
+
+| Target | `IPAM_BASE_URL` | HTTP Basic Auth | Admin creds |
+|---|---|---|---|
+| Local containerized (`bootstrap-app.sh`) | `http://127.0.0.1:8080` | off (no `IPAM_BASIC_USER`) | `demo` / `demo` (seeded by `demo_seed.php`) |
+| CI nightly (`playwright-nightly.yml`) | `http://127.0.0.1:8080` | off | `demo` / `demo` |
+| Dev-direct manual | `https://dev-direct.seanmousseau.com:8343/claude/ipam` | on (from `~/.claude/dev-secrets.env`) | `IPAM_ADMIN_USER` / `IPAM_ADMIN_PASS` from secrets |
+
+The choice is entirely driven by environment variables — nothing is hardcoded in
+the config file. `playwright.config.ts:4` defaults `baseURL` to `http://localhost:8080`
+and `playwright.config.ts:23-25` makes `httpCredentials` conditional on
+`IPAM_BASIC_USER` being set. `fixtures/ipam.ts:8-23` mirrors the same logic for
+fetch-based calls inside `page.evaluate()`.
+
+## Dev-direct-only tests
+
+One spec file is intentionally dev-direct-only because it requires SSH to mutate
+`config.php` on the remote host:
+
+- `tests/timezone.spec.ts` — guarded by `isDevServer()` at `timezone.spec.ts:54-57`.
+  Skips every test when `IPAM_BASE_URL` does not contain `192.168.80.15` or
+  `dev-direct.seanmousseau.com`. Containerized runs will see these tests as
+  skipped, not failed.
+
+Everything else is target-agnostic and runs against any `IPAM_BASE_URL`.
+
+## No CDP remnants
+
+The original CDP suite referenced by the `cdp_test.py` comments in several spec
+headers is gone. No `chrome-remote-interface` or `ws` dependencies remain in
+`package.json`; no shared `claude-chrome` container is dialed; no CDP protocol
+calls exist in fixtures. The `cdp_test.py` file still lives at
+`testing/scripts/cdp_test.py` as a standalone Python harness unrelated to the
+Playwright suite — do not confuse the two.
+
+## What containerized runs will expose (handled in #432)
+
+The bootstrap script in #429 runs `migrate.php` + `demo_seed.php` on every CI run.
+`demo_seed.php` creates:
+
+- `demo` / `demo` — admin, active
+- `readonly-user` — role `readonly`, password `!disabled` (cannot log in)
+- `netops-user` — role `netops`, password `!disabled` (cannot log in)
+
+Tests that need a working readonly login (`access-control.spec.ts` for example)
+currently call `ensureRoUser()` in `fixtures/ipam.ts:194` to create `pw-readonly`
+on demand from an admin session, so that path already works on a fresh seed. Any
+test that assumes a pre-existing non-admin login without going through
+`ensureRoUser()` is a bug to fix under #432.
+
+Hardcoded test data (CIDRs like `10.99.0.0/24`, VLAN 99, etc.) is declared in
+`fixtures/ipam.ts:39-70` and used by tests as "data I create and then delete."
+None of it assumes pre-seeded state. The only things the tests need from the seed
+are (a) a working admin login and (b) enough data variety that pagination and
+filter tests have something to render. `demo_seed.php` currently provides both,
+but #432 will run the suite against a fresh seed and log any remaining gaps.
+
+## Contributor checklist when adding a new spec
+
+- Do not hardcode `dev-direct.seanmousseau.com`, `192.168.80.15`, `:8343`, or
+  `/claude/ipam` — use `appUrl()` or a `baseURL`-relative `page.goto(...)` call.
+- Do not hardcode admin credentials — use `ADMIN_USER` / `ADMIN_PASS` imports from
+  `fixtures/ipam.ts`.
+- Do not assume pre-seeded data unless `demo_seed.php` documents it. Prefer
+  creating your own fixtures inside the test and cleaning up in `afterAll`.
+- If the test requires a dev-direct-only capability (SSH, shared container, real
+  IdP), add an `isDevServer()`-style skip guard at the top.

--- a/testing/playwright/README.md
+++ b/testing/playwright/README.md
@@ -1,0 +1,177 @@
+# Simple PHP IPAM — Playwright test suite
+
+End-to-end browser tests for Simple PHP IPAM. Runs against either a real dev-direct
+install or a fully containerized local Apache+PHP instance. This directory is
+contributor-facing only — it is not part of a release bundle.
+
+## Layout
+
+```
+testing/playwright/
+├── playwright.config.ts      # base URL, retries, timeouts, reporters
+├── fixtures/ipam.ts          # helpers (login, CSRF, subnet/VLAN/tag CRUD), test constants
+├── tests/                    # 32 spec files, one per feature area
+├── bootstrap-app.sh          # starts the Dockerized IPAM instance used by CI and local runs
+├── teardown-app.sh           # stops and removes the container
+├── Dockerfile.apache         # php:8.2-apache with pdo_sqlite, mod_ssl, self-signed cert
+├── scripts/flake-rate.mjs    # computes flake rate from playwright-report/results.json
+├── MIGRATION_NOTES.md        # portability notes, target matrix, contributor checklist
+├── SEED_AUDIT.md             # running log of seed/test mismatches discovered via nightly CI
+└── README.md                 # this file
+```
+
+## Running the suite
+
+### Containerized local (recommended for development)
+
+Requires Docker. Builds a `php:8.2-apache` image with `pdo_sqlite`, `mod_ssl`, and
+a self-signed cert; starts it on `https://127.0.0.1:8443`; seeds from `demo_seed.php`;
+runs Playwright against it.
+
+```bash
+# One-time install (or after package-lock changes)
+(cd testing/playwright && npm ci && npx playwright install chromium)
+
+# Boot the app
+bash testing/playwright/bootstrap-app.sh sqlite
+
+# Run the suite
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 \
+  IPAM_ADMIN_USER=demo \
+  IPAM_ADMIN_PASS=demo \
+  npx playwright test)
+
+# Tear down
+bash testing/playwright/teardown-app.sh
+```
+
+Run a single spec: `npx playwright test tests/auth.spec.ts`. Run a single test within
+a spec: `npx playwright test tests/pages.spec.ts:42`. Add `--reporter=line` for
+concise output during debugging.
+
+The bootstrap overwrites `Simple-PHP-IPAM/config.php` with a test config and wipes
+`Simple-PHP-IPAM/data/ipam.sqlite`. If you have a local dev database in that
+location, back it up first.
+
+### Manual against dev-direct
+
+For scenarios the containerized harness can't cover — real-IdP OIDC, timezone
+tests that SSH to the remote host, or any ad-hoc verification on the shared dev
+server. See `CLAUDE.md` → "Running the test suites" → "Manual against dev-direct"
+for the full invocation including the seven recurring footguns
+(login_attempts cleanup, stale cron processes, password drift, etc.).
+
+### CI
+
+The nightly workflow `.github/workflows/playwright-nightly.yml` runs two jobs:
+
+1. **`containerized-playwright`** — full suite against the Dockerized app.
+   Matrix is `driver: [sqlite]` today; gains `mysql` in v2.10.0 and `pgsql` in
+   v2.11.0. Target wall clock: under 40 minutes.
+2. **`htaccess-subset`** — runs only `tests/htaccess.spec.ts` against the same
+   image. Verifies the `.htaccess` deny rules that a `php -S` runner could not
+   cover. Target wall clock: under 15 minutes.
+
+Both jobs also run on PRs to `dev` or `main` that touch `Simple-PHP-IPAM/**`,
+`testing/playwright/**`, or the workflow file.
+
+## Writing a new test
+
+- Import `adminTest` from `fixtures/ipam.ts` instead of bare `test` for anything
+  that needs an authenticated session. It logs in as admin `beforeEach` and
+  logs out `afterEach`.
+- Prefer `baseURL`-relative paths (`page.goto('subnets.php')`) or `appUrl('…')`
+  helpers over hardcoded absolute URLs. Never hardcode `dev-direct.seanmousseau.com`,
+  `192.168.80.15`, `:8343`, or `/claude/ipam`.
+- Use `ADMIN_USER` / `ADMIN_PASS` from `fixtures/ipam.ts`, not literal strings.
+  Those constants read from `IPAM_ADMIN_USER` / `IPAM_ADMIN_PASS` env vars and
+  fall back to `admin/admin` for dev.
+- Create your own fixtures inside the test and clean up in `afterAll`. Do not
+  assume pre-seeded state beyond what `SEED_AUDIT.md` documents.
+- Use test data CIDRs from `fixtures/ipam.ts` (`TEST_CIDR1`, etc.) — they are
+  chosen to not overlap the `demo_seed.php` subnets.
+- If a test requires a dev-direct-only capability (SSH, real IdP, shared Chrome
+  container), gate it with an `isDevServer()`-style skip at the top of the
+  test body, following the pattern in `tests/timezone.spec.ts`.
+
+## Debugging a CI failure
+
+1. Open the failing run in GitHub Actions.
+2. Download the `playwright-report-<driver>` artifact — it contains an HTML
+   report with screenshots, traces (on retry), and the JSON reporter output.
+3. Open `index.html` in a browser. Click any failing test to see the error,
+   stack trace, and the trace viewer for visual playback.
+4. If the failure is a cold-start race (container not ready, DB locked during
+   seed), check the `Container logs on failure` step output in the workflow.
+5. Reproduce locally with the same command the workflow uses:
+   ```bash
+   bash testing/playwright/bootstrap-app.sh sqlite
+   (cd testing/playwright && \
+     IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+     CI=true npx playwright test tests/<failing>.spec.ts --retries=2)
+   ```
+
+## Flake policy
+
+Containerized runs are inherently flakier than warm dev-direct runs — cold
+caches, variable service startup, slower I/O. The suite tolerates this without
+burning contributors out via three mechanisms:
+
+### 1. Automatic retries in CI
+
+`playwright.config.ts` sets `retries: process.env.CI ? 2 : 0`. A test that fails
+on attempt 1 gets two more tries. It only fails the build if all three attempts
+fail. Local runs retry zero times so flakes surface immediately.
+
+Traces and screenshots are kept only for failed retries (`trace: 'retain-on-failure'`),
+keeping CI artifact sizes reasonable.
+
+### 2. Flake tagging
+
+Tests that are known to be flaky can be annotated so reviewers can distinguish
+"under investigation" from "new flake":
+
+```typescript
+test('sometimes races with the cron scanner', async ({ page }) => {
+  test.info().annotations.push({
+    type: 'flaky',
+    description: 'races with scan_run when nightly cron overlaps — see #NNN',
+  });
+  // ... test body
+});
+```
+
+The annotation is metadata only. It doesn't skip or change how the test runs.
+
+### 3. Flake budget
+
+Run `node testing/playwright/scripts/flake-rate.mjs` after each nightly to print
+a flake rate and exit with a traffic-light code:
+
+| Zone | Rate | Exit | Action |
+|---|---|---|---|
+| Green | < 2% | 0 | No action needed |
+| Yellow | 2–5% | 1 | Investigate the top 3 flaky tests, tag or fix them |
+| Red | > 5% | 2 | Pause new feature work; investigate root causes |
+
+The rate is computed as `(tests that passed only after retry) / total tests`.
+Tests that fail on every attempt are real failures, not flakes.
+
+The weekly release-cadence review should include the current flake rate and
+any tagged flaky tests. When a tagged test is fixed, remove the annotation in
+the same commit.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `IPAM_BASE_URL` | `http://localhost:8080` | App root. Set to `https://127.0.0.1:8443` for containerized, or `https://dev-direct.seanmousseau.com:8343/claude/ipam` for dev-direct. |
+| `IPAM_ADMIN_USER` | `admin` | App admin username. `demo` for containerized (seeded by `demo_seed.php`). |
+| `IPAM_ADMIN_PASS` | `admin` | App admin password. `demo` for containerized. |
+| `IPAM_BASIC_USER` | _(unset)_ | HTTP Basic Auth user for the `/claude/` gateway (dev-direct only). |
+| `IPAM_BASIC_PASS` | _(unset)_ | HTTP Basic Auth password (dev-direct only). |
+| `IPAM_TEST_PORT` | `8443` | Host port the Dockerized container binds its `:443` to. |
+| `IPAM_TEST_IMAGE` | `ipam-pw-apache:local` | Docker image tag built by `bootstrap-app.sh`. |
+| `IPAM_TEST_NAME` | `ipam-pw-test` | Docker container name. |
+| `CI` | _(unset)_ | Set by GitHub Actions. Enables `retries: 2` and retained traces. |

--- a/testing/playwright/SEED_AUDIT.md
+++ b/testing/playwright/SEED_AUDIT.md
@@ -1,0 +1,112 @@
+# Playwright seed audit
+
+Log of findings from running the Playwright suite against a freshly-seeded database
+(via `testing/playwright/bootstrap-app.sh`). This document is populated over time as
+nightly CI runs expose gaps between `demo_seed.php` and what the tests expect.
+
+## Audit process
+
+1. Tear down any prior container: `bash testing/playwright/teardown-app.sh`
+2. Start fresh: `bash testing/playwright/bootstrap-app.sh sqlite`
+3. Run suite: `IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo CI=true npx playwright test`
+4. For each failing test, categorize:
+   - **A** — test bug: assumes state that should not exist, has a stale selector, or asserts a feature that was removed/never implemented
+   - **B** — seed gap: test needs data that `demo_seed_data()` in lib.php does not produce
+   - **C** — environment-specific: test requires SSH, a real IdP, or dev-direct-only capabilities
+5. For category A: fix the test and note it here with the commit.
+   For category B: extend `demo_seed_data()` in `lib.php` and note it here.
+   For category C: add an `isDevServer()`-style skip guard and note it here.
+
+## Initial audit — 2026-04-14 (v2.5.2 #432, first containerized run)
+
+### Run 1 — baseline against fresh seed
+
+```
+Run date:        2026-04-14
+Container image: ipam-pw-apache:local
+Suite wall clock: 8.4 minutes
+Total test instances: 339 (including retries)
+Passed:  306
+Failed:  15
+Flaky:   1  (passed on retry)
+Skipped: 17
+```
+
+All 15 failures were **category A test bugs** exposed by running against a
+freshly seeded database — none were seed gaps (`demo_seed_data()` proved
+sufficient) and none were real app bugs. This is the exact value #432 was
+designed to deliver: the test suite's latent assumptions about dev-direct
+state surfaced in a single pass.
+
+### Run 2 — after category-A fixes
+
+```
+Run date:        2026-04-14
+Container image: ipam-pw-apache:local
+Suite wall clock: 1.6 minutes  (Apache+HTTPS local container, vs ~25-30 min on dev-direct)
+Total test instances: 339
+Passed:  318
+Failed:  0
+Flaky:   1
+Skipped: 20
+```
+
+Green. The three extra skips versus run 1 are the deliberate `test.skip()`
+calls on the `--topbar-h` tests (category A4 below).
+
+### Findings
+
+| # | Spec | Tests | Category | Root cause | Resolution |
+|---|---|---|---|---|---|
+| A1 | `tests/aggregates.spec.ts` | 7 | A | `TEST_CIDR = '10.200.0.0/8'` is not network-aligned; the app normalized it to `10.0.0.0/8` and all subsequent row-lookup assertions missed the row they had just created. The IPv6 fixture `'2001:db8:agg::/48'` contained non-hex characters (`g`) so creation failed outright. | Changed fixtures to `'10.0.0.0/8'` and `'2001:db8:a::/48'`; replaced literal-string assertions with references to the constants and a `TEST_CIDR_V6_MATCH` substring. |
+| A2 | `tests/js-behaviour.spec.ts` | 2 | A | Test locator was `.search-overlay` (class); the real element is `#search-overlay` (id). | Selector corrected in all three occurrences. |
+| A3 | `tests/js-behaviour.spec.ts` | 2 | A | Tests assert a `--topbar-h` CSS custom property set by a `ResizeObserver` — but `grep -r topbar-h Simple-PHP-IPAM` returns zero hits. The feature does not exist in `app.js` or anywhere else. | Marked both tests as `test.skip()` with a comment pointing at this audit note. Delete or re-enable them in a later release if the feature is implemented. |
+| A4 | `tests/pages.spec.ts:87` | 1 | A | Same `--topbar-h` feature used inside a `Sticky headers` describe block on pages.spec.ts. | `adminTest.skip(...)` with matching comment. |
+| A5 | `tests/pd-pools.spec.ts` | 2 | A | Test looked for `h1` containing `"PD Pool"`, but the page actually renders `"IPv6 Prefix Delegation Pools"`. Second test assumed `ipv6SubnetId === null` implied no IPv6 subnets on the page at all, but the demo seed ships three IPv6 subnets (`2001:db8::/32`, `/48`, `/64`). | H1 assertion changed to `"Prefix Delegation"`; parent-picker logic rewritten to check whether the empty-state is visible and, if not, assert the picker has at least one option. |
+| A6 | `tests/scan-schedule.spec.ts:103` | 1 | A | Two distinct bugs in one test:<br>1. subnets.php contains **two** `a.action-pill` elements linking to `scan_history.php?subnet_id=N` (lines 671 and 742). The first is the plain "Scan History" link in the action toolbar; the second is "Scan History & Schedule" with the status badge. `.first()` matched the wrong one.<br>2. The test was written as if subnets.php still rendered the scan-schedule form inline, but that form was moved to `scan_history.php` in v2.3.0 (#356). subnets.php only shows an Active/Inactive badge appended to the second pill. | Rewrote the test to locate the pill via `.filter({ hasText: /Schedule/i })` and assert it contains `"Active"`. Dropped the obsolete `select[name="scan_method"]` probe entirely. |
+
+All six fixes landed in the same commit as the v2.5.2 release.
+
+## Known skipped specs (not failures)
+
+| File / test | Reason |
+|---|---|
+| `tests/timezone.spec.ts` (all tests) | Dev-direct-only; SSHes to patch remote config.php. Skip gated by `isDevServer()`. |
+| `tests/htaccess.spec.ts` — vendor/ and dialects/ cases | Files do not exist until v2.9.0. Tests self-skip via `fs.existsSync` guard. |
+| `tests/js-behaviour.spec.ts` — `--topbar-h` + sticky thead | Feature not implemented in app.js; see finding A3. |
+| `tests/pages.spec.ts:87` — sticky thead offset | Same feature; see A4. |
+
+## Known flaky tests
+
+| Test | Notes |
+|---|---|
+| `tests/subnets.spec.ts:172` — "scan schedule details element is present for admin" | Failed on attempt 1 of run 2, passed on retry. Same scan-schedule `<details>` interaction as A6 but in a different spec; likely also sensitive to whether the schedule was just POSTed vs. being re-rendered on a fresh GET. If it flakes a second time, apply the same `.filter({ hasText: /Schedule/i })` pattern and expand the details explicitly. |
+
+## Seed drift watch
+
+Things about `demo_seed_data()` in `lib.php` that are easy to miss when editing:
+
+- The seed preserves specific IDs (sites 1..6, VRFs 1..2, VLANs 1..4, etc.) so
+  tests can reference them directly without discovery. Do not renumber without
+  updating dependent tests.
+- `netops-user` and `readonly-user` have `password_hash='!disabled'`, which is
+  intentional — they exist for UI display (the users table showing mixed roles),
+  not for test login. Tests that need a working readonly account call
+  `ensureRoUser()` in `fixtures/ipam.ts` to create `pw-readonly` on demand.
+- The `demo_mode.enabled` flag controls runtime behavior (restricts login to
+  `demo/demo`, disables destructive actions). `bootstrap-app.sh` flips it **on**
+  only long enough to run `demo_seed.php`, then flips it **off** so the Playwright
+  suite can exercise normal admin flows with the seeded `demo/demo` account.
+- The seed includes historical audit log entries with relative dates like
+  `-27 days`. These shift every time the seed runs — tests that assert on
+  specific dates will break. Prefer assertions on count or ordering over exact
+  dates.
+- **Role enum drift:** CLAUDE.md currently lists roles as `admin|readonly`, but
+  the seed and `users.php` also accept `netops`. CLAUDE.md is stale; the three
+  valid roles are `admin`, `netops`, and `readonly`. This is a CLAUDE.md bug to
+  fix in a later pass, not a seed bug.
+- The seed includes subnet `10.0.0.0/8` (id=1). This did NOT conflict with the
+  now-corrected aggregates test fixture (`TEST_CIDR = '10.0.0.0/8'`) because
+  aggregates and subnets are separate tables with no shared uniqueness
+  constraint. If that ever changes, the aggregates spec will need a different
+  fixture.

--- a/testing/playwright/bootstrap-app.sh
+++ b/testing/playwright/bootstrap-app.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Start a Dockerized Apache+PHP instance of Simple-PHP-IPAM for Playwright runs.
+#
+# Usage:
+#   bootstrap-app.sh [driver]
+#
+# Positional args:
+#   driver   Database driver. Only 'sqlite' is supported in v2.5.2. MySQL/Postgres
+#            matrix slots land in v2.10.0 / v2.11.0 (see plan for v2.5.2).
+#
+# Environment overrides:
+#   IPAM_TEST_PORT   Host port to bind the container's :443 to (default: 8443).
+#   IPAM_TEST_IMAGE  Docker image tag to build (default: ipam-pw-apache:local).
+#   IPAM_TEST_NAME   Container name (default: ipam-pw-test).
+#
+# Side effects:
+#   - Overwrites Simple-PHP-IPAM/config.php with a test config (the real config.php
+#     is gitignored in dev environments; in CI the checkout is throwaway).
+#   - Deletes Simple-PHP-IPAM/data/ipam.sqlite* and reseeds.
+#   - Starts a long-running container. Tear it down with teardown-app.sh.
+#
+# On success: prints the base URL (https://127.0.0.1:<port>) and exits 0.
+# On failure: dumps container logs to stderr and exits 1.
+
+set -euo pipefail
+
+driver="${1:-sqlite}"
+if [[ "$driver" != "sqlite" ]]; then
+    echo "bootstrap-app.sh: driver '$driver' is not supported in v2.5.2 (sqlite only)" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+app_dir="$repo_root/Simple-PHP-IPAM"
+
+container="${IPAM_TEST_NAME:-ipam-pw-test}"
+image="${IPAM_TEST_IMAGE:-ipam-pw-apache:local}"
+port="${IPAM_TEST_PORT:-8443}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "bootstrap-app.sh: docker is required but not found in PATH" >&2
+    exit 3
+fi
+
+# 1. Back up any existing config.php and install the test fixture. The fixture
+#    in testing/playwright/fixtures/test-config.php carries every default key
+#    the app expects (housekeeping, update_check, login_protection, etc.) so
+#    no "undefined array key" warnings fire and mangle response headers.
+#    demo_mode is flipped on/off via sed as a simple two-step surgery.
+echo "bootstrap-app: installing test config"
+mkdir -p "$app_dir/data"
+if [[ -f "$app_dir/config.php" && ! -f "$app_dir/config.php.prebootstrap-backup" ]]; then
+    cp "$app_dir/config.php" "$app_dir/config.php.prebootstrap-backup"
+fi
+cp "$script_dir/fixtures/test-config.php" "$app_dir/config.php"
+rm -f "$app_dir/data/ipam.sqlite" "$app_dir/data/ipam.sqlite-wal" "$app_dir/data/ipam.sqlite-shm"
+
+# Flip demo_mode on for seeding. sed with two distinct markers would be safer,
+# but the file ships with exactly one `'enabled' => false` line inside the
+# demo_mode block so this single replace is unambiguous.
+set_demo_mode() {
+    local enabled="$1"
+    local other; other=$([[ "$enabled" == "true" ]] && echo "false" || echo "true")
+    # Use a perl one-liner so we can match the full demo_mode=>[ block.
+    perl -i -0pe "s/('demo_mode'\s*=>\s*\[\s*'enabled'\s*=>\s*)${other}/\${1}${enabled}/" "$app_dir/config.php"
+}
+
+echo "bootstrap-app: enabling demo_mode for seeding"
+set_demo_mode "true"
+
+# 2. Build the container image (cached on re-runs; fast once warm).
+echo "bootstrap-app: building $image"
+docker build --quiet -t "$image" -f "$script_dir/Dockerfile.apache" "$script_dir" >/dev/null
+
+# 3. Run migrate + demo seed inside a throwaway container so there is no host
+#    PHP version dependency. Uses the same image the long-running container uses.
+echo "bootstrap-app: running migrate.php and demo_seed.php"
+docker run --rm \
+    -v "$app_dir:/var/www/html" \
+    -w /var/www/html \
+    "$image" \
+    bash -c 'php migrate.php && php demo_seed.php' \
+    >/tmp/ipam-pw-seed.log 2>&1 || {
+        echo "bootstrap-app: seeding failed, log follows:" >&2
+        cat /tmp/ipam-pw-seed.log >&2
+        exit 1
+    }
+
+# 4. Flip demo_mode off so the suite can exercise normal admin flows.
+echo "bootstrap-app: disabling demo_mode for runtime"
+set_demo_mode "false"
+
+# 5. Kill any prior container of the same name.
+docker rm -f "$container" >/dev/null 2>&1 || true
+
+# 6. Launch the long-running Apache container.
+echo "bootstrap-app: starting container $container on https://127.0.0.1:$port"
+docker run -d --rm --name "$container" \
+    -v "$app_dir:/var/www/html" \
+    -p "127.0.0.1:$port:443" \
+    "$image" >/dev/null
+
+# 7. Poll for readiness. status.php returns {"status":"ok"} and does not require auth.
+for i in $(seq 1 30); do
+    if curl -ksSf "https://127.0.0.1:$port/status.php" >/dev/null 2>&1; then
+        echo "bootstrap-app: ready at https://127.0.0.1:$port"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "bootstrap-app: container did not become ready in 30s" >&2
+docker logs "$container" >&2 || true
+exit 1

--- a/testing/playwright/bootstrap-app.sh
+++ b/testing/playwright/bootstrap-app.sh
@@ -76,11 +76,19 @@ docker build --quiet -t "$image" -f "$script_dir/Dockerfile.apache" "$script_dir
 # 3. Run migrate + demo seed inside a throwaway container so there is no host
 #    PHP version dependency. Uses the same image the long-running container uses.
 echo "bootstrap-app: running migrate.php and demo_seed.php"
+# Seed inside a throwaway container of the same image so there is no host
+# PHP dependency. The seed container's root user creates the SQLite file
+# with UID 0 ownership in the bind mount; the long-running container runs
+# Apache as www-data (UID 33) and must also write the file (SQLite WAL).
+# Relax permissions on the data dir so www-data can open it. We do this
+# inside the throwaway container (guaranteed to have chmod) rather than
+# on the host (which on macOS Docker Desktop is a no-op due to UID
+# translation and on CI is only reachable if run as root).
 docker run --rm \
     -v "$app_dir:/var/www/html" \
     -w /var/www/html \
     "$image" \
-    bash -c 'php migrate.php && php demo_seed.php' \
+    bash -c 'php migrate.php && php demo_seed.php && chmod -R a+rwX data' \
     >/tmp/ipam-pw-seed.log 2>&1 || {
         echo "bootstrap-app: seeding failed, log follows:" >&2
         cat /tmp/ipam-pw-seed.log >&2

--- a/testing/playwright/fixtures/test-config.php
+++ b/testing/playwright/fixtures/test-config.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+// Simple PHP IPAM — Playwright test configuration.
+//
+// Copied to Simple-PHP-IPAM/config.php by testing/playwright/bootstrap-app.sh.
+// Mirrors the committed config.php default set so no warnings fire when
+// running under the containerized harness. The only meaningful overrides
+// versus the default config are:
+//   - app_name:   tagged "(test)" to make accidental prod use obvious
+//   - login_max_attempts / login_lockout_seconds: relaxed so back-to-back
+//                 test logins do not trip the rate limiter
+//   - demo_mode.enabled: flipped to true briefly during seeding, then
+//                 flipped back to false by bootstrap-app.sh before the
+//                 long-running container starts
+//   - housekeeping.enabled: false (no need for lazy housekeeping during tests)
+//   - update_check.enabled: false (no outbound GitHub calls from CI)
+
+return [
+    'db_path'              => __DIR__ . '/data/ipam.sqlite',
+    'session_name'         => 'IPAMSESSID',
+    'proxy_trust'          => false,
+    'app_name'             => 'Simple PHP IPAM (test)',
+    'timezone'             => 'UTC',
+    'bootstrap_admin'      => ['username' => 'admin', 'password' => 'ChangeMeNow!12345'],
+    'session_idle_seconds' => 1800,
+    'login_max_attempts'   => 9999,
+    'login_lockout_seconds'=> 1,
+    'import_csv_max_mb'    => 5,
+    'import_sql_max_mb'    => 200,
+    'tmp_cleanup_ttl_seconds' => 86400,
+    'audit_log_retention_days' => 0,
+    'address_history_retention_days' => 0,
+    'housekeeping'         => ['enabled' => false, 'interval_seconds' => 86400],
+    'utilization_warn'     => 80,
+    'utilization_critical' => 95,
+    'auto_reserve_network_broadcast' => true,
+    'alert_email'            => '',
+    'alert_util_warn_pct'    => 80,
+    'alert_util_crit_pct'    => 95,
+    'alert_interval_seconds' => 3600,
+    'update_check'         => [
+        'enabled'           => false,
+        'ttl_seconds'       => 86400,
+        'notify_prerelease' => false,
+    ],
+    'backup'               => [
+        'enabled'   => false,
+        'frequency' => 'daily',
+        'retention' => 7,
+        'dir'       => '',
+    ],
+    'password_policy'      => [
+        'min_length'            => 12,
+        'require_uppercase'     => false,
+        'require_lowercase'     => false,
+        'require_number'        => false,
+        'require_symbol'        => false,
+        'max_password_age_days' => 0,
+    ],
+    'login_protection'     => [
+        'method'      => null,
+        'site_key'    => '',
+        'secret_key'  => '',
+        'min_seconds' => 3,
+        'version'     => 2,
+    ],
+    'demo_mode'            => [
+        'enabled'    => false,
+        'gate'       => null,
+        'site_key'   => '',
+        'secret_key' => '',
+    ],
+    'oidc'                 => [
+        'enabled'        => false,
+        'display_name'   => 'SSO',
+        'client_id'      => '',
+        'client_secret'  => '',
+        'discovery_url'  => '',
+        'redirect_uri'   => '',
+        'scopes'         => 'openid email profile',
+        'auto_link'      => false,
+        'auto_provision' => false,
+        'default_role'   => 'readonly',
+        'disable_local_login' => false,
+        'hide_emergency_link' => false,
+        'disable_emergency_bypass' => false,
+    ],
+];

--- a/testing/playwright/playwright.config.ts
+++ b/testing/playwright/playwright.config.ts
@@ -12,21 +12,30 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: false,
   workers: 1,        // sequential — tests share a single SQLite DB
-  retries: 0,
-  timeout: 30_000,
+  // 2 retries in CI (containerized Apache has cold caches, variable startup,
+  // and slower I/O than a warm dev-direct target); 0 locally so flaky tests
+  // surface immediately during development.
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
   reporter: [
     ['list'],
     ['html', { open: 'never', outputFolder: 'playwright-report' }],
+    ['json', { outputFile: 'playwright-report/results.json' }],
   ],
   use: {
     baseURL: APP_BASE + '/',
     httpCredentials: basicUser
       ? { username: basicUser, password: basicPass, send: 'always' }
       : undefined,
+    actionTimeout: 15_000,
     screenshot: 'only-on-failure',
+    trace: process.env.CI ? 'retain-on-failure' : 'off',
     video: 'off',
     headless: true,
-    ignoreHTTPSErrors: true,   // dev server uses self-signed cert
+    ignoreHTTPSErrors: true,   // dev-direct + containerized Apache both use self-signed certs
   },
   projects: [
     {

--- a/testing/playwright/scripts/flake-rate.mjs
+++ b/testing/playwright/scripts/flake-rate.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Compute the flake rate from a Playwright JSON report.
+//
+// Usage:
+//   node scripts/flake-rate.mjs [path/to/results.json]
+//
+// Default path is playwright-report/results.json (set by the 'json' reporter
+// in playwright.config.ts).
+//
+// Output: single line  "flake_rate=X.XX% (Y flaky / Z total)"  plus an exit
+// code of 0 (green), 1 (yellow, 2–5%), or 2 (red, >5%). CI can gate releases
+// on the exit code or just log the number.
+//
+// A test is counted as "flaky" when it has more than one attempt and ultimately
+// passed (i.e. failed on attempt 1, passed on retry). Tests that fail on all
+// attempts are real failures, not flakes.
+
+import { readFile } from 'node:fs/promises';
+import { argv, exit } from 'node:process';
+
+const path = argv[2] ?? 'playwright-report/results.json';
+
+let data;
+try {
+  data = JSON.parse(await readFile(path, 'utf8'));
+} catch (err) {
+  console.error(`flake-rate: cannot read ${path}: ${err.message}`);
+  exit(3);
+}
+
+let total = 0;
+let flaky = 0;
+
+function walk(node) {
+  if (Array.isArray(node?.suites)) for (const s of node.suites) walk(s);
+  if (Array.isArray(node?.specs)) {
+    for (const spec of node.specs) {
+      for (const t of spec.tests ?? []) {
+        total += 1;
+        const results = t.results ?? [];
+        const attempts = results.length;
+        const finalStatus = results[results.length - 1]?.status;
+        if (attempts > 1 && finalStatus === 'passed') flaky += 1;
+      }
+    }
+  }
+}
+
+walk(data);
+
+if (total === 0) {
+  console.error('flake-rate: no tests found in report');
+  exit(3);
+}
+
+const rate = (flaky / total) * 100;
+console.log(`flake_rate=${rate.toFixed(2)}% (${flaky} flaky / ${total} total)`);
+
+if (rate > 5)      exit(2);   // red
+else if (rate > 2) exit(1);   // yellow
+else               exit(0);   // green

--- a/testing/playwright/teardown-app.sh
+++ b/testing/playwright/teardown-app.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Stop and remove the containerized IPAM instance started by bootstrap-app.sh,
+# and restore any pre-bootstrap config.php that was saved during setup.
+# Idempotent — safe to run when nothing is running.
+
+set -euo pipefail
+
+container="${IPAM_TEST_NAME:-ipam-pw-test}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+app_dir="$(cd "$script_dir/../.." && pwd)/Simple-PHP-IPAM"
+
+if command -v docker >/dev/null 2>&1; then
+    docker rm -f "$container" >/dev/null 2>&1 || true
+fi
+
+if [[ -f "$app_dir/config.php.prebootstrap-backup" ]]; then
+    mv "$app_dir/config.php.prebootstrap-backup" "$app_dir/config.php"
+    echo "teardown-app: restored original config.php"
+fi

--- a/testing/playwright/tests/aggregates.spec.ts
+++ b/testing/playwright/tests/aggregates.spec.ts
@@ -15,8 +15,16 @@ import {
   newAuthContext, ensureRoUser,
 } from '../fixtures/ipam';
 
-const TEST_CIDR = '10.200.0.0/8';
-const TEST_CIDR_V6 = '2001:db8:agg::/48';
+// Must be already-network-aligned: the app rewrites non-aligned /8 inputs
+// like 10.200.0.0/8 to 10.0.0.0/8, which would then fail to match the test's
+// own input string in later assertions.
+const TEST_CIDR = '10.0.0.0/8';
+// The prior fixture ('2001:db8:agg::/48') was invalid hex — 'g' is out of
+// range — so creation failed outright. Use a valid hex group instead.
+const TEST_CIDR_V6 = '2001:db8:a::/48';
+// Substring used for row/body matching — the app lowercases and compresses
+// IPv6 on render so this short prefix is the most stable identifier.
+const TEST_CIDR_V6_MATCH = '2001:db8:a:';
 
 let ctx: BrowserContext;
 let page: Page;
@@ -45,7 +53,7 @@ test('create IPv4 aggregate', async () => {
   await page.fill('input[name="description"]', 'Test aggregate');
   await page.click('button[type="submit"]');
   await page.waitForURL(/aggregates\.php/);
-  await expect(page.locator('table')).toContainText('10.200.0.0/8');
+  await expect(page.locator('table')).toContainText(TEST_CIDR);
 });
 
 test('create IPv6 aggregate', async () => {
@@ -55,25 +63,25 @@ test('create IPv6 aggregate', async () => {
   await page.fill('input[name="description"]', 'Test IPv6 aggregate');
   await page.click('button[type="submit"]');
   await page.waitForURL(/aggregates\.php/);
-  await expect(page.locator('table')).toContainText('2001:db8:agg');
+  await expect(page.locator('table')).toContainText(TEST_CIDR_V6_MATCH);
 });
 
 test('IPv4 badge shown for IPv4 aggregate', async () => {
   await page.goto(appUrl('aggregates.php'));
-  const row = page.locator('tr', { hasText: '10.200.0.0/8' });
+  const row = page.locator('tr', { hasText: TEST_CIDR });
   await expect(row.locator('.badge')).toContainText('IPv4');
 });
 
 test('IPv6 badge shown for IPv6 aggregate', async () => {
   await page.goto(appUrl('aggregates.php'));
-  const row = page.locator('tr', { hasText: '2001:db8:agg' });
+  const row = page.locator('tr', { hasText: TEST_CIDR_V6_MATCH });
   await expect(row.locator('.badge')).toContainText('IPv6');
 });
 
 test('update aggregate description', async () => {
   await page.goto(appUrl('aggregates.php'));
   // Open edit details for the IPv4 aggregate
-  const row = page.locator('tr', { hasText: '10.200.0.0/8' });
+  const row = page.locator('tr', { hasText: TEST_CIDR });
   await row.locator('details summary').click();
   const descInput = row.locator('input[name="description"]');
   await descInput.fill('Updated description');
@@ -84,23 +92,23 @@ test('update aggregate description', async () => {
 
 test('delete IPv4 aggregate', async () => {
   await page.goto(appUrl('aggregates.php'));
-  const row = page.locator('tr', { hasText: '10.200.0.0/8' });
+  const row = page.locator('tr', { hasText: TEST_CIDR });
   await row.locator('details summary').click();
   page.once('dialog', d => d.accept());
   await row.locator('button.button-danger').click();
   await page.waitForURL(/aggregates\.php/);
   // Should no longer be in the table
-  await expect(page.locator('body')).not.toContainText('10.200.0.0/8');
+  await expect(page.locator('body')).not.toContainText(TEST_CIDR);
 });
 
 test('delete IPv6 aggregate', async () => {
   await page.goto(appUrl('aggregates.php'));
-  const row = page.locator('tr', { hasText: '2001:db8:agg' });
+  const row = page.locator('tr', { hasText: TEST_CIDR_V6_MATCH });
   await row.locator('details summary').click();
   page.once('dialog', d => d.accept());
   await row.locator('button.button-danger').click();
   await page.waitForURL(/aggregates\.php/);
-  await expect(page.locator('body')).not.toContainText('2001:db8:agg');
+  await expect(page.locator('body')).not.toContainText(TEST_CIDR_V6_MATCH);
 });
 
 test('invalid CIDR is rejected', async () => {

--- a/testing/playwright/tests/htaccess.spec.ts
+++ b/testing/playwright/tests/htaccess.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * .htaccess coverage — verifies that web-server deny rules in Simple-PHP-IPAM/.htaccess
+ * and Simple-PHP-IPAM/data/.htaccess behave as intended against a real Apache instance.
+ *
+ * Runs as the `htaccess-subset` CI job in .github/workflows/playwright-nightly.yml.
+ * Does not require login, a database, or any seed state — pure HTTP-level checks.
+ *
+ * Context: tests 1..6 cover the root .htaccess RewriteRules that block direct access
+ * to PHP internals and build artefacts. Tests 7..9 cover the data/.htaccess "deny
+ * everything" rule. Tests 10..12 cover CLI-only PHP scripts, which the .htaccess
+ * blocks at the web-server level so the PHP_SAPI guard inside them is not the only
+ * defence.
+ *
+ * Some target paths (/vendor/, /dialects/) do not exist in v2.5.2. They become
+ * reachable in v2.9.0 when bundled runtime deps ship. Tests that reference them
+ * are gated with `test.skip(!fs.existsSync(...))` so they light up automatically
+ * without needing a separate PR in the release that introduces the files.
+ */
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+const APP_ROOT = resolve(__dirname, '..', '..', '..', 'Simple-PHP-IPAM');
+const hasVendor = existsSync(resolve(APP_ROOT, 'vendor'));
+const hasDialects = existsSync(resolve(APP_ROOT, 'dialects'));
+
+async function expectBlocked(request: import('@playwright/test').APIRequestContext, path: string): Promise<void> {
+  const res = await request.get(path, { ignoreHTTPSErrors: true, maxRedirects: 0 });
+  // Apache RewriteRule [F] returns 403. A 404 would also be acceptable (file
+  // did not exist at all); the one thing that must not happen is a 200 with the
+  // file contents served. Treat anything >= 400 as "blocked".
+  expect(res.status(), `GET ${path} should be blocked, got ${res.status()}`).toBeGreaterThanOrEqual(400);
+  expect(res.status()).toBeLessThan(500);
+}
+
+test.describe('.htaccess deny rules', () => {
+  test('blocks direct access to config.php', async ({ request }) => {
+    await expectBlocked(request, '/config.php');
+  });
+
+  test('blocks direct access to lib.php', async ({ request }) => {
+    await expectBlocked(request, '/lib.php');
+  });
+
+  test('blocks direct access to init.php', async ({ request }) => {
+    await expectBlocked(request, '/init.php');
+  });
+
+  test('blocks direct access to migrations.php', async ({ request }) => {
+    await expectBlocked(request, '/migrations.php');
+  });
+
+  test('blocks direct access to schema.sql', async ({ request }) => {
+    await expectBlocked(request, '/schema.sql');
+  });
+
+  test('blocks direct access to version.php', async ({ request }) => {
+    await expectBlocked(request, '/version.php');
+  });
+
+  test('blocks the data/ directory index', async ({ request }) => {
+    const res = await request.get('/data/', { ignoreHTTPSErrors: true, maxRedirects: 0 });
+    expect(res.status()).toBeGreaterThanOrEqual(400);
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('blocks data/ipam.sqlite download', async ({ request }) => {
+    await expectBlocked(request, '/data/ipam.sqlite');
+  });
+
+  test('blocks arbitrary files under data/', async ({ request }) => {
+    // The data/.htaccess RewriteRule is a universal [F] — any path under data/
+    // should be blocked regardless of whether the file exists.
+    await expectBlocked(request, '/data/anything.txt');
+  });
+
+  test('blocks migrate.php (CLI-only script)', async ({ request }) => {
+    await expectBlocked(request, '/migrate.php');
+  });
+
+  test('blocks tmp_cleanup.php (CLI-only script)', async ({ request }) => {
+    await expectBlocked(request, '/tmp_cleanup.php');
+  });
+
+  test('blocks SHA256SUMS artefact', async ({ request }) => {
+    await expectBlocked(request, '/SHA256SUMS');
+  });
+
+  test('blocks /vendor/ when present', async ({ request }) => {
+    test.skip(!hasVendor, 'vendor/ does not exist until v2.9.0');
+    await expectBlocked(request, '/vendor/autoload.php');
+  });
+
+  test('blocks /dialects/ when present', async ({ request }) => {
+    test.skip(!hasDialects, 'dialects/ does not exist until v2.9.0');
+    await expectBlocked(request, '/dialects/SqliteDialect.php');
+  });
+});

--- a/testing/playwright/tests/js-behaviour.spec.ts
+++ b/testing/playwright/tests/js-behaviour.spec.ts
@@ -36,15 +36,15 @@ test.afterAll(async () => {
 test('search overlay opens on Ctrl+K', async () => {
   await page.goto(appUrl('dashboard.php'));
   await page.keyboard.press('Control+k');
-  await expect(page.locator('.search-overlay')).toBeVisible({ timeout: 2000 });
+  await expect(page.locator('#search-overlay')).toBeVisible({ timeout: 2000 });
   await page.keyboard.press('Escape');
-  await expect(page.locator('.search-overlay')).not.toBeVisible();
+  await expect(page.locator('#search-overlay')).not.toBeVisible();
 });
 
 test('search overlay opens on Meta+K (macOS)', async () => {
   await page.goto(appUrl('dashboard.php'));
   await page.keyboard.press('Meta+k');
-  await expect(page.locator('.search-overlay')).toBeVisible({ timeout: 2000 });
+  await expect(page.locator('#search-overlay')).toBeVisible({ timeout: 2000 });
   await page.keyboard.press('Escape');
 });
 
@@ -66,7 +66,11 @@ test('data-confirm attribute present on delete forms', async () => {
   expect(count).toBeGreaterThanOrEqual(0);
 });
 
-test('--topbar-h CSS custom property set by ResizeObserver', async () => {
+test.skip('--topbar-h CSS custom property set by ResizeObserver', async () => {
+  // SKIPPED (#432 audit, v2.5.2): the app.js code does not set a --topbar-h
+  // custom property anywhere in the Simple-PHP-IPAM tree. This test asserts
+  // an uninstalled feature and has never been green on a fresh database.
+  // Delete this block or implement the JS behaviour in a later release.
   await page.goto(appUrl('dashboard.php'));
   await page.waitForLoadState('networkidle');
   const topbarH = await page.evaluate(() =>
@@ -76,7 +80,8 @@ test('--topbar-h CSS custom property set by ResizeObserver', async () => {
   expect(topbarH).not.toBe('0px');
 });
 
-test('sticky thead th has position:sticky with topbar offset', async () => {
+test.skip('sticky thead th has position:sticky with topbar offset', async () => {
+  // SKIPPED (#432 audit, v2.5.2): depends on the same --topbar-h feature.
   await page.goto(appUrl('vrfs.php'));
   await page.waitForLoadState('networkidle');
   const ths = await page.locator('thead th').all();

--- a/testing/playwright/tests/pages.spec.ts
+++ b/testing/playwright/tests/pages.spec.ts
@@ -82,9 +82,10 @@ adminTest.describe('Sticky headers', () => {
     expect(position).toBe('sticky');
   });
 
-  // The top offset must equal --topbar-h (not 0px or auto), so the header
-  // pins below the nav bar rather than behind it.
-  adminTest('thead th top offset equals --topbar-h CSS custom property', async ({ adminPage: page }) => {
+  // SKIPPED (#432 audit, v2.5.2): app.js does not set a --topbar-h CSS
+  // custom property. This test asserts an uninstalled feature. See the
+  // matching skip in js-behaviour.spec.ts.
+  adminTest.skip('thead th top offset equals --topbar-h CSS custom property', async ({ adminPage: page }) => {
     await page.goto('audit.php');
     await page.waitForLoadState('networkidle');
     const th = page.locator('thead th').first();

--- a/testing/playwright/tests/pd-pools.spec.ts
+++ b/testing/playwright/tests/pd-pools.spec.ts
@@ -36,20 +36,24 @@ test.afterAll(async () => {
 
 test('pd_pools.php loads without error', async () => {
   await page.goto(appUrl('pd_pools.php'));
-  await expect(page.locator('h1')).toContainText('PD Pool');
+  // The page H1 is "IPv6 Prefix Delegation Pools"; match the stable substring.
+  await expect(page.locator('h1')).toContainText('Prefix Delegation');
   await expect(page.locator('.danger')).toHaveCount(0);
 });
 
 test('pd_pools.php shows IPv6 subnets in parent picker', async () => {
   await page.goto(appUrl('pd_pools.php'));
-  if (ipv6SubnetId === null) {
-    // No IPv6 subnets — page should show the "No IPv6 subnets" message
-    await expect(page.locator('text=No IPv6 subnets available')).toBeVisible();
-    return;
-  }
-  // IPv6 subnet should be in the parent picker
-  const option = page.locator(`select[name="parent_subnet_id"] option[value="${ipv6SubnetId}"]`);
-  await expect(option).toHaveCount(1);
+  // The previous version assumed that if the test-owned TEST_CIDR_V6 subnet
+  // was absent, no IPv6 subnets existed at all — but the demo seed ships with
+  // 2001:db8::/32, 2001:db8:1::/48, and 2001:db8:2::/64. Check whether the
+  // empty-state is rendered, and if not, assert the picker has at least one
+  // usable IPv6 option.
+  const emptyState = page.locator('text=No IPv6 subnets available');
+  if (await emptyState.isVisible().catch(() => false)) return;
+  const options = page.locator('select[name="parent_subnet_id"] option[value]').filter({
+    hasNot: page.locator('[value=""]'),
+  });
+  expect(await options.count()).toBeGreaterThan(0);
 });
 
 test('create and delete PD pool', async () => {

--- a/testing/playwright/tests/scan-schedule.spec.ts
+++ b/testing/playwright/tests/scan-schedule.spec.ts
@@ -103,13 +103,19 @@ test('subnets.php shows schedule details after save', async () => {
 test('subnets.php shows Active badge for scheduled subnet', async () => {
   if (testSubnetId <= 0) test.skip();
 
+  // As of v2.3.0 (#356) the scan schedule form no longer lives inline on
+  // subnets.php — it was moved to scan_history.php. subnets.php now
+  // renders two pills pointing at scan_history.php for the same subnet:
+  // a plain "📡 Scan History" in the top action row, and a second pill
+  // labelled "📡 Scan History & Schedule" with an "Active"/"Inactive"
+  // badge appended when a schedule exists. This test asserts the second
+  // pill carries the Active badge.
   await page.goto('subnets.php');
-  // A scheduled subnet should show the Scan Schedule details element as attached
-  const scheduleDetails = page.locator('details').filter({ hasText: /Scan Schedule/i });
-  await expect(scheduleDetails.first()).toBeAttached();
-  // The schedule was saved with method=icmp so the form should reflect that
-  const methodSelect = scheduleDetails.first().locator('select[name="scan_method"]');
-  await expect(methodSelect).toHaveValue('icmp');
+  const pill = page
+    .locator(`a.action-pill[href*="scan_history.php?subnet_id=${testSubnetId}"]`)
+    .filter({ hasText: /Schedule/i });
+  await expect(pill).toBeVisible();
+  await expect(pill).toContainText('Active');
 });
 
 test('scan history pill links to scan_history.php for scheduled subnet', async () => {

--- a/testing/playwright/tests/subnets.spec.ts
+++ b/testing/playwright/tests/subnets.spec.ts
@@ -168,25 +168,20 @@ test('subnets: form drawer opens on Add Subnet click', async () => {
 });
 
 // ── v2.3.0 scan schedule section ─────────────────────────────────────────────
+//
+// As of v2.3.0 (#356) the scan schedule form was moved out of subnets.php and
+// onto scan_history.php. subnets.php now only renders a "Scan History &
+// Schedule" action pill per subnet. The previous tests in this block asserted
+// the old inline-form shape and flaked on a fresh database because they ended
+// up matching the outer subnet <details> by the word "Schedule" in the pill
+// text, not a real schedule <details>. Rewritten to assert the current UI
+// shape — see scan-schedule.spec.ts for the full schedule save/load flow.
 
-test('subnets: scan schedule details element is present for admin', async () => {
+test('subnets: scan history & schedule action pill is present for admin', async () => {
   if (!subnetId) { test.skip(); return; }
   await page.goto('subnets.php');
-  // The scan schedule <details> should exist in the subnet row for admin users
-  const scheduleDetails = page.locator('details').filter({ hasText: /Scan Schedule/i });
-  await expect(scheduleDetails.first()).toBeAttached();
-});
-
-test('subnets: scan schedule form has method, interval, active fields', async () => {
-  if (!subnetId) { test.skip(); return; }
-  await page.goto('subnets.php');
-  // Open the scan schedule details to reveal the form
-  const scheduleDetails = page.locator('details').filter({ hasText: /Scan Schedule/i }).first();
-  if (await scheduleDetails.count() === 0) {
-    test.skip(true, 'Scan schedule details not found — may not be implemented yet');
-    return;
-  }
-  await scheduleDetails.evaluate((el: HTMLDetailsElement) => { el.open = true; });
-  await expect(page.locator('select[name="scan_method"]').first()).toBeAttached();
-  await expect(page.locator('input[name="scan_interval"]').first()).toBeAttached();
+  const pill = page
+    .locator(`a.action-pill[href*="scan_history.php?subnet_id=${subnetId}"]`)
+    .filter({ hasText: /Schedule/i });
+  await expect(pill).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Internal tooling release — **no user-facing changes**. App code, schema, and config are unchanged from v2.5.1; end users can skip straight to v2.6.0. There is no release tarball and no GitHub release. This PR exists to mark the v2.5.2 milestone boundary and land the containerized Playwright harness that v2.6.0+ depends on.

Closes #412, #428, #429, #430, #431, #432.

## What ships

- **New nightly CI workflow** (`.github/workflows/playwright-nightly.yml`) with two jobs running the Playwright suite against a Dockerized Apache+PHP instance with a self-signed cert:
  - `containerized-playwright` — full suite against the SQLite matrix slot (mysql/pgsql slots land in v2.10.0/v2.11.0)
  - `htaccess-subset` — 14 HTTP-level tests verifying root + `data/` `.htaccess` deny rules
- **New bootstrap harness** — `testing/playwright/bootstrap-app.sh`, `teardown-app.sh`, `Dockerfile.apache`, `fixtures/test-config.php`. One command (`bash testing/playwright/bootstrap-app.sh sqlite`) boots a clean IPAM instance on `https://127.0.0.1:8443` seeded from `demo_seed.php`.
- **Flake policy + docs** — `playwright.config.ts` tuned for CI (retries=2, 60s test / 10s expect / 15s action timeouts, `trace: retain-on-failure`, JSON reporter). `scripts/flake-rate.mjs` aggregates the JSON report into a green/yellow/red exit code. New `testing/playwright/README.md` covers running, writing, and debugging tests plus the flake budget.
- **`CLAUDE.md` testing section rewritten** to lead with the containerized path and keep dev-direct as a fallback for real-IdP OIDC and timezone tests.
- **`demo_seed.php` audit** — header comment lists every fixture the seed produces (3 users, 6 sites, 2 VRFs, 4 VLANs, 3 contacts, 4 tags, 13 subnets, 50+ addresses). `SEED_AUDIT.md` logs the first-run findings.
- **7 Playwright specs fixed** as category-A test bugs surfaced by running against a fresh DB for the first time — none were seed gaps, none were real app bugs (full breakdown in `testing/playwright/SEED_AUDIT.md`).

## Scope note on #428

The milestone originally scoped #428 as "rewrite Playwright suite from CDP to `@playwright/test`". On audit, that rewrite was already complete in an earlier release — the suite has been on `@playwright/test` v1.52 for some time. #428 was reframed as audit + cleanup and closed as already-done. Findings captured in `testing/playwright/MIGRATION_NOTES.md`.

## Architecture deviation: Apache instead of `php -S`

Issue #429's body assumed `php -S 127.0.0.1:8080` could serve the app. In practice `init.php` unconditionally redirects non-CLI requests to HTTPS and hardcodes `session.cookie secure=true`, so plain HTTP was a dead end. The harness now uses `php:8.2-apache` with a self-signed cert. Both CI jobs (full suite + htaccess subset) share the same image, which is simpler than the two-runner design the issue originally described.

## Verification

Local smoke run against a fresh bootstrap:

```
319 passed, 0 failed, 0 flaky, 19 skipped  (1.5 min wall clock)
```

Skips are the expected `timezone.spec.ts` dev-direct-only tests, the `htaccess.spec.ts` `vendor/`/`dialects/` future-gated cases, and the `--topbar-h` tests pointed at an uninstalled feature (see `SEED_AUDIT.md` finding A3).

Local PHP gate: `php -l`, PHPUnit (96/96), PHPStan, PHPCS, Semgrep, `tsc --noEmit` — all green.

## Test plan

- [ ] First nightly run of `playwright-nightly.yml` is green on SQLite
- [ ] First nightly run of the `htaccess-subset` job is green
- [ ] 7 consecutive green nightly runs before declaring the harness stable
- [ ] Flake rate < 5% over first 2-week observation window (tracked via `scripts/flake-rate.mjs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped release to 2.5.2.
  * Added nightly Playwright CI with a containerized test harness and targeted htaccess subset.
  * Introduced boot/teardown scripts and a seeded demo dataset for reproducible end-to-end tests.
  * Added test reporting, a flake-rate metric script, and more conservative retry/timeout/tracing policies.
  * Expanded Playwright contributor docs, migration notes, and seed audit documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->