### PR TITLE
feat(release): Composer runtime-dep infrastructure (#416)

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -20,8 +20,16 @@ jobs:
           extensions: pdo_sqlite, mbstring, openssl
           coverage: none
 
+      - name: Validate composer.json
+        run: composer validate --strict
+
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer audit (security advisories)
+        # #416: fail the build on any known CVE in a runtime or dev dep.
+        # Runs after install so the lock file's resolved versions are checked.
+        run: composer audit --no-dev --locked
 
       - name: PHP Lint
         run: find Simple-PHP-IPAM -name '*.php' -not -path '*/data/*' | sort | xargs -n1 php -l

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -4,6 +4,15 @@ declare(strict_types=1);
 /** @var IpamConfig $config */
 $config = require __DIR__ . '/config.php';
 
+// Composer autoloader (#416). Conditional because v2.9.0 ships with an empty
+// require {} — vendor/autoload.php only exists in release tarballs (built by
+// releases/make_releases.sh) and in dev environments where the tester has run
+// `composer install`. A fresh git clone without composer install must still
+// boot, so we skip silently if the file is absent.
+if (is_file(__DIR__ . '/vendor/autoload.php')) {
+    require_once __DIR__ . '/vendor/autoload.php';
+}
+
 // Seed a UTC default so any pre-DB date/time operations (HTTPS redirect, session
 // setup) are deterministic. The real timezone is applied from the DB settings
 // (branding.timezone) once $db is open and lib.php is loaded — see below.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,13 @@
 {
     "name": "seanmousseau/simple-php-ipam",
     "description": "Simple PHP IPAM — lightweight IPv4/IPv6 address management",
+    "type": "project",
+    "license": "MIT",
+    "prefer-stable": true,
+    "minimum-stability": "stable",
+    "require": {
+        "php": ">=8.2"
+    },
     "require-dev": {
         "phpstan/phpstan": "^2.0",
         "squizlabs/php_codesniffer": "^4.0",
@@ -10,6 +17,9 @@
         "platform": {
             "php": "8.2"
         },
+        "platform-check": true,
+        "optimize-autoloader": true,
+        "sort-packages": true,
         "allow-plugins": {}
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd695318ec83f17f6bdb9657d97db659",
+    "content-hash": "2ff30b50af7c7dc3d165f652606ab64e",
     "packages": [],
     "packages-dev": [
         {
@@ -1924,9 +1924,11 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.2"
+    },
     "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,8 @@ git clone https://github.com/seanmousseau/Simple-PHP-IPAM.git /var/www/ipam
 
 The application files live inside the `Simple-PHP-IPAM/` subdirectory of the repo. Point your web server document root at that directory.
 
+> **About `vendor/` (v2.9.0+).** Starting in v2.9.0, release tarballs bundle a small set of pre-built PHP libraries under `Simple-PHP-IPAM/vendor/`. You do **not** need Composer on the target server — the libraries are pre-packaged. Do not edit anything inside `vendor/`; it will be overwritten on the next upgrade. The bundled `vendor/.htaccess` denies direct HTTP access to library source.
+
 ---
 
 ## Step 2 — Set file permissions

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -89,6 +89,23 @@ The backup is left in place after a successful upgrade. You can remove it manual
 
 ## Version-specific upgrade notes
 
+### v2.9.0
+
+**New `vendor/` directory in the release tarball.** Starting in v2.9.0, the release bundle includes `Simple-PHP-IPAM/vendor/` with a pre-built Composer autoloader. You do **not** need Composer on the target server — `upgrade.sh` handles `vendor/` like every other file in the tree (rsync overwrites it on each upgrade).
+
+If you have customised anything inside `vendor/` on the server, those changes will be lost on upgrade. Don't do that — keep all customisation outside `vendor/`.
+
+The bundled `vendor/.htaccess` denies direct HTTP access to library source. Verify after upgrade with:
+
+```bash
+curl -sI https://your-host/path/to/ipam/vendor/autoload.php | head -1
+# Expected: HTTP/1.1 403 Forbidden (or 404 if your server hides denied paths)
+```
+
+**No schema changes that require manual action.** v2.9.0 includes a one-shot internal migration that normalises `ip_bin` / `network_bin` storage to BLOB affinity on SQLite. `upgrade.sh` runs `migrate.php` automatically, so no operator action is required. The migration is idempotent — re-running it is a no-op.
+
+---
+
 ### v2.7.0
 
 **No schema changes.** v2.7.0 is entirely a runtime rewire — every registered setting was already seeded into the `settings` table by v2.6.0's migration. `upgrade.sh` just syncs files, runs `php migrate.php` (no-op), and you are done.

--- a/releases/make_releases.sh
+++ b/releases/make_releases.sh
@@ -54,6 +54,10 @@ VERSION="${2:-}"
 [[ -n "$RELEASE_DIR" && -n "$VERSION" ]] || { usage; exit 2; }
 RELEASE_DIR="$(cd "$RELEASE_DIR" && pwd)" || { echo "Bad release dir" >&2; exit 2; }
 
+# Repo root is the parent of $RELEASE_DIR (which is .../Simple-PHP-IPAM/).
+# composer.json + composer.lock live at the repo root.
+REPO_ROOT="$(dirname "$RELEASE_DIR")"
+
 need() { command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }; }
 
 need rsync
@@ -65,6 +69,7 @@ need sed
 need head
 need mkdir
 need mv
+need composer
 
 # --- tar selection (macOS prefers gtar) ---
 OS="$(uname -s)"
@@ -98,7 +103,9 @@ PAYLOAD="$STAGE/$TOPDIR"
 
 mkdir -p "$PAYLOAD"
 
-# Copy release tree into staging payload
+# Copy release tree into staging payload. Exclude vendor/ from the source
+# rsync — we install production deps into the payload separately below so
+# the developer's local vendor/ (which has dev deps) is never bundled.
 rsync -a \
   --exclude '*.sqlite' --exclude '*.db' \
   --exclude 'data/ipam.sqlite' --exclude 'data/ipam.sqlite-wal' --exclude 'data/ipam.sqlite-shm' \
@@ -107,8 +114,50 @@ rsync -a \
   --exclude 'data/cron.lock' --exclude 'data/backups/' \
   --exclude 'data/.db_initialized' \
   --exclude 'data/tmp/*' \
+  --exclude 'vendor/' \
   --exclude '.git/' --exclude '.github/' --exclude '.DS_Store' \
   "$RELEASE_DIR/" "$PAYLOAD/"
+
+# --- Composer production install (#416) ---
+# Build vendor/ in a scratch directory using composer.json + composer.lock
+# from the repo root so the bundle gets a clean prod-only autoloader without
+# touching the developer's repo-root vendor/ (which has dev deps).
+if [[ -f "$REPO_ROOT/composer.json" ]]; then
+  COMPOSER_TMP="$TMP/composer-prod"
+  mkdir -p "$COMPOSER_TMP"
+  cp "$REPO_ROOT/composer.json" "$COMPOSER_TMP/composer.json"
+  if [[ -f "$REPO_ROOT/composer.lock" ]]; then
+    cp "$REPO_ROOT/composer.lock" "$COMPOSER_TMP/composer.lock"
+  fi
+  (
+    cd "$COMPOSER_TMP"
+    COMPOSER_ALLOW_SUPERUSER=1 composer install \
+      --no-dev \
+      --optimize-autoloader \
+      --no-interaction \
+      --no-progress \
+      --no-scripts \
+      --prefer-dist
+  )
+  if [[ -d "$COMPOSER_TMP/vendor" ]]; then
+    mkdir -p "$PAYLOAD/vendor"
+    rsync -a "$COMPOSER_TMP/vendor/" "$PAYLOAD/vendor/"
+    # Belt-and-suspenders: deny direct HTTP access to bundled library source.
+    cat > "$PAYLOAD/vendor/.htaccess" <<'HTACCESS'
+# Deny all direct web access to bundled Composer libraries.
+# The application autoloads them via vendor/autoload.php; nothing here
+# should be reachable as a URL.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+  Order allow,deny
+  Deny from all
+</IfModule>
+HTACCESS
+    chmod 0644 "$PAYLOAD/vendor/.htaccess"
+  fi
+fi
 
 # --- Permission sanitization ---
 find "$PAYLOAD" -type d -exec chmod 0755 {} \;


### PR DESCRIPTION
## Summary

Lays the v2.9.0 scaffolding for shipping curated runtime dependencies via Composer **without changing the end-user deployment story**. v2.9.0 itself ships with an empty `require` block — only the autoloader infrastructure is bundled. The first actual dep lands in v3.2.0 (#415, PHPMailer for SMTP).

End users still extract a tarball and run. No `composer install` on the target server. No network access to packagist required at install time.

## Changes

- **`composer.json`** — `require: { "php": ">=8.2" }`, `prefer-stable: true`, `minimum-stability: stable`, `config.platform-check: true`, plus `type`, `license`, `sort-packages`. Lock file refreshed.
- **`releases/make_releases.sh`** — installs production deps into a scratch tmp dir (`composer install --no-dev --optimize-autoloader --no-scripts`) and rsyncs the resulting `vendor/` into the staging payload. The dev's repo-root vendor/ is never touched. Bundles a `vendor/.htaccess` denying direct HTTP access (Apache 2.4 + 2.2 syntax). Source rsync now excludes `vendor/` so the dev tree's vendor never leaks.
- **`Simple-PHP-IPAM/init.php`** — conditional `require_once vendor/autoload.php` after `$config`, before `lib.php`. The `is_file` check means fresh git clones without `composer install` still boot.
- **`.github/workflows/php-qa.yml`** — `composer validate --strict` and `composer audit --no-dev --locked` steps. (#411 will later move these into the Tier 1 matrix.)
- **`docs/install.md`** — note about bundled vendor/.
- **`docs/upgrading.md`** — new v2.9.0 section explaining vendor/ and the upcoming BLOB-affinity migration from #410.

## Test plan

- [x] Bundle smoke test: `OUT_DIR=/tmp ./releases/make_releases.sh Simple-PHP-IPAM 2.9.0-test` builds successfully.
- [x] Bundle inspection: `vendor/autoload.php` present, `vendor/.htaccess` present (`-rw-r--r--`), `upgrade.sh` is `-rwxr-xr-x`, ownership root:root, no `data/ipam.sqlite`.
- [x] Extracted bundle: `php -r 'require "vendor/autoload.php"; echo "OK\n";'` works.
- [x] `composer validate --strict` clean.
- [x] `composer audit --no-dev --locked` clean (0 advisories).
- [x] Full PHPUnit (126/126), PHPStan level 9 (no errors), PHPCS, Semgrep all green.
- [ ] CI green on the PR (will exercise the new `composer audit` step against ubuntu-latest).

Refs #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)