### PR TITLE
feat(settings): Phase C deprecation tooling for v2.7.0 (#376)

### DIFF
--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -108,6 +108,22 @@ page_header('Dashboard');
   </div>
 </div>
 
+<?php if (current_user()['role'] === 'admin'):
+    // v2.7.0 #376: nudge admins to migrate any customised config.php values
+    // into the database before v3.0.0 removes the fallback. The settings
+    // page has the real banner with per-key import buttons — this card just
+    // gets the admin to click over and see it.
+    $_deprecatedDash = ipam_setting_deprecated_keys();
+    if ($_deprecatedDash):
+?>
+  <div class="admin-notice admin-notice--warning" role="alert">
+    &#9888; <strong>Settings migration needed:</strong>
+    <?= count($_deprecatedDash) ?> registered setting(s) are still being read from
+    <code>config.php</code>. These will stop working at v3.0.0.
+    <a href="settings.php#deprecated-banner">Review and migrate in Settings &rsaquo;</a>
+  </div>
+    <?php endif; unset($_deprecatedDash); endif; ?>
+
 <div class="page-actions">
   <a class="action-pill" href="subnets.php#add-subnet">➕ Add Subnet</a>
   <a class="action-pill" href="search.php">🔎 Search</a>

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -89,6 +89,34 @@ if ($_configWarnings) {
 }
 unset($_configWarnings);
 
+// #376: surface a rate-limited server-log warning listing any registered
+// settings still being served from config.php. Touch a marker file so we
+// emit at most one line per hour regardless of traffic. Missing/unwritable
+// data/tmp/ silently falls through to the "no marker" path so the warning
+// still fires once per request — preferable to failing silently.
+$_deprecated = ipam_setting_deprecated_keys();
+if ($_deprecated) {
+    $_markerPath = __DIR__ . '/data/tmp/deprecation_warning.txt';
+    $_shouldLog  = true;
+    if (is_file($_markerPath) && (time() - (int)@filemtime($_markerPath)) < 3600) {
+        $_shouldLog = false;
+    }
+    if ($_shouldLog) {
+        $_keyList = implode(', ', array_map(fn($d) => $d['key'], $_deprecated));
+        error_log(
+            'Simple-PHP-IPAM: ' . count($_deprecated)
+            . ' registered setting(s) still served from config.php — will break at v3.0.0. Keys: '
+            . $_keyList
+            . '. Migrate via Admin → Settings.'
+        );
+        @ensure_tmp_dir();
+        @touch($_markerPath);
+        @chmod($_markerPath, 0600);
+    }
+    unset($_markerPath, $_shouldLog, $_keyList);
+}
+unset($_deprecated);
+
 // Run best-effort housekeeping at most once/day (configurable)
 run_housekeeping_if_due($config, $db);
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -1070,6 +1070,85 @@ function ipam_setting_source(PDO $db, string $key): string
 }
 
 /**
+ * Return the list of registered settings that are still being served from
+ * $config (config.php) instead of the database. Drives the v2.7.0 deprecation
+ * banner in settings.php, the init.php boot-time log warning, and the
+ * dashboard admin card that nudges admins to migrate before v3.0.0 removes
+ * the fallback.
+ *
+ * A key is considered deprecated iff **all** of these hold:
+ *   - its registry definition exists (bootstrap-only keys like db_driver
+ *     are not in the registry so they are never flagged);
+ *   - no row exists in the `settings` table for that key;
+ *   - the key's `config_key` path resolves to a non-null value in
+ *     $GLOBALS['config'];
+ *   - that value differs from the registry `default`.
+ *
+ * The last condition keeps a pristine install with a seeded default
+ * config.php from lighting up the banner for every single key — we only
+ * surface what the admin has actually customised.
+ *
+ * On any DB error the helper returns [] (fail-quiet) so the boot path and
+ * the dashboard render never break because of this advisory feature.
+ *
+ * @return list<array{key: string, config_path: string, current: mixed}>
+ */
+function ipam_setting_deprecated_keys(): array
+{
+    $db = $GLOBALS['db'] ?? null;
+    if (!($db instanceof PDO)) return [];
+
+    try {
+        $st   = $db->query("SELECT key FROM settings");
+        $rows = $st !== false ? $st->fetchAll(PDO::FETCH_COLUMN) : [];
+    } catch (\Throwable) {
+        return [];
+    }
+    $inDb = [];
+    foreach ($rows as $k) {
+        if (is_string($k)) $inDb[$k] = true;
+    }
+
+    $config = $GLOBALS['config'] ?? null;
+    if (!is_array($config)) return [];
+
+    $out  = [];
+    $defs = ipam_setting_definitions();
+    foreach ($defs as $key => $def) {
+        if (isset($inDb[$key])) continue;
+        $configKey = $def['config_key'] ?? null;
+        if ($configKey === null || (!is_string($configKey) && !is_array($configKey))) continue;
+
+        $current = ipam_setting_config_fallback($config, $configKey);
+        if ($current === null) continue;
+
+        // Skip values that match the registry default — a config that still
+        // holds the shipped default is not "customised". Loose compares keep
+        // '0' vs 0 vs false from producing spurious banner entries.
+        $default = $def['default'] ?? null;
+        $type = is_string($def['type'] ?? null) ? $def['type'] : 'string';
+        if ($type === 'bool' && (bool)$current === (bool)$default) continue;
+        if ($type === 'int'  && is_numeric($current) && is_numeric($default) && (int)$current === (int)$default) continue;
+        if (($type === 'string' || $type === 'json') && $current === $default) continue;
+
+        if (is_array($configKey)) {
+            $segments   = [];
+            foreach ($configKey as $seg) $segments[] = to_str($seg);
+            $configPath = implode('.', $segments);
+        } else {
+            $configPath = $configKey;
+        }
+
+        $out[] = [
+            'key'         => $key,
+            'config_path' => $configPath,
+            'current'     => $current,
+        ];
+    }
+    return $out;
+}
+
+/**
  * Resolve a setting definition's `options` entry to a `[value => label]` map,
  * or null when the setting is free-form. Supports three registry shapes:
  *

--- a/Simple-PHP-IPAM/settings.php
+++ b/Simple-PHP-IPAM/settings.php
@@ -20,6 +20,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 
+    // v2.7.0 #376: "Import to database" action from the deprecation banner.
+    // Takes a single registered setting key whose value currently lives in
+    // config.php, reads that fallback value through the same helper that
+    // produced the banner, and persists it via ipam_setting_set(). On
+    // success the key stops appearing as deprecated on the next render.
+    if (to_str($_POST['action'] ?? '') === 'import_deprecated') {
+        $user   = current_user();
+        $userId = to_int($user['id'] ?? 0) ?: null;
+        $importKey = to_str($_POST['import_key'] ?? '');
+        $deprecated = ipam_setting_deprecated_keys();
+        $known = [];
+        foreach ($deprecated as $d) $known[$d['key']] = $d['current'];
+        if ($importKey === '' || !array_key_exists($importKey, $known)) {
+            flash_set('That setting is not in the deprecated list.', 'danger');
+            header('Location: settings.php');
+            exit;
+        }
+        try {
+            ipam_setting_set($db, $importKey, $known[$importKey], $userId);
+            flash_set("Imported \"{$importKey}\" into the database.");
+        } catch (\Throwable $e) {
+            error_log('settings.php import failed: ' . $e->getMessage());
+            flash_set('Import failed. Please try again.', 'danger');
+        }
+        header('Location: settings.php');
+        exit;
+    }
+
     $postedGroup = to_str($_POST['group'] ?? '');
     if ($postedGroup === '' || !isset($groups[$postedGroup])) {
         flash_set('Unknown settings group.', 'danger');
@@ -185,6 +213,58 @@ page_header('Settings');
 <?php endif; ?>
 <?php if (!empty($fieldErrors['_group'])): ?>
   <p class="danger"><?= e($fieldErrors['_group']) ?></p>
+<?php endif; ?>
+
+<?php $deprecated = ipam_setting_deprecated_keys(); if ($deprecated): ?>
+  <!--
+    #376 deprecation banner: lists every registered setting whose value is
+    still being served from config.php. Each row gets an "Import to database"
+    button that POSTs action=import_deprecated to this page; the handler
+    reads the current fallback value and persists it via ipam_setting_set().
+    The banner disappears once every customised key has been imported, or
+    once the admin edits the key through its own group form.
+  -->
+  <div class="card admin-notice admin-notice--warning" id="deprecated-banner">
+    <h2 style="margin-top:0;">⚠ config.php settings to migrate</h2>
+    <div class="muted" style="margin-bottom:.5rem;">
+      These <?= count($deprecated) ?> setting(s) are still being read from <code>config.php</code>.
+      In v3.0.0 the fallback is removed — migrate them into the database now
+      so they survive the upgrade. Import copies the current <code>config.php</code>
+      value into the <code>settings</code> table; you can then remove it from
+      <code>config.php</code> at your convenience.
+    </div>
+    <table class="table">
+      <thead>
+        <tr><th>Setting</th><th>config.php path</th><th>Current value</th><th>&nbsp;</th></tr>
+      </thead>
+      <tbody>
+      <?php foreach ($deprecated as $row): ?>
+        <?php
+        $key  = to_str($row['key']);
+        $path = to_str($row['config_path']);
+        $def  = $definitions[$key] ?? null;
+        $isSensitive = is_array($def) && !empty($def['sensitive']);
+        $display = $isSensitive
+            ? '***'
+            : (is_scalar($row['current']) ? (string)$row['current'] : json_encode($row['current']));
+        ?>
+        <tr>
+          <td><code><?= e($key) ?></code></td>
+          <td><code class="muted"><?= e($path) ?></code></td>
+          <td><?= e(is_string($display) ? $display : '') ?></td>
+          <td>
+            <form method="post" action="settings.php" style="margin:0;">
+              <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action" value="import_deprecated">
+              <input type="hidden" name="import_key" value="<?= e($key) ?>">
+              <button type="submit" class="button-secondary btn-sm">Import to database</button>
+            </form>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
 <?php endif; ?>
 
 <?php foreach ($groups as $groupKey => $groupMeta): ?>

--- a/testing/playwright/tests/settings.spec.ts
+++ b/testing/playwright/tests/settings.spec.ts
@@ -5,10 +5,41 @@
  * assertion must be self-sufficient rather than depend on a prior test.
  */
 import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { execFileSync } from 'child_process';
 import {
   login, appUrl, ADMIN_USER, ADMIN_PASS,
   newAuthContext,
 } from '../fixtures/ipam';
+
+/**
+ * Delete a settings row from the containerized test database so a known key
+ * falls back to config.php and appears in the #376 deprecation banner.
+ * Uses docker exec + php -r via execFileSync (no shell) because the
+ * container is the source of truth for test state and there is no HTTP
+ * endpoint that can surgically drop a row. A no-op (swallowed) when the
+ * container is not running so the rest of the spec still skips cleanly
+ * under dev-direct.
+ */
+function deleteSettingRowInContainer(key: string): void {
+  // Key is hardcoded in the call site below; guard anyway in case the
+  // function is reused so a stray quote can never break out of the PHP
+  // string literal.
+  if (!/^[a-z_][a-z0-9_.]*$/.test(key)) return;
+  try {
+    execFileSync(
+      'docker',
+      [
+        'exec', 'ipam-pw-test',
+        'php', '-r',
+        'require "/var/www/html/init.php"; ' +
+        '$db->prepare("DELETE FROM settings WHERE key = :k")->execute([":k" => "' + key + '"]);',
+      ],
+      { stdio: 'pipe' },
+    );
+  } catch {
+    // Swallow — the test will detect the absent banner and skip itself.
+  }
+}
 
 let ctx: BrowserContext;
 let page: Page;
@@ -120,6 +151,53 @@ test.describe('Settings page', () => {
     for (const value of ['UTC', 'America/Toronto', 'Europe/London']) {
       await expect(select.locator(`option[value="${value}"]`)).toHaveCount(1);
     }
+  });
+
+  test('#376 deprecation banner lists a customised config.php key', async () => {
+    // The v2.6.0 migration seeds every registered key into the settings
+    // table on install, so on a pristine container nothing is deprecated.
+    // Force a deprecated state by dropping a specific row so its value
+    // falls back to config.php (which is "0" / false in the test fixture
+    // but "true" in the registry default — different, so flagged).
+    deleteSettingRowInContainer('update_check.enabled');
+    await page.goto(appUrl('settings.php'));
+    const banner = page.locator('#deprecated-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner.locator('h2')).toContainText('config.php settings to migrate');
+    const row = banner.locator('tr', { hasText: 'update_check.enabled' });
+    await expect(row).toBeVisible();
+  });
+
+  test('#376 Import to database persists the value and drops the row', async () => {
+    deleteSettingRowInContainer('update_check.enabled');
+    await page.goto(appUrl('settings.php'));
+    const banner = page.locator('#deprecated-banner');
+    if (await banner.count() === 0) {
+      test.skip(true, 'could not force a deprecated state — container not running?');
+      return;
+    }
+    const row = banner.locator('tr', { hasText: 'update_check.enabled' });
+    await expect(row).toBeVisible();
+
+    await row.locator('button[type="submit"]').click();
+    await page.waitForURL(/settings\.php/);
+    await expect(page.locator('body')).toContainText('Imported');
+    const bannerAfter = page.locator('#deprecated-banner');
+    if (await bannerAfter.count() > 0) {
+      await expect(bannerAfter.locator('tr', { hasText: 'update_check.enabled' })).toHaveCount(0);
+    }
+  });
+
+  test('#376 dashboard shows a deprecation warning card for admin', async () => {
+    deleteSettingRowInContainer('update_check.enabled');
+    await page.goto(appUrl('dashboard.php'));
+    const warning = page.locator('.admin-notice--warning', { hasText: 'Settings migration needed' });
+    if (await warning.count() === 0) {
+      test.skip(true, 'could not force a deprecated state — container not running?');
+      return;
+    }
+    await expect(warning).toBeVisible();
+    await expect(warning.locator('a[href*="settings.php"]')).toHaveCount(1);
   });
 
   test('#442 out-of-set login_protection.method is rejected server-side', async () => {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -304,6 +304,72 @@ class SettingsTest extends TestCase
         $this->assertSame(['x' => 'Xray', 'y' => 'Yankee'], $callable);
     }
 
+    public function testDeprecatedKeysEmptyWhenNothingCustomised(): void
+    {
+        // v2.7.0 #376: a fresh install with empty $config and empty settings
+        // table must not light up the banner for every registered key.
+        $GLOBALS['config'] = [];
+        ipam_setting_cache_bust();
+        $this->assertSame([], ipam_setting_deprecated_keys());
+    }
+
+    public function testDeprecatedKeysSkipsDefaultValues(): void
+    {
+        // $config may carry every registered default literally (as v2.6.0
+        // ipam_config_sync() does). None of those should be flagged — only
+        // admin-customised values should.
+        $GLOBALS['config'] = [
+            'app_name'                => 'Simple PHP IPAM', // registry default
+            'alert_util_warn_pct'     => 80,                // registry default
+            'oidc'                    => ['enabled' => false],
+        ];
+        ipam_setting_cache_bust();
+        $this->assertSame([], ipam_setting_deprecated_keys());
+    }
+
+    public function testDeprecatedKeysFlagsCustomisedConfigValues(): void
+    {
+        $GLOBALS['config'] = [
+            'app_name'            => 'Acme IPAM',            // customised
+            'alert_util_warn_pct' => 70,                     // customised
+            'oidc'                => ['enabled' => true],    // customised
+        ];
+        ipam_setting_cache_bust();
+
+        $deprecated = ipam_setting_deprecated_keys();
+        $keys = array_column($deprecated, 'key');
+        $this->assertContains('branding.site_name', $keys);
+        $this->assertContains('alert.util_warn_pct', $keys);
+        $this->assertContains('oidc.enabled', $keys);
+
+        // Each row must carry the config_path and the current value so the
+        // banner can render them.
+        $row = null;
+        foreach ($deprecated as $d) {
+            if ($d['key'] === 'branding.site_name') { $row = $d; break; }
+        }
+        $this->assertNotNull($row);
+        $this->assertSame('app_name', $row['config_path']);
+        $this->assertSame('Acme IPAM', $row['current']);
+
+        // Nested config_key flattens with '.' so the banner column stays
+        // readable.
+        foreach ($deprecated as $d) {
+            if ($d['key'] === 'oidc.enabled') {
+                $this->assertSame('oidc.enabled', $d['config_path']);
+                break;
+            }
+        }
+    }
+
+    public function testDeprecatedKeysHidesRowsAlreadyInDb(): void
+    {
+        $GLOBALS['config'] = ['app_name' => 'Acme IPAM'];
+        ipam_setting_set($this->db, 'branding.site_name', 'Acme IPAM');
+        ipam_setting_cache_bust();
+        $this->assertSame([], ipam_setting_deprecated_keys());
+    }
+
     public function testCallerDefaultIgnoredForRegisteredKey(): void
     {
         // Registry default must win; caller-supplied $default only matters for


### PR DESCRIPTION
## Summary

Phase C of the v2.7.0 milestone — adds the admin-facing deprecation tooling promised in #376 so operators can find and migrate \`config.php\` keys before v3.0.0 removes the fallback.

**Branch is stacked on #444 (Phase A).** The banner reuses the restructured \`settings.php\` markup from Phase A, so rebasing it onto a bare \`dev\` would mean doing the merge twice. Merge #444 first, then this PR rebases cleanly.

## What's in the box

1. **New helper** \`ipam_setting_deprecated_keys()\` in \`lib.php\` — walks the registry and returns rows where (a) no settings-table entry exists, (b) the key's \`config_key\` resolves to a non-null \`\$config\` value, and (c) that value differs from the registry default. Fail-quiet (returns \`[]\`) on any DB error so the boot path and dashboard render never break. Bootstrap-only keys like \`db_driver\` are not in the registry so they are never flagged.

2. **Settings page banner** — renders a \`#deprecated-banner\` card above the group forms listing each deprecated key with its config path, current value, and an **Import to database** button. Sensitive keys show \`***\` in the value column. Button POSTs \`action=import_deprecated\`; the handler validates the key is in the current deprecated set before writing it via \`ipam_setting_set()\`.

3. **Boot-time log warning** — \`init.php\` emits a single consolidated \`error_log()\` line listing the deprecated keys, rate-limited to once per hour via a marker file in \`data/tmp/\`. Never crashes the request.

4. **Dashboard admin notice** — \`dashboard.php\` shows a warning card for admins when deprecated keys exist, linking to the banner in settings.php.

## Test plan

- [x] \`php -l\` on every changed PHP file
- [x] \`vendor/bin/phpstan analyse --memory-limit=1G\` — clean (4 new errors introduced mid-edit and fixed before commit)
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`vendor/bin/phpunit\` — 123/123 passing, including 4 new unit tests for the helper (empty-on-clean, skip defaults, flag customised, hide already-in-DB)
- [x] \`semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/\` — 0 findings
- [x] Containerized Playwright \`tests/settings.spec.ts\` — 11/11 passing (3 new tests force a deprecated state via \`docker exec ... php -r\`, then assert the banner renders, the Import button persists the value, and the dashboard admin notice appears)
- [x] \`tests/pages.spec.ts\` + \`tests/console-clean.spec.ts\` + \`tests/csp.spec.ts\` + \`tests/auth.spec.ts\` — 82 pass, 2 skip, no regressions

## Not in scope

- Docs + changelog + version bump + release bundle — Phase D (#377).
- Removal of the \`config.php\` fallback — v3.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)