### PR TITLE
fix(docs): unblock GitHub Pages build

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,6 @@
 title: Simple PHP IPAM
 description: Lightweight IPv4/IPv6 address management — PHP 8.2+, SQLite, zero runtime dependencies.
 theme: minima
-remote_theme: ""
 
 # GitHub Pages source
 baseurl: "/Simple-PHP-IPAM"


### PR DESCRIPTION
## Summary

The Pages deploy has been failing since the v2.4.0 merge (PR #362) and again on v2.5.0 (PR #365) with:

```
jekyll-remote-theme-0.4.3/lib/jekyll-remote-theme/theme.rb:85:in 'theme_parts':
  undefined method 'match' for nil (NoMethodError)
```

## Root cause

`docs/_config.yml` set `remote_theme: ""` alongside `theme: minima`. `jekyll-remote-theme` still parses the empty string — the resulting URI has a nil path — and the plugin blows up trying to `match` against it.

`theme: minima` is sufficient on its own; the `remote_theme` line was vestigial and has never contributed anything to the build.

## Fix

One-line deletion. No other docs changes.

## Test plan

- [ ] `pages.yml` workflow runs green on the merge commit
- [ ] https://seanmousseau.github.io/Simple-PHP-IPAM/ loads with the minima theme (it should look identical to before the breakage, since the empty remote_theme was never doing anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed remote theme configuration from documentation site settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->