### PR TITLE
feat(settings): make oidc.default_role an enumerated dropdown (#455)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -779,12 +779,16 @@ function ipam_setting_definitions(): array
         ],
         'oidc.default_role' => [
             'label'       => 'OIDC default role',
-            'description' => "Role assigned to auto-provisioned users. 'readonly' is recommended.",
+            'description' => "Role assigned to auto-provisioned users. 'Read-only' is recommended.",
             'type'        => 'string',
             'group'       => 'oidc',
             'default'     => 'readonly',
             'sensitive'   => false,
             'config_key'  => ['oidc', 'default_role'],
+            'options'     => [
+                'readonly' => 'Read-only',
+                'admin'    => 'Administrator',
+            ],
         ],
         'oidc.disable_local_login' => [
             'label'       => 'Disable local password login',


### PR DESCRIPTION
## Summary

Adds an `options` key to the `oidc.default_role` settings registry entry so admins pick from a real dropdown {Read-only, Administrator} on **⚙ Admin → Settings** instead of typing a free-form string. A typo previously broke OIDC auto-provisioning silently.

## Why one-line

The settings renderer already handles `string + options` as a `<select>` (`settings.php:477`) and the two-phase POST handler already rejects out-of-set values via `array_key_exists` against the options map (`settings.php:174`). The registry entry is the only change required — no renderer or validator edits.

## Test plan

- [x] PHPUnit (Util) — green
- [x] PHPCS lib.php — clean
- [x] php -l lib.php — clean
- [x] Project semgrep rules — 0 findings
- [ ] Manual: open Settings page, confirm `oidc.default_role` renders as a `<select>` with two options, save with each value, confirm round-trip

Closes #455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)