### PR TITLE
feat(db): refactor lib.php SQL + binary binds through dialect (#379)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
  * Returns the active SQL dialect (#378). init.php instantiates this once per
  * request and stows it under $GLOBALS['ipam_dialect']. v2.9.0 always returns
  * a SqliteDialect; v2.10.0+ may return Mysql/Pgsql variants based on
- * $config['db_driver']. Tests that need to bypass init.php can set the
- * global directly.
- *
- * Throws a RuntimeException only if init.php was skipped — every page entry
- * point loads init.php which guarantees the global is populated.
+ * $config['db_driver']. Tests and CLI scripts that bootstrap lib.php
+ * directly (without init.php) get a SqliteDialect lazily — this is the
+ * v2.9.0 default and matches the only driver shipped this release.
  */
 function ipam_dialect(): Dialect
 {
     if (!isset($GLOBALS['ipam_dialect']) || !($GLOBALS['ipam_dialect'] instanceof Dialect)) {
-        throw new RuntimeException('ipam_dialect() called before init.php loaded the dialect — did you bypass init.php?');
+        require_once __DIR__ . '/dialects/Dialect.php';
+        require_once __DIR__ . '/dialects/SqliteDialect.php';
+        $GLOBALS['ipam_dialect'] = new SqliteDialect();
     }
     return $GLOBALS['ipam_dialect'];
 }
@@ -48,7 +48,10 @@ function ipam_dialect(): Dialect
  *   inet_pton('2001:db8::')       = \x20\x01\x0D\xB8...  (mostly null bytes)
  *   inet_pton('255.255.255.255')  = \xFF\xFF\xFF\xFF  (all high bytes)
  */
-function ipam_bind_binary(PDOStatement $stmt, string $param, string $bin): void
+/**
+ * @param int|string $param 1-based positional index, or ':name' for a named placeholder.
+ */
+function ipam_bind_binary(PDOStatement $stmt, int|string $param, string $bin): void
 {
     $stmt->bindValue($param, $bin, PDO::PARAM_LOB);
 }
@@ -1048,14 +1051,15 @@ function ipam_setting_set(PDO $db, string $key, mixed $value, ?int $userId = nul
         $oldType = is_string($prev['type'] ?? null) && $prev['type'] !== '' ? $prev['type'] : $type;
     }
 
+    // #379: route through the dialect so v2.10.0 / v2.11.0 swap upsert and
+    // timestamp idioms without touching this call site. The dialect's
+    // upsert() returns the ON CONFLICT...DO UPDATE fragment for the engine.
+    $d = ipam_dialect();
+    $upsertClause = $d->upsert('settings', ['key'], ['value', 'type', 'updated_at', 'updated_by']);
     $up = $db->prepare(
         "INSERT INTO settings (key, value, type, updated_at, updated_by)
-         VALUES (:k, :v, :t, datetime('now'), :u)
-         ON CONFLICT(key) DO UPDATE SET
-             value = excluded.value,
-             type = excluded.type,
-             updated_at = datetime('now'),
-             updated_by = excluded.updated_by"
+         VALUES (:k, :v, :t, {$d->now()}, :u)
+         $upsertClause"
     );
     $up->execute([
         ':k' => $key,
@@ -1921,10 +1925,14 @@ function check_utilization_alerts(PDO $db, array $config): void
             }
 
             $now = date('Y-m-d H:i:s');
+            // #379: route through the dialect's upsert() so v2.10.0+ can
+            // swap to ON DUPLICATE KEY UPDATE / ON CONFLICT DO UPDATE
+            // without touching this call site.
+            $alertUpsert = ipam_dialect()->upsert('alert_state', ['subnet_id', 'level'], ['last_alerted_at']);
             $db->prepare(
                 "INSERT INTO alert_state (subnet_id, level, last_alerted_at)
                  VALUES (:sid, :lvl, :now)
-                 ON CONFLICT(subnet_id, level) DO UPDATE SET last_alerted_at = excluded.last_alerted_at"
+                 $alertUpsert"
             )->execute([':sid' => $sid, ':lvl' => $lvl, ':now' => $now]);
             $alertState[$sid][$lvl] = $now;
         }
@@ -2619,15 +2627,26 @@ function auto_reserve_subnet_ips(PDO $db, int $subnetId, string $cidr, ?string $
     $p = parse_cidr($cidr);
     if (!$p) return;
 
+    // #379/#410: bind ip_bin via ipam_bind_binary() (PARAM_LOB) so the stored
+    // affinity is BLOB on SQLite and bytes round-trip safely on MySQL/Postgres.
+    // The scalar params still come through bindValue so we can mix the two
+    // binding styles on a single statement.
     $ins = $db->prepare(
         "INSERT OR IGNORE INTO addresses (subnet_id, ip, ip_bin, hostname, status, owner, note, grp, mac)
          VALUES (:sid, :ip, :ipbin, :host, 'reserved', '', 'Auto-reserved', '', '')"
     );
+    $reserveBind = function (int $sid, string $ip, string $bin, string $host) use ($ins): void {
+        $ins->bindValue(':sid',  $sid,  PDO::PARAM_INT);
+        $ins->bindValue(':ip',   $ip,   PDO::PARAM_STR);
+        ipam_bind_binary($ins, ':ipbin', $bin);
+        $ins->bindValue(':host', $host, PDO::PARAM_STR);
+        $ins->execute();
+    };
 
     // Network address
     $netIp  = $p['network'];
     $netBin = $p['net_bin'];
-    $ins->execute([':sid' => $subnetId, ':ip' => $netIp, ':ipbin' => $netBin, ':host' => 'network']);
+    $reserveBind($subnetId, $netIp, $netBin, 'network');
     if ($db->lastInsertId()) {
         audit($db, 'address.create', 'address', (int)$db->lastInsertId(), "auto-reserve network $netIp in subnet $subnetId");
     }
@@ -2640,7 +2659,7 @@ function auto_reserve_subnet_ips(PDO $db, int $subnetId, string $cidr, ?string $
         if ($bcastBin !== null) {
             $bcastIp = inet_ntop($bcastBin) ?: '';
             if ($bcastIp !== '' && $bcastIp !== $netIp) {
-                $ins->execute([':sid' => $subnetId, ':ip' => $bcastIp, ':ipbin' => $bcastBin, ':host' => 'broadcast']);
+                $reserveBind($subnetId, $bcastIp, $bcastBin, 'broadcast');
                 if ($db->lastInsertId()) {
                     audit($db, 'address.create', 'address', (int)$db->lastInsertId(), "auto-reserve broadcast $bcastIp in subnet $subnetId");
                 }
@@ -2652,7 +2671,7 @@ function auto_reserve_subnet_ips(PDO $db, int $subnetId, string $cidr, ?string $
     if ($gateway !== null && $gateway !== '') {
         $gwNorm = normalize_ip($gateway);
         if ($gwNorm && ip_in_cidr($gwNorm['ip'], $p['network'], $p['prefix'])) {
-            $ins->execute([':sid' => $subnetId, ':ip' => $gwNorm['ip'], ':ipbin' => $gwNorm['bin'], ':host' => 'gateway']);
+            $reserveBind($subnetId, $gwNorm['ip'], $gwNorm['bin'], 'gateway');
             if ($db->lastInsertId()) {
                 audit($db, 'address.create', 'address', (int)$db->lastInsertId(), "auto-reserve gateway {$gwNorm['ip']} in subnet $subnetId");
             }
@@ -2906,6 +2925,23 @@ function demo_seed_data(PDO $db): void
         [4, 'Monitored',   '#6c757d'],
         ] as $t) $tg->execute($t);
 
+    // #379/#410: helper that binds the ten subnet columns onto a prepared
+    // INSERT, routing network_bin through ipam_bind_binary() (PARAM_LOB) so
+    // every demo-seeded row is BLOB-affinity from the start. Positional ? in
+    // the prepare maps to 1-based bindValue indexes.
+    $bindSubnetRow = function (PDOStatement $stmt, int $id, string $cidr, string $netNorm, string $netBin, int $pfx, string $desc, ?int $siteId, ?int $vlanFk, ?int $vrfId): void {
+        $stmt->bindValue(1,  $id,      PDO::PARAM_INT);
+        $stmt->bindValue(2,  $cidr,    PDO::PARAM_STR);
+        $stmt->bindValue(3,  $netNorm, PDO::PARAM_STR);
+        ipam_bind_binary($stmt, 4, $netBin);
+        $stmt->bindValue(5,  $pfx,     PDO::PARAM_INT);
+        $stmt->bindValue(6,  $desc,    PDO::PARAM_STR);
+        $stmt->bindValue(7,  $siteId,  $siteId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->bindValue(8,  $vlanFk,  $vlanFk === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->bindValue(9,  $vrfId,   $vrfId  === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $stmt->execute();
+    };
+
     // --- Subnets (IPv4) ---
     // [id, cidr, site_id, vlan_fk, vrf_id, description]
     $sn = $db->prepare(
@@ -2928,7 +2964,7 @@ function demo_seed_data(PDO $db): void
         $rawBin  = inet_pton($net) ?: throw new \RuntimeException("Invalid IP: $net");
         $netNorm = inet_ntop(apply_prefix_mask($rawBin, (int)$pfx)) ?: throw new \RuntimeException("inet_ntop failed");
         $netBin  = inet_pton($netNorm) ?: throw new \RuntimeException("inet_pton failed on $netNorm");
-        $sn->execute([$id, $cidr, $netNorm, $netBin, (int)$pfx, $desc, $siteId, $vlanFk, $vrfId]);
+        $bindSubnetRow($sn, $id, $cidr, $netNorm, $netBin, (int)$pfx, $desc, $siteId, $vlanFk, $vrfId);
     }
 
     // --- Subnets (IPv6) ---
@@ -2945,7 +2981,7 @@ function demo_seed_data(PDO $db): void
         $rawBin6  = inet_pton($net) ?: throw new \RuntimeException("Invalid IP: $net");
         $netNorm6 = inet_ntop(apply_prefix_mask($rawBin6, (int)$pfx)) ?: throw new \RuntimeException("inet_ntop failed");
         $netBin6  = inet_pton($netNorm6) ?: throw new \RuntimeException("inet_pton failed on $netNorm6");
-        $sn6->execute([$id, $cidr, $netNorm6, $netBin6, (int)$pfx, $desc, $siteId, $vlanFk, $vrfId]);
+        $bindSubnetRow($sn6, $id, $cidr, $netNorm6, $netBin6, (int)$pfx, $desc, $siteId, $vlanFk, $vrfId);
     }
 
     // --- Subnet tags ---
@@ -3038,7 +3074,22 @@ function demo_seed_data(PDO $db): void
         [10, '172.16.1.100','',             '',          'free',     '',                        '',                  null,         null],
         ] as [$sid, $ip, $hn, $ow, $st, $nt, $mac, $exp, $cid]) {
         $bin = inet_pton($ip);
-        $ai->execute([$sid, $ip, $bin, $hn, $ow, $st, $nt, $mac, $exp, $cid]);
+        if ($bin === false) throw new \RuntimeException("inet_pton failed on $ip");
+        // #379/#410: bind ip_bin via ipam_bind_binary() (PARAM_LOB) so demo
+        // seed rows are BLOB affinity from the start. Other params use
+        // bindValue with explicit PARAM_* so the prepare's positional ?
+        // placeholders bind cleanly (no execute(array) shorthand).
+        $ai->bindValue(1,  $sid, PDO::PARAM_INT);
+        $ai->bindValue(2,  $ip,  PDO::PARAM_STR);
+        ipam_bind_binary($ai, 3, $bin);
+        $ai->bindValue(4,  $hn,  PDO::PARAM_STR);
+        $ai->bindValue(5,  $ow,  PDO::PARAM_STR);
+        $ai->bindValue(6,  $st,  PDO::PARAM_STR);
+        $ai->bindValue(7,  $nt,  PDO::PARAM_STR);
+        $ai->bindValue(8,  $mac, PDO::PARAM_STR);
+        $ai->bindValue(9,  $exp, $exp === null ? PDO::PARAM_NULL : PDO::PARAM_STR);
+        $ai->bindValue(10, $cid, $cid === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+        $ai->execute();
     }
 
     // --- Address tags ---
@@ -3573,16 +3624,16 @@ function ensure_subnet_exists(PDO $db, string $cidr, string $description = ''): 
     $row = $st->fetch();
     if ($row) return to_int($row['id']);
 
+    // #379/#410: bind network_bin via ipam_bind_binary() (PARAM_LOB).
     $ins = $db->prepare("INSERT INTO subnets (cidr, ip_version, network, network_bin, prefix, description)
                          VALUES (:cidr,:ver,:net,:nb,:pre,:d)");
-    $ins->execute([
-        ':cidr' => $normalized,
-        ':ver' => $p['version'],
-        ':net' => $p['network'],
-        ':nb' => $p['net_bin'],
-        ':pre' => $p['prefix'],
-        ':d' => $description,
-    ]);
+    $ins->bindValue(':cidr', $normalized,    PDO::PARAM_STR);
+    $ins->bindValue(':ver',  $p['version'],  PDO::PARAM_INT);
+    $ins->bindValue(':net',  $p['network'],  PDO::PARAM_STR);
+    ipam_bind_binary($ins, ':nb', $p['net_bin']);
+    $ins->bindValue(':pre',  $p['prefix'],   PDO::PARAM_INT);
+    $ins->bindValue(':d',    $description,   PDO::PARAM_STR);
+    $ins->execute();
 
     return (int)$db->lastInsertId();
 }


### PR DESCRIPTION
## Summary

Routes every binary IP write site in `lib.php` through `ipam_bind_binary()` (introduced in #410) and routes the two `ON CONFLICT` call sites through the new Dialect abstraction (#378). After this PR every new `subnets.network_bin` and `addresses.ip_bin` row written from `lib.php` has BLOB affinity on SQLite.

> ⚠️ **Stacked PR.** Base is `feat/v2.9.0-blob-affinity-migration` (PR #475), which is itself stacked on `feat/v2.9.0-dialect-scaffolding` (PR #474).
>
> ⚠️ **Hard sequencing:** #474 → #475 → this PR. Merging in any other order breaks SQLite.

## Bind sites refactored

- **`auto_reserve_subnet_ips()`** — production path on every subnet creation. The 3 `INSERT OR IGNORE` calls (network address, IPv4 broadcast, gateway) now go through a local `$reserveBind` closure that binds `:ipbin` via `ipam_bind_binary()`.
- **`ipam_ensure_subnet()`** — auto-create path used by CSV import and API subnet auto-create. Now binds `network_bin` via the helper.
- **`demo_seed_data()`** — called from `demo_seed.php`. The IPv4 subnet inserter, IPv6 subnet inserter, and addresses inserter all bind their respective binary columns via the helper. A local `$bindSubnetRow` closure deduplicates the IPv4/IPv6 logic.

## Dialect call sites

- **`ipam_set_setting()`** — replaces literal `ON CONFLICT(key) DO UPDATE` with `$d->upsert('settings', ['key'], [...])` and `datetime('now')` with `$d->now()`.
- **`check_utilization_alerts()`** — replaces literal `ON CONFLICT(subnet_id, level) DO UPDATE` with `$d->upsert('alert_state', ['subnet_id', 'level'], ['last_alerted_at'])`.

## Other changes

- **`ipam_dialect()` is now lazy** — defaults to `SqliteDialect` when no global is set, so CLI scripts that bypass `init.php` (cron, demo_seed, tests/bootstrap.php) work without explicit setup.
- **`ipam_bind_binary` accepts `int|string`** for positional placeholders alongside named ones.

## What's deferred to a follow-up

`PRAGMA foreign_keys` literals (lib.php:71, 1378, 1383, 1401, 1408, 2176, 2247) and `AUTOINCREMENT`/`datetime('now')` in `ensure_audit_log_table()`/`ensure_migrations_table()`/CREATE TABLE statements. These are deeper bootstrap paths; refactoring them is separable and does not affect the data-integrity goal.

## Test plan

- [x] **PHPUnit 152/152** (no test changes — pure refactor)
- [x] PHPStan level 9 clean
- [x] PHPCS clean
- [x] Semgrep clean
- [x] **Live containerized bootstrap**: `subnets BLOB=13 / addresses BLOB=54` on a fresh `bash testing/playwright/bootstrap-app.sh sqlite` (previously TEXT=13/TEXT=54), proving `demo_seed.php` now writes BLOB from the start.
- [x] **`ORDER BY ip_bin` smoke**: returns the correct numeric sequence `10.10.2.1 → 10.10.2.10 → 10.10.2.11 → 10.10.2.12 → 10.10.2.20`.
- [ ] CI green when stacked PRs merge in order.

Refs #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)