### PR TITLE
fix(claude): v2.8.0 CodeRabbit cleanup (#452 #453 #454)

### DIFF
--- a/.claude/agents/ip-binary-auditor.md
+++ b/.claude/agents/ip-binary-auditor.md
@@ -15,9 +15,9 @@ You are the IP-binary and IP-injection auditor for Simple PHP IPAM. IP handling 
 - **Never** left-pad IPv4 to 16 bytes. If you see any code that pads, concatenates, or str_repeat's zero bytes onto an IP before storing, flag it as **Critical**.
 - Any code that decodes `ip_bin`/`network_bin` must use `inet_ntop()` and must not assume a length.
 
-### 2. `ipam_bind_binary()` for all binds *(applies from v2.9.0 — currently shipped version is v2.7.0)*
+### 2. `ipam_bind_binary()` for all binds *(applies from v2.9.0 — currently shipped version is v2.8.0)*
 
-In v2.9.0 and later, every binary-column bind must go through `ipam_bind_binary()` which uses `PDO::PARAM_LOB`. Pre-v2.9.0 the project uses `PDO::PARAM_STR` which works on SQLite but with TEXT affinity — causing `ORDER BY ip_bin` bugs. When reviewing a v2.9.0+ diff, flag any raw `$stmt->bindValue(..., $bin)` or `bindParam(..., $bin)` against a binary column that does not use the helper. For v2.7.x diffs, skip this check.
+In v2.9.0 and later, every binary-column bind must go through `ipam_bind_binary()` which uses `PDO::PARAM_LOB`. Pre-v2.9.0 the project uses `PDO::PARAM_STR` which works on SQLite but with TEXT affinity — causing `ORDER BY ip_bin` bugs. When reviewing a v2.9.0+ diff, flag any raw `$stmt->bindValue(..., $bin)` or `bindParam(..., $bin)` against a binary column that does not use the helper. For v2.8.x diffs, skip this check.
 
 ### 3. `normalize_ip()` before any shell or socket boundary
 
@@ -52,4 +52,4 @@ If the diff introduces a new binding path and there's no test covering at least 
 
 - Do not review general PHP style, formatting, or unrelated logic.
 - Do not rewrite code — report findings only.
-- Do not flag pre-v2.9.0 code for the `ipam_bind_binary()` rule (rule 2) when the currently shipped version is v2.7.x. The CLAUDE.md top banner documents which rules are current vs forward-looking.
+- Do not flag pre-v2.9.0 code for the `ipam_bind_binary()` rule (rule 2) when the currently shipped version is v2.8.x. The CLAUDE.md top banner documents which rules are current vs forward-looking.

--- a/.claude/hooks/block-sensitive-paths.sh
+++ b/.claude/hooks/block-sensitive-paths.sh
@@ -10,8 +10,21 @@ file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty')"
 
 [[ -z "$file" ]] && exit 0
 
-# Normalise to repo-relative
-rel="${file#"$PWD/"}"
+# Canonicalize both the input path and $PWD so ./ and ../ segments cannot
+# bypass the block list, and so symlinked working directories (e.g. macOS
+# OneDrive Library/CloudStorage <-> ~/OneDrive) strip cleanly. We use
+# python3 because BSD realpath on macOS lacks -m and cannot canonicalize
+# paths whose leaf does not yet exist (Edit/Write may target new files).
+rel="$(FILE="$file" python3 - <<'PY'
+import os, sys
+f = os.environ["FILE"]
+# os.path.realpath resolves symlinks; works for non-existent leaves.
+abs_file = os.path.realpath(os.path.abspath(f))
+abs_pwd  = os.path.realpath(os.path.abspath(os.getcwd()))
+prefix = abs_pwd + os.sep
+sys.stdout.write(abs_file[len(prefix):] if abs_file.startswith(prefix) else abs_file)
+PY
+)"
 
 case "$rel" in
   releases/ipam-*/ipam-*.tar.gz|releases/ipam-*/SHA256SUMS)

--- a/.claude/skills/release-gate/SKILL.md
+++ b/.claude/skills/release-gate/SKILL.md
@@ -91,9 +91,11 @@ Build:
 Stage:
 
 ```bash
-mkdir -p releases/ipam-X.Y.Z
-mv ipam-X.Y.Z/ipam-X.Y.Z.tar.gz ipam-X.Y.Z/SHA256SUMS releases/ipam-X.Y.Z/
-rmdir ipam-X.Y.Z 2>/dev/null || true
+# make_releases.sh emits artifacts directly under releases/ipam-X.Y.Z/.
+# Verify they exist and add to the git index so the release commit picks them up.
+test -f releases/ipam-X.Y.Z/ipam-X.Y.Z.tar.gz
+test -f releases/ipam-X.Y.Z/SHA256SUMS
+git add releases/ipam-X.Y.Z/ipam-X.Y.Z.tar.gz releases/ipam-X.Y.Z/SHA256SUMS
 ```
 
 Verify the tarball contents:


### PR DESCRIPTION
## Summary

Three trivial `.claude/` infrastructure fixes from the v2.8.0 CodeRabbit sweep on PR #450. All target the v2.9.0 milestone.

- **#452** — `block-sensitive-paths.sh` canonicalization bypass. The `${file#"$PWD/"}` strip only matched exact absolute prefixes, so `./Simple-PHP-IPAM/config.php`, `Simple-PHP-IPAM/data/../config.php`, and any path under a symlinked working directory slipped past every block pattern. Replaced with a `python3` canonicalizer that resolves both input and `$PWD` via `os.path.realpath` — works on macOS (BSD `realpath` has no `-m`), Linux, and CI.
- **#453** — release-gate `SKILL.md` stage step. Documented `mv ipam-X.Y.Z/...` block pointed at a non-existent repo-root dir; `make_releases.sh` writes directly under `releases/ipam-X.Y.Z/` already. Replaced with a `test -f && git add` block.
- **#454** — `ip-binary-auditor.md` baseline bump. v2.7.0 → v2.8.0 in the two shipped-version references.

## Test plan

- [x] Hook reproduction matrix passes — 11 path forms including absolute, `./`, `../` segments, symlinked OneDrive `Library/CloudStorage`, allowed files, and empty input. All expected ALLOW/BLOCK outcomes verified.
- [x] No PHP code touched, no migrations, no schema — local PHP gate not applicable.
- [ ] CI green on the PR (php-qa workflow runs unconditionally).

Closes #452, #453, #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)