### PR TITLE
ci: restructure PHP QA into Tier 1 with engine matrix (#411)

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -1,14 +1,47 @@
 name: PHP QA
 
+# ---------------------------------------------------------------------------
+# Tier 1 — fast per-commit CI (#411).
+#
+# Runs on every push to dev/main and every PR targeting dev or main. Target
+# wall clock: 5–8 minutes. Blocks merge.
+#
+# Engine matrix: SQLite only in v2.9.0. Placeholder comments mark where the
+# MySQL slot lands in v2.10.0 (#384) and the Postgres slot lands in v2.11.0
+# (#388). `fail-fast: false` means one engine's failure does not cancel the
+# others' runs — we want to see all engine failures at once.
+#
+# Tier 2 (path-filtered migration round-trip tests) and Tier 3 (nightly,
+# informational) live in their own workflow files. See docs/ci.md.
+# ---------------------------------------------------------------------------
+
 on:
   push:
     branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
+
+# Cancel in-progress runs for the same ref when a new commit lands. Saves
+# minutes on busy PRs without hiding the latest result.
+concurrency:
+  group: php-qa-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   qa:
+    name: PHP QA (${{ matrix.engine }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        engine: [sqlite]
+        # v2.10.0 (#384) appends 'mysql'
+        # v2.11.0 (#388) appends 'pgsql'
+
+    env:
+      IPAM_DB_DRIVER: ${{ matrix.engine }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -19,6 +52,22 @@ jobs:
           php-version: '8.2'
           extensions: pdo_sqlite, mbstring, openssl
           coverage: none
+
+      # ----- Composer cache (#411) -----
+      # Keyed on composer.lock so a no-dep PR doesn't bust the cache. Saves
+      # ~20–30s per job and compounds across matrix slots once MySQL and
+      # Postgres land.
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.2-composer-
 
       - name: Validate composer.json
         run: composer validate --strict
@@ -35,10 +84,14 @@ jobs:
         run: find Simple-PHP-IPAM -name '*.php' -not -path '*/data/*' | sort | xargs -n1 php -l
 
       - name: PHPStan
-        run: vendor/bin/phpstan analyse --no-progress
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
 
       - name: PHPCS
         run: vendor/bin/phpcs
 
       - name: PHPUnit
         run: vendor/bin/phpunit
+
+      # SchemaParityTest lands in v2.10.0 (#409) once the MySQL schema file
+      # exists. It will run inside this matrix slot and assert that every
+      # engine's schema file produces structurally equivalent tables.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,87 @@
+# CI tiers
+
+Simple PHP IPAM organizes its CI into three tiers. The structure exists so v2.10.0 (MySQL) and v2.11.0 (Postgres) have a predictable home, and so heavier round-trip migration tests do not bloat per-commit checks.
+
+## Tier 1 — fast per-commit (blocking)
+
+**Workflow:** `.github/workflows/php-qa.yml`
+
+**Trigger:** every push to `dev`/`main`, every PR targeting `dev`/`main`.
+
+**Target wall clock:** 5–8 minutes.
+
+**What runs:**
+
+- `composer validate --strict`
+- `composer install` (with cached download dir)
+- `composer audit --no-dev --locked` (fails on any CVE in a runtime dep)
+- `php -l` on every PHP file under `Simple-PHP-IPAM/`
+- `vendor/bin/phpstan analyse` (level 9)
+- `vendor/bin/phpcs`
+- `vendor/bin/phpunit`
+
+**Engine matrix:**
+
+| Engine | Version added |
+|---|---|
+| `sqlite` | shipped — v2.9.0 |
+| `mysql` | placeholder — v2.10.0 (#384) |
+| `pgsql` | placeholder — v2.11.0 (#388) |
+
+The matrix uses `fail-fast: false` so one engine's failure does not cancel the others' runs. Each engine slot reports independently in the GitHub UI.
+
+**Caching:** Composer's package cache is keyed on `composer.lock`. A no-dep PR reuses the prior cache entirely; a dep update pays one cold install and warms the cache for the next run.
+
+**Concurrency:** in-progress runs for the same `ref` are cancelled when a new commit lands. Saves CI minutes on busy PRs without hiding the latest result.
+
+## Tier 2 — path-filtered per-commit (blocking when applicable)
+
+**Workflow:** does not exist yet — lands in v3.0.0 alongside `migrate_db.php` (#391).
+
+**Trigger:** PRs that touch `migrate_db.php`, `dialects/`, `schema*.sql`, `migrations.php`, or `testing/samples/large-db-sample/`.
+
+**What will run:**
+
+- `migrate_db.php` 6-direction round-trip tests (SQLite ↔ MySQL ↔ Postgres × both directions)
+- `MigrationTest` convergence: replay every migration on an empty DB and assert it matches `schema.X.sql`
+
+**Why path-filtered, not nightly-only:** catches regressions on the PR that caused them. Unrelated PRs are not taxed with 5–10 minutes of I/O-heavy test work.
+
+## Tier 3 — nightly on `main` (informational)
+
+**Workflow:** `.github/workflows/playwright-nightly.yml` (existing) + future `nightly.yml`
+
+**Trigger:** `schedule:` cron at 07:00 UTC daily. Also fires on PRs that touch `Simple-PHP-IPAM/**` or `testing/playwright/**` (the playwright job's own path filter — separate from Tier 1).
+
+**What runs:**
+
+- Containerized Playwright suite against `testing/playwright/Dockerfile.apache`
+- `htaccess-subset` (HTTP-level deny rule verification)
+- `api-tests` (#451 — wired in v2.9.0; runs `testing/scripts/test_api.sh` against the bootstrapped image)
+- `composer outdated --direct` (informational, never blocks)
+
+**Failure handling:** GitHub notification on red. No PR blocking. First task next morning is to investigate.
+
+## Tier 4 — on-demand (manual)
+
+Things that still require a real shared deployment and cannot easily containerize. Not in CI.
+
+- Real-IdP OIDC flows (the bundled mock OIDC fixture covers code paths but not vendor-specific quirks)
+- `timezone.spec.ts` (SSHes to patch remote config)
+- Stress tests against a live MySQL/Postgres install
+- Reverse-proxy CSP testing through dev-direct
+
+These run from a developer machine following `CLAUDE.md` → "Manual against dev-direct". They are not automated and no plans exist to automate them further.
+
+## How to add a new check
+
+- **Always-on, fast:** add it to the `qa` job in `php-qa.yml`. Keep wall clock under 8 minutes per matrix slot.
+- **Engine-specific:** add it to the same job — it inherits the matrix automatically and reports per engine.
+- **Slow but conditional:** wait for Tier 2 (v3.0.0) and add path filters.
+- **Best-effort overnight:** add it to the nightly workflow and document the cron in this file.
+
+## How to debug a failing matrix slot
+
+The matrix's job name is `PHP QA (sqlite)` (or `(mysql)` / `(pgsql)` once those land). In the GitHub Actions UI, expand the matching slot to see the failing step. The first failure is almost always the right place to look — composer install / autoload errors cascade, but PHPStan / PHPCS / PHPUnit failures are independent.
+
+If only one engine is red and the others are green, the bug is engine-specific — usually a SQL literal that differs across engines (something the v2.9.0 dialect refactor is supposed to prevent).


### PR DESCRIPTION
## Summary

Lays the v2.9.0 CI tier structure so MySQL (v2.10.0 #384) and Postgres (v2.11.0 #388) slot in cleanly when they land. Documented in `docs/ci.md`.

> ⚠️ **Stacked PR.** Base is `feat/v2.9.0-composer-infrastructure` (PR #471), not `dev`. Merge #471 first, then re-target this PR to `dev` and merge.

## Changes

- **`.github/workflows/php-qa.yml`**:
  - Now runs on PRs to `dev` *and* `main` (previously only `main`, which meant feature branches into dev had **zero** PHP QA coverage — caught while reviewing recent PR runs).
  - Job becomes a `fail-fast: false` matrix with a single `sqlite` engine. The matrix is the seam where v2.10.0 will append `mysql` and v2.11.0 will append `pgsql`.
  - Composer cache via `actions/cache@v4` keyed on `composer.lock` for ~20–30s savings per slot.
  - `concurrency: cancel-in-progress` on the workflow ref so busy PRs do not stack runs.
  - PHPStan gets `--memory-limit=1G` (the project's documented setting; the default 128M crashes parallel workers).

- **`docs/ci.md`** — new file documenting all four tiers:
  - Tier 1: fast per-commit blocking (this workflow)
  - Tier 2: path-filtered round-trip tests (v3.0.0 placeholder)
  - Tier 3: nightly Playwright + composer outdated (existing `playwright-nightly.yml`)
  - Tier 4: manual dev-direct flows
  - Plus debugging guide for failing matrix slots.

## What's intentionally **not** in this PR

- MySQL / Postgres matrix slots — those are #384 / #388.
- `SchemaParityTest` — that is #409 in v2.10.0.
- `composer outdated` nightly step — that lands when the nightly workflow is restructured.
- `test_api.sh` integration — that is #451 (separate Wave 1 PR).

## Test plan

- [x] YAML structure sanity check (required keys, line count).
- [x] Composer cache key references `composer.lock` (lock file is committed).
- [ ] CI green when merged — the workflow runs against itself, so the first run on this PR is the proof.

Refs #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)