### PR TITLE
feat(settings): Phase B subsystem rewires for v2.7.0 (#373, #374, #375)

### DIFF
--- a/Simple-PHP-IPAM/cron.php
+++ b/Simple-PHP-IPAM/cron.php
@@ -151,12 +151,12 @@ try {
 // Task 4: Subnet utilisation alerts
 // ---------------------------------------------------------------------------
 try {
-    $alertEmail = to_str($config['alert_email'] ?? '');
+    $alertEmail = to_str(ipam_setting('alert.email'));
     if ($alertEmail !== '') {
         check_utilization_alerts($db, $config);
         $emit(['task' => 'utilisation_alerts', 'ran' => true, 'ts' => $now]);
     } else {
-        $emit(['task' => 'utilisation_alerts', 'skipped' => true, 'reason' => 'alert_email not configured', 'ts' => $now]);
+        $emit(['task' => 'utilisation_alerts', 'skipped' => true, 'reason' => 'alert.email not configured', 'ts' => $now]);
     }
 } catch (Throwable $e) {
     $fail('utilisation_alerts', $e->getMessage());

--- a/Simple-PHP-IPAM/cron.php
+++ b/Simple-PHP-IPAM/cron.php
@@ -36,10 +36,9 @@ $scriptDir = __DIR__;
 /** @var IpamConfig $config */
 $config = require $scriptDir . '/config.php';
 
-// Apply configured timezone before any date/time operations
-date_default_timezone_set(is_string($config['timezone'] ?? null) && $config['timezone'] !== ''
-    ? $config['timezone']
-    : 'UTC');
+// Seed a UTC default so any pre-DB date operations in lib.php bootstrap are
+// deterministic. Real timezone is applied from the DB settings below.
+date_default_timezone_set('UTC');
 
 require $scriptDir . '/lib.php';
 
@@ -83,6 +82,15 @@ register_shutdown_function(static function () use ($cronLockHandle): void {
 });
 
 $db       = ipam_db(to_str($config['db_path']));
+
+// Apply admin-configured timezone from DB settings now that $db is open. All
+// downstream date() calls in this cron run pick up the new zone.
+$tz = to_str(ipam_setting('branding.timezone'));
+if ($tz === '' || !@date_default_timezone_set($tz)) {
+    date_default_timezone_set('UTC');
+}
+unset($tz);
+
 $now      = date('c');
 $exitCode = 0;
 

--- a/Simple-PHP-IPAM/demo_gate.php
+++ b/Simple-PHP-IPAM/demo_gate.php
@@ -60,7 +60,7 @@ header('X-Content-Type-Options: nosniff');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 
 require_once __DIR__ . '/version.php';
-$appName = trim(to_str($config['app_name'] ?? '')) ?: 'Simple PHP IPAM';
+$appName = trim(to_str(ipam_setting('branding.site_name'))) ?: 'Simple PHP IPAM';
 ?>
 <!doctype html>
 <html>
@@ -71,8 +71,8 @@ $appName = trim(to_str($config['app_name'] ?? '')) ?: 'Simple PHP IPAM';
   <link rel="icon" type="image/webp" sizes="32x32" href="assets/favicon-32.webp">
   <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="assets/apple-touch-icon.png">
-  <link rel="stylesheet" href="assets/app.css?v=2.6.0">
-  <script defer src="assets/app.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="assets/app.css?v=2.7.0">
+  <script defer src="assets/app.js?v=2.7.0"></script>
 </head>
 <body>
 <div class="gate-wrap">

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 /** @var IpamConfig $config */
 $config = require __DIR__ . '/config.php';
 
-// Apply configured timezone before any date/time operations. All DB timestamps are
-// stored as UTC; display_datetime() in lib.php converts them for UI output.
-date_default_timezone_set(is_string($config['timezone'] ?? null) && $config['timezone'] !== ''
-    ? $config['timezone']
-    : 'UTC');
+// Seed a UTC default so any pre-DB date/time operations (HTTPS redirect, session
+// setup) are deterministic. The real timezone is applied from the DB settings
+// (branding.timezone) once $db is open and lib.php is loaded — see below.
+date_default_timezone_set('UTC');
 
 /**
  * Convert a mixed value to string. Defined early in init.php so it is available
@@ -73,6 +72,15 @@ require __DIR__ . '/lib.php';
 
 $db = ipam_db(to_str($config['db_path']));
 ipam_db_init($db);
+
+// Now that settings are available, apply the admin-configured timezone. All DB
+// timestamps are stored as UTC; display_datetime() in lib.php converts them
+// for UI output using the effective timezone set here.
+$tz = to_str(ipam_setting('branding.timezone'));
+if ($tz === '' || !@date_default_timezone_set($tz)) {
+    date_default_timezone_set('UTC');
+}
+unset($tz);
 
 // Auto-populate any missing config keys with their defaults
 $_addedConfigKeys = ipam_config_sync(__DIR__ . '/config.php', $config);

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -2138,13 +2138,14 @@ function recaptcha_enterprise_verify(string $token, string $siteKey, array $cfg)
  * or a non-empty error string that should be shown to the user.
  * Fails open on network errors so a broken CAPTCHA provider never blocks login.
  *
- * @param LoginProtectionConfig $config
+ * @param LoginProtectionConfig $config Unused since v2.7.0 — config flows
+ *                                      through ipam_setting().
  * @param array<string, mixed> $post
  */
 function login_protection_verify(array $config, array $post): ?string
 {
-    $cfg    = $config['login_protection'];
-    $method = to_str($cfg['method'] ?? '');
+    unset($config);
+    $method = to_str(ipam_setting('login_protection.method'));
     if ($method === '' || $method === 'null') return null;
 
     if ($method === 'honeypot') {
@@ -2152,7 +2153,7 @@ function login_protection_verify(array $config, array $post): ?string
     }
 
     if ($method === 'time_check') {
-        $min = max(1, $cfg['min_seconds']);
+        $min = max(1, to_int(ipam_setting('login_protection.min_seconds')));
         $ts  = to_int($_SESSION['login_form_at'] ?? 0);
         unset($_SESSION['login_form_at']);
         if ($ts === 0 || (time() - $ts) < $min) {
@@ -2161,7 +2162,7 @@ function login_protection_verify(array $config, array $post): ?string
         return null;
     }
 
-    $secretKey = $cfg['secret_key'];
+    $secretKey = to_str(ipam_setting('login_protection.secret_key'));
 
     if ($method === 'turnstile') {
         $token = to_str($post['cf-turnstile-response'] ?? '');
@@ -2200,11 +2201,16 @@ function login_protection_verify(array $config, array $post): ?string
         if ($token === '') return 'Please complete the security check.';
 
         // Use Enterprise API if configured; fall back to standard reCAPTCHA API
-        /** @var IpamConfig $gConfig */
-        $gConfig    = $GLOBALS['config'] ?? [];
-        $enterprise = $gConfig['recaptcha_enterprise'];
-        if (!empty($enterprise['enabled'])) {
-            return recaptcha_enterprise_verify($token, $cfg['site_key'], $enterprise);
+        if ((bool)ipam_setting('recaptcha_enterprise.enabled')) {
+            $rawThreshold = ipam_setting('recaptcha_enterprise.score_threshold');
+            $enterprise = [
+                'enabled'         => true,
+                'project_id'      => to_str(ipam_setting('recaptcha_enterprise.project_id')),
+                'api_key'         => to_str(ipam_setting('recaptcha_enterprise.api_key')),
+                'expected_action' => to_str(ipam_setting('recaptcha_enterprise.expected_action')),
+                'score_threshold' => is_numeric($rawThreshold) ? (float)$rawThreshold : 0.5,
+            ];
+            return recaptcha_enterprise_verify($token, to_str(ipam_setting('login_protection.site_key')), $enterprise);
         }
 
         try {
@@ -2228,7 +2234,7 @@ function login_protection_verify(array $config, array $post): ?string
             $resp = oidc_http_post('https://api.friendlycaptcha.com/api/v1/siteverify', [
                 'secret'  => $secretKey,
                 'solution'=> $token,
-                'sitekey' => $cfg['site_key'],
+                'sitekey' => to_str(ipam_setting('login_protection.site_key')),
             ]);
         } catch (Throwable $e) {
             error_log('FriendlyCaptcha verify error: ' . $e->getMessage());
@@ -2243,13 +2249,14 @@ function login_protection_verify(array $config, array $post): ?string
 /**
  * Return the HTML widget snippet to embed in the login/gate form.
  * For time_check, also sets the session timestamp on GET requests.
+ *
+ * @param LoginProtectionConfig $config Unused since v2.7.0 — kept for signature stability.
  */
-/** @param LoginProtectionConfig $config */
 function login_protection_widget_html(array $config): string
 {
-    $cfg     = $config['login_protection'];
-    $method  = to_str($cfg['method'] ?? '');
-    $siteKey = e($cfg['site_key']);
+    unset($config);
+    $method  = to_str(ipam_setting('login_protection.method'));
+    $siteKey = e(to_str(ipam_setting('login_protection.site_key')));
 
     switch ($method) {
         case 'honeypot':
@@ -2266,16 +2273,14 @@ function login_protection_widget_html(array $config): string
             return "<script src='https://js.hcaptcha.com/1/api.js' async defer></script>"
                  . "<div class='h-captcha' data-sitekey='{$siteKey}'></div>";
         case 'recaptcha':
-            $ver        = $cfg['version'];
-            /** @var IpamConfig $gCfg */
-            $gCfg  = $GLOBALS['config'] ?? [];
-            $isEnt = !empty($gCfg['recaptcha_enterprise']['enabled']);
+            $ver   = to_int(ipam_setting('login_protection.version'));
+            $isEnt = (bool)ipam_setting('recaptcha_enterprise.enabled');
             if ($ver === 3) {
                 $scriptSrc    = $isEnt
                     ? "https://www.google.com/recaptcha/enterprise.js?render={$siteKey}"
                     : "https://www.google.com/recaptcha/api.js?render={$siteKey}";
                 $entAttr      = $isEnt ? " data-recaptcha-enterprise='1'" : '';
-                $action       = e(to_str($gCfg['recaptcha_enterprise']['expected_action']));
+                $action       = e(to_str(ipam_setting('recaptcha_enterprise.expected_action')));
                 $actionAttr   = " data-recaptcha-action='{$action}'";
                 return "<script src='{$scriptSrc}' async defer></script>"
                      . "<input type='hidden' name='g-recaptcha-response' id='g-recaptcha-response' data-recaptcha-v3-key='{$siteKey}'{$entAttr}{$actionAttr}>";
@@ -2297,12 +2302,13 @@ function login_protection_widget_html(array $config): string
  * be explicitly allowed; Friendly Captcha uses Web Components (no iframe needed).
  */
 /**
- * @param LoginProtectionConfig $config
+ * @param LoginProtectionConfig $config Unused since v2.7.0 — kept for signature stability.
  * @return array{script_src: string, frame_src: string}
  */
 function login_protection_extra_csp(array $config): array
 {
-    $method = to_str($config['login_protection']['method'] ?? '');
+    unset($config);
+    $method = to_str(ipam_setting('login_protection.method'));
     return match ($method) {
         'turnstile'        => [
             'script_src' => 'https://challenges.cloudflare.com',
@@ -3389,10 +3395,14 @@ function subnet_overlap_warning_text(array $overlaps): string
 /** @param array<string, string> $opts */
 function page_header(string $title, array $opts = []): void
 {
+    // Still needed for the bootstrap_admin default-password warning below —
+    // that is a pre-registry config-only check that stays on config.php
+    // forever (see below). Everything else in this function reads through
+    // ipam_setting() as of v2.7.0.
     global $config;
     $u = to_str($_SESSION['username'] ?? '');
     $role = to_str($_SESSION['role'] ?? '');
-    $appName = trim($config['app_name']) ?: 'Simple PHP IPAM';
+    $appName = trim(to_str(ipam_setting('branding.site_name'))) ?: 'Simple PHP IPAM';
 
     $extraScriptSrc = isset($opts['extra_script_src']) && $opts['extra_script_src'] !== '' ? ' ' . $opts['extra_script_src'] : '';
     $frameSrc       = isset($opts['extra_frame_src'])  && $opts['extra_frame_src']  !== '' ? " frame-src 'self' " . $opts['extra_frame_src'] . ';' : '';
@@ -3407,11 +3417,11 @@ function page_header(string $title, array $opts = []): void
     echo "<link rel='icon' type='image/png' sizes='32x32' href='assets/favicon-32.png'>";
     echo "<link rel='apple-touch-icon' type='image/webp' sizes='180x180' href='assets/apple-touch-icon.webp'>";
     echo "<link rel='apple-touch-icon' sizes='180x180' href='assets/apple-touch-icon.png'>";
-    echo "<link rel='stylesheet' href='assets/app.css?v=2.6.0'>";
+    echo "<link rel='stylesheet' href='assets/app.css?v=2.7.0'>";
     // Expose server-side theme via meta tag so app.js can seed localStorage (CSP-safe)
     $userTheme = to_str($_SESSION['user_theme'] ?? 'auto');
     echo "<meta name='ipam-server-theme' content='" . e($userTheme) . "'>";
-    echo "<script defer src='assets/app.js?v=2.6.0'></script>";
+    echo "<script defer src='assets/app.js?v=2.7.0'></script>";
     echo "</head><body>";
 
     echo "<div class='topbar'><div class='nav-wrap'>";
@@ -3576,7 +3586,7 @@ function page_header(string $title, array $opts = []): void
 
     // Update-available dismissible banner (admin only, client-side dismiss via localStorage)
     if ($role === 'admin') {
-        $update = ipam_update_check($config ?? []);
+        $update = ipam_update_check($config);
         if ($update) {
             $uv  = e(to_str($update['version']));
             $url = e(to_str($update['url']));
@@ -3644,20 +3654,20 @@ function ipam_normalise_version(string $v): string
  * Returns ['version' => '1.2.1', 'url' => 'https://...'] if newer, otherwise null.
  */
 /**
- * @param IpamConfig $config
+ * @param IpamConfig $config Unused since v2.7.0 — kept for signature stability.
  * @return array{version: string, url: string}|null
  */
 function ipam_update_check(array $config): ?array
 {
+    unset($config);
     // Memoize within a single request — page_header() and page_footer() both call this
     static $memo = false;
     if ($memo !== false) return $memo;
 
-    $uc = $config['update_check'];
-    if (!(bool)$uc['enabled']) { $memo = null; return null; }
+    if (!(bool)ipam_setting('update_check.enabled')) { $memo = null; return null; }
 
-    $ttl             = max(3600, to_int($uc['ttl_seconds']));
-    $notifyPrerelease = !empty($uc['notify_prerelease']);
+    $ttl              = max(3600, to_int(ipam_setting('update_check.ttl_seconds')));
+    $notifyPrerelease = (bool)ipam_setting('update_check.notify_prerelease');
 
     ensure_tmp_dir();
     $cache = tmp_dir() . '/update-check.json';

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -759,6 +759,33 @@ function ipam_setting_definitions(): array
             'sensitive'   => false,
             'config_key'  => ['oidc', 'default_role'],
         ],
+        'oidc.disable_local_login' => [
+            'label'       => 'Disable local password login',
+            'description' => 'When OIDC is active, hide the local username/password form entirely. Emergency bypass still works unless also disabled below.',
+            'type'        => 'bool',
+            'group'       => 'oidc',
+            'default'     => false,
+            'sensitive'   => false,
+            'config_key'  => ['oidc', 'disable_local_login'],
+        ],
+        'oidc.disable_emergency_bypass' => [
+            'label'       => 'Disable emergency local bypass',
+            'description' => 'Disable the ?local=1 emergency access path that lets a local admin sign in even when local login is hidden. Leave off until you are confident SSO will keep working.',
+            'type'        => 'bool',
+            'group'       => 'oidc',
+            'default'     => false,
+            'sensitive'   => false,
+            'config_key'  => ['oidc', 'disable_emergency_bypass'],
+        ],
+        'oidc.hide_emergency_link' => [
+            'label'       => 'Hide emergency bypass link',
+            'description' => 'Hide the "(emergency local access)" link even if the ?local=1 bypass itself is still reachable.',
+            'type'        => 'bool',
+            'group'       => 'oidc',
+            'default'     => false,
+            'sensitive'   => false,
+            'config_key'  => ['oidc', 'hide_emergency_link'],
+        ],
     ];
 }
 
@@ -3722,15 +3749,20 @@ function find_parent_site_id(PDO $db, string $cidr, ?int $excludeId = null, ?int
  * OIDC — Authorization Code + PKCE (pure PHP, no dependencies)
  * ============================================================ */
 
-/** @param IpamConfig $config */
+/**
+ * @param IpamConfig $config Unused since v2.7.0 — kept for back-compat with
+ *                           existing callers. Reads go through ipam_setting()
+ *                           which falls back to $GLOBALS['config'] on a miss,
+ *                           so legacy config.php-only installs still work.
+ */
 function oidc_enabled(array $config): bool
 {
-    $o = $config['oidc'];
-    return !empty($o['enabled'])
-        && !empty($o['client_id'])
-        && !empty($o['client_secret'])
-        && !empty($o['discovery_url'])
-        && !empty($o['redirect_uri']);
+    unset($config); // keep the signature stable; body now reads through ipam_setting()
+    return (bool)ipam_setting('oidc.enabled')
+        && to_str(ipam_setting('oidc.client_id'))     !== ''
+        && to_str(ipam_setting('oidc.client_secret')) !== ''
+        && to_str(ipam_setting('oidc.discovery_url')) !== ''
+        && to_str(ipam_setting('oidc.redirect_uri'))  !== '';
 }
 
 /**
@@ -3739,12 +3771,13 @@ function oidc_enabled(array $config): bool
  * contain that path.
  */
 /**
- * @param IpamConfig $config
+ * @param IpamConfig $config Unused since v2.7.0 — kept for signature stability.
  * @return array<string, mixed>
  */
 function oidc_discovery(array $config): array
 {
-    $base = rtrim($config['oidc']['discovery_url'], '/');
+    unset($config);
+    $base = rtrim(to_str(ipam_setting('oidc.discovery_url')), '/');
     if ($base === '') throw new RuntimeException('OIDC discovery_url not set');
 
     $url = (str_contains($base, '.well-known')) ? $base : $base . '/.well-known/openid-configuration';

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -1590,16 +1590,18 @@ function prune_address_history(PDO $db, int $retentionDays): int
  * Deduplicates sends using the alert_state table (max one alert per subnet+level per 24 h).
  * Auto-clears alert_state rows when utilization drops back below the threshold.
  *
- * @param IpamConfig $config
+ * @param IpamConfig $config Unused since v2.7.0 — thresholds and the
+ *                           recipient now flow through ipam_setting().
  */
 function check_utilization_alerts(PDO $db, array $config): void
 {
-    $alertEmail = trim(to_str($config['alert_email'] ?? ''));
+    unset($config);
+    $alertEmail = trim(to_str(ipam_setting('alert.email')));
     if ($alertEmail === '') return;
 
-    $warnPct = to_int($config['alert_util_warn_pct'] ?? 80);
-    $critPct = to_int($config['alert_util_crit_pct'] ?? 95);
-    $appName = to_str($config['app_name']);
+    $warnPct = to_int(ipam_setting('alert.util_warn_pct'));
+    $critPct = to_int(ipam_setting('alert.util_crit_pct'));
+    $appName = to_str(ipam_setting('branding.site_name'));
 
     // Compute direct address counts per subnet (used+reserved)
     $rows = ($db->query("
@@ -1680,14 +1682,14 @@ function check_utilization_alerts(PDO $db, array $config): void
  * Run utilization alert check if the alert interval has elapsed.
  * Uses a dedicated state file so it can fire more frequently than main housekeeping.
  *
- * @param IpamConfig $config
+ * @param IpamConfig $config Unused since v2.7.0 — kept for signature stability.
  */
 function alerts_check_if_due(array $config, PDO $db): void
 {
-    $alertEmail = trim(to_str($config['alert_email'] ?? ''));
+    $alertEmail = trim(to_str(ipam_setting('alert.email')));
     if ($alertEmail === '') return;
 
-    $interval = to_int($config['alert_interval_seconds'] ?? 3600);
+    $interval = to_int(ipam_setting('alert.interval_seconds'));
     if ($interval < 60) $interval = 60;
 
     $statePath = __DIR__ . '/data/alerts_last_run.txt';

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -32,9 +32,9 @@ try {
     $firstRun = true; // treat as first-run if audit_log is temporarily unavailable
 }
 $oidcActive            = oidc_enabled($config) && !demo_mode_enabled();
-$disableLocal          = $oidcActive && !empty($config['oidc']['disable_local_login']);
-$disableEmergencyBypass= $oidcActive && !empty($config['oidc']['disable_emergency_bypass']);
-$hideEmergencyLink     = $oidcActive && !empty($config['oidc']['hide_emergency_link']);
+$disableLocal          = $oidcActive && (bool)ipam_setting('oidc.disable_local_login');
+$disableEmergencyBypass= $oidcActive && (bool)ipam_setting('oidc.disable_emergency_bypass');
+$hideEmergencyLink     = $oidcActive && (bool)ipam_setting('oidc.hide_emergency_link');
 $localForceShown       = isset($_GET['local']) && !$disableEmergencyBypass;
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -135,7 +135,7 @@ $appName = trim(to_str($config['app_name'])) ?: 'Simple PHP IPAM';
   <?php if ($error): ?><p class="danger"><?= e($error) ?></p><?php endif; ?>
 
   <?php if ($oidcActive): ?>
-  <p><a href="oidc_login.php" class="btn-sso">Sign in with <?= e(to_str($config['oidc']['display_name'])) ?></a></p>
+  <p><a href="oidc_login.php" class="btn-sso">Sign in with <?= e(to_str(ipam_setting('oidc.display_name'))) ?></a></p>
   <?php endif; ?>
 
   <?php if (!$disableLocal || $localForceShown): ?>

--- a/Simple-PHP-IPAM/login.php
+++ b/Simple-PHP-IPAM/login.php
@@ -7,14 +7,14 @@ require __DIR__ . '/init.php';
 if (is_logged_in()) { header('Location: dashboard.php'); exit; }
 if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
 
-$maxAttempts   = to_int($config['login_max_attempts']);
-$lockoutSeconds = to_int($config['login_lockout_seconds']);
+$maxAttempts   = to_int(ipam_setting('security.login_max_attempts'));
+$lockoutSeconds = to_int(ipam_setting('security.login_lockout_seconds'));
 
 $error    = '';
 $timedOut = !empty($_GET['timeout']);
 
 // Login protection setup (#124) — widget HTML also sets time_check session ts on GET
-$lpMethod     = to_str($config['login_protection']['method'] ?? '');
+$lpMethod     = to_str(ipam_setting('login_protection.method'));
 $lpWidgetHtml = login_protection_widget_html($config);
 $lpCsp        = login_protection_extra_csp($config);
 
@@ -118,7 +118,7 @@ page_header('Login', array_filter([
     'extra_script_src' => $lpCsp['script_src'],
     'extra_frame_src'  => $lpCsp['frame_src'],
 ]));
-$appName = trim(to_str($config['app_name'])) ?: 'Simple PHP IPAM';
+$appName = trim(to_str(ipam_setting('branding.site_name'))) ?: 'Simple PHP IPAM';
 ?>
 <div class="login-wrap">
 <div class="login-card">

--- a/Simple-PHP-IPAM/oidc_callback.php
+++ b/Simple-PHP-IPAM/oidc_callback.php
@@ -58,9 +58,9 @@ try {
     $tokens = oidc_http_post(to_str($discovery['token_endpoint']), [
         'grant_type'    => 'authorization_code',
         'code'          => $code,
-        'redirect_uri'  => to_str($config['oidc']['redirect_uri']),
-        'client_id'     => to_str($config['oidc']['client_id']),
-        'client_secret' => to_str($config['oidc']['client_secret']),
+        'redirect_uri'  => to_str(ipam_setting('oidc.redirect_uri')),
+        'client_id'     => to_str(ipam_setting('oidc.client_id')),
+        'client_secret' => to_str(ipam_setting('oidc.client_secret')),
         'code_verifier' => $verifier,
     ]);
 } catch (Throwable $e) {
@@ -74,7 +74,7 @@ if (empty($tokens['id_token'])) {
 // ---- Verify ID token (with one JWKS cache-bust retry for key rotation) ----
 $expect = [
     'iss'   => to_str($discovery['issuer'] ?? ''),
-    'aud'   => to_str($config['oidc']['client_id']),
+    'aud'   => to_str(ipam_setting('oidc.client_id')),
     'nonce' => $nonce,
 ];
 
@@ -110,8 +110,8 @@ $user = $st->fetch();
 // auto_link: link incoming OIDC login to an existing unlinked local account by username/email.
 // auto_provision: create a new account when no match is found (implies auto_link).
 // For backwards compatibility, if auto_link is absent, fall back to auto_provision for both.
-$autoProvision = !empty($config['oidc']['auto_provision']);
-$autoLink      = !empty($config['oidc']['auto_link']);
+$autoProvision = (bool)ipam_setting('oidc.auto_provision');
+$autoLink      = (bool)ipam_setting('oidc.auto_link');
 
 if (!$user && $autoLink) {
     // Try to link an existing local user by preferred_username then by email
@@ -138,7 +138,7 @@ if (!$user && $autoLink) {
         $user = $existing;
     } elseif ($autoProvision) {
         // Auto-provision a new local user
-        $role = to_str($config['oidc']['default_role']);
+        $role = to_str(ipam_setting('oidc.default_role'));
         if (!in_array($role, ['admin', 'netops', 'readonly'], true)) $role = 'readonly';
 
         // Derive a username: prefer preferred_username, fall back to email local-part, then sub

--- a/Simple-PHP-IPAM/oidc_login.php
+++ b/Simple-PHP-IPAM/oidc_login.php
@@ -25,9 +25,9 @@ $_SESSION['oidc_verifier'] = $pkce['verifier'];
 
 $params = [
     'response_type'         => 'code',
-    'client_id'             => to_str($config['oidc']['client_id']),
-    'redirect_uri'          => to_str($config['oidc']['redirect_uri']),
-    'scope'                 => to_str($config['oidc']['scopes']),
+    'client_id'             => to_str(ipam_setting('oidc.client_id')),
+    'redirect_uri'          => to_str(ipam_setting('oidc.redirect_uri')),
+    'scope'                 => to_str(ipam_setting('oidc.scopes')),
     'state'                 => $state,
     'nonce'                 => $nonce,
     'code_challenge'        => $pkce['challenge'],

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -252,6 +252,63 @@ class SettingsTest extends TestCase
         $this->assertArrayHasKey('max', $defs['alert.util_crit_pct']);
     }
 
+    public function testOidcEnabledReadsThroughSettingsHelperFromDb(): void
+    {
+        // v2.7.0 #373: oidc_enabled() must stop reading $config['oidc'][...]
+        // directly and instead go through ipam_setting() so DB-backed values
+        // take precedence over config.php and the admin UI actually controls
+        // the subsystem.
+        $GLOBALS['config'] = [];
+        $this->assertFalse(oidc_enabled([]), 'defaults to disabled');
+
+        // Seed every required key in the DB and confirm it flips true.
+        ipam_setting_set($this->db, 'oidc.enabled',       true);
+        ipam_setting_set($this->db, 'oidc.client_id',     'cid');
+        ipam_setting_set($this->db, 'oidc.client_secret', 'secret');
+        ipam_setting_set($this->db, 'oidc.discovery_url', 'https://idp.example/');
+        ipam_setting_set($this->db, 'oidc.redirect_uri',  'https://app.example/oidc_callback.php');
+        ipam_setting_cache_bust();
+
+        $this->assertTrue(oidc_enabled([]), 'enabled once every required DB key is set');
+
+        // Flipping enabled to false in the DB must take effect even if
+        // $config still has every OIDC key filled in. DB wins over config.
+        $GLOBALS['config'] = [
+            'oidc' => [
+                'enabled'       => true,
+                'client_id'     => 'cid',
+                'client_secret' => 'secret',
+                'discovery_url' => 'https://idp.example/',
+                'redirect_uri'  => 'https://app.example/oidc_callback.php',
+            ],
+        ];
+        ipam_setting_set($this->db, 'oidc.enabled', false);
+        ipam_setting_cache_bust();
+        $this->assertFalse(oidc_enabled([]), 'DB enabled=false overrides config enabled=true');
+    }
+
+    public function testOidcEnabledFallsBackToConfigPhpWhenDbEmpty(): void
+    {
+        // Back-compat guarantee for v2.7.0: admins who have not touched the
+        // settings UI yet must still see OIDC work with pure config.php.
+        $GLOBALS['config'] = [
+            'oidc' => [
+                'enabled'       => true,
+                'client_id'     => 'cid',
+                'client_secret' => 'secret',
+                'discovery_url' => 'https://idp.example/',
+                'redirect_uri'  => 'https://app.example/oidc_callback.php',
+            ],
+        ];
+        ipam_setting_cache_bust();
+        $this->assertTrue(oidc_enabled([]));
+
+        // Remove one required key — back to disabled.
+        $GLOBALS['config']['oidc']['client_secret'] = '';
+        ipam_setting_cache_bust();
+        $this->assertFalse(oidc_enabled([]));
+    }
+
     public function testCallerDefaultIgnoredForRegisteredKey(): void
     {
         // Registry default must win; caller-supplied $default only matters for

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -287,6 +287,33 @@ class SettingsTest extends TestCase
         $this->assertFalse(oidc_enabled([]), 'DB enabled=false overrides config enabled=true');
     }
 
+    public function testAlertThresholdsFallbackChain(): void
+    {
+        // v2.7.0 #374: alerting thresholds must follow the DB → config.php →
+        // registry default chain so an admin can override either way.
+        $GLOBALS['config'] = [];
+        $this->assertSame(80, ipam_setting('alert.util_warn_pct'), 'registry default');
+        $this->assertSame(95, ipam_setting('alert.util_crit_pct'), 'registry default');
+        $this->assertSame(3600, ipam_setting('alert.interval_seconds'), 'registry default');
+
+        $GLOBALS['config'] = [
+            'alert_util_warn_pct'    => 70,
+            'alert_util_crit_pct'    => 88,
+            'alert_interval_seconds' => 900,
+            'alert_email'            => 'ops@example.com',
+        ];
+        ipam_setting_cache_bust();
+        $this->assertSame(70, ipam_setting('alert.util_warn_pct'), 'config fallback honoured');
+        $this->assertSame(88, ipam_setting('alert.util_crit_pct'));
+        $this->assertSame(900, ipam_setting('alert.interval_seconds'));
+        $this->assertSame('ops@example.com', ipam_setting('alert.email'));
+
+        // DB value wins over config.
+        ipam_setting_set($this->db, 'alert.util_warn_pct', 60);
+        ipam_setting_cache_bust();
+        $this->assertSame(60, ipam_setting('alert.util_warn_pct'));
+    }
+
     public function testOidcEnabledFallsBackToConfigPhpWhenDbEmpty(): void
     {
         // Back-compat guarantee for v2.7.0: admins who have not touched the


### PR DESCRIPTION
## Summary

Phase B of the v2.7.0 milestone — moves the five heavy \`config.php\` consumers onto the v2.6.0 database settings helper. Admin UI edits now take effect without a config.php edit or restart. \`config.php\` still works as a fallback; removal is v3.0.0.

Three independent commits, one per subsystem, reviewable on their own:

### 78de3fe — OIDC rewire (#373)
- \`oidc_enabled()\` and \`oidc_discovery()\` keep their \`array \$config\` signatures for back-compat but route every read through \`ipam_setting('oidc.*')\`.
- \`oidc_login.php\`, \`oidc_callback.php\`, and \`login.php\` replace \`\$config['oidc'][...]\` with \`ipam_setting('oidc.*')\`.
- Three login-hardening flags that previously had no registry presence are now registered keys: \`oidc.disable_local_login\`, \`oidc.disable_emergency_bypass\`, \`oidc.hide_emergency_link\`.
- New PHPUnit tests prove DB → config → registry-default precedence for \`oidc_enabled()\`.

### 2ddf49d — Alerting rewire (#374)
- \`check_utilization_alerts()\` and \`alerts_check_if_due()\` in \`lib.php\` read \`alert.email\`, \`alert.util_warn_pct\`, \`alert.util_crit_pct\`, \`alert.interval_seconds\`, and \`branding.site_name\` via \`ipam_setting()\`.
- \`cron.php\` task 4 reads \`alert.email\` via \`ipam_setting()\`; skip message updated to reference the new key.
- Silent-no-op-when-empty behaviour preserved; \`alert_state\` table untouched.

### c9f90cf — Branding, login protection, update checker (#375)
- \`page_header()\` reads \`branding.site_name\` for the \`<title>\` and nav brand. Login and demo gate do the same.
- Timezone: \`init.php\` and \`cron.php\` seed a UTC default pre-DB, then reapply \`branding.timezone\` once \`\$db\` is open. Bad value → UTC fallback, never a broken state.
- \`login_protection_verify()\`, \`login_protection_widget_html()\`, and \`login_protection_extra_csp()\` route everything through \`ipam_setting('login_protection.*')\` and \`ipam_setting('recaptcha_enterprise.*')\`. The enterprise dict is assembled on the fly from the five registered keys; \`recaptcha_enterprise_verify()\` signature is unchanged.
- \`ipam_update_check()\` reads \`update_check.enabled\`, \`ttl_seconds\`, \`notify_prerelease\` via \`ipam_setting()\`.
- Asset cache-buster bumped to \`?v=2.7.0\`.
- \`page_header()\` keeps \`global \$config;\` for the one remaining bootstrap-only read: the default bootstrap_admin password warning. That key is intentionally out-of-registry.

## Test plan

- [x] \`php -l\` on every changed PHP file
- [x] \`vendor/bin/phpstan analyse --memory-limit=1G\` — clean (5 new errors were introduced mid-rewire and fixed before commit)
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`vendor/bin/phpunit\` — 118/118 passing, plus three new rewire-specific tests (OIDC helper + alerting fallback chain)
- [x] \`semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/\` — 0 findings
- [x] Containerized Playwright: auth + settings + pages + console-clean + csp + upgrade specs, 99 pass / 2 skip / 0 fail

## Not in scope

- Deprecation tooling for \`config.php\` keys — Phase C (#376).
- Docs + changelog + version bump + release bundle — Phase D (#377).
- Removal of the config.php fallback — v3.0.0.

## Depends on

- #444 (Phase A settings.php UX fixes) is not a hard dependency — this branch is off clean \`dev\`. When both merge the rewire and the UX polish take effect together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)