### PR TITLE
feat(db): route page handlers + db_tools + migrations through dialect (#380)

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -2269,15 +2269,14 @@ function api_scan_schedules_save(PDO $db, array $apiKey, array $body): never
     $interval = max(1, to_int($body['interval_minutes'] ?? 60));
     $active   = isset($body['is_active']) ? ((bool) $body['is_active'] ? 1 : 0) : 1;
 
+    // #380: route through the dialect so v2.10.0+ swaps upsert + timestamp
+    // idioms without touching this call site.
+    $d = ipam_dialect();
+    $upsertClause = $d->upsert('scan_schedules', ['subnet_id'], ['method', 'tcp_port', 'interval_minutes', 'is_active', 'updated_at']);
     $st = $db->prepare("
         INSERT INTO scan_schedules (subnet_id, method, tcp_port, interval_minutes, is_active, updated_at)
-        VALUES (:sid, :method, :port, :interval, :active, datetime('now'))
-        ON CONFLICT(subnet_id) DO UPDATE SET
-            method           = excluded.method,
-            tcp_port         = excluded.tcp_port,
-            interval_minutes = excluded.interval_minutes,
-            is_active        = excluded.is_active,
-            updated_at       = datetime('now')
+        VALUES (:sid, :method, :port, :interval, :active, {$d->now()})
+        $upsertClause
     ");
     $st->execute([':sid' => $subnetId, ':method' => $method, ':port' => $tcpPort, ':interval' => $interval, ':active' => $active]);
 

--- a/Simple-PHP-IPAM/db_tools.php
+++ b/Simple-PHP-IPAM/db_tools.php
@@ -76,8 +76,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'impor
         if (!$err) {
             // Execute import inside a transaction; rollback on any error
             try {
-                // Close current connection cleanly, re-open after replacing DB content
-                $db->exec("PRAGMA foreign_keys=OFF");
+                // Close current connection cleanly, re-open after replacing DB content.
+                // #380: route FK toggle through the dialect so future engines
+                // swap in their own connection-level override.
+                $d = ipam_dialect();
+                $fkOff = $d->pragma_foreign_keys(false);
+                if ($fkOff !== null) $db->exec($fkOff);
                 $db->beginTransaction();
 
                 // Drop all user tables (except sqlite_sequence which is auto-managed)
@@ -173,7 +177,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'impor
                     $stmtCount++;
                 }
 
-                $db->exec("PRAGMA foreign_keys=ON");
+                $fkOn = $d->pragma_foreign_keys(true);
+                if ($fkOn !== null) $db->exec($fkOn);
                 $db->commit();
 
                 $elapsed = round(microtime(true) - $importStart, 1);
@@ -184,7 +189,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'impor
                 @unlink(__DIR__ . '/data/.db_initialized');
             } catch (Throwable $ex) {
                 if ($db->inTransaction()) $db->rollBack();
-                $db->exec("PRAGMA foreign_keys=ON");
+                $fkOnRecover = ipam_dialect()->pragma_foreign_keys(true);
+                if ($fkOnRecover !== null) $db->exec($fkOnRecover);
                 $err = 'Import failed: ' . $ex->getMessage()
                      . ' The database has been restored from the pre-import state.';
                 audit($db, 'db.import_failed', 'system', null,

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -18,11 +18,17 @@ function ipam_migrations(): array
             $st->execute();
             $rows = $st->fetchAll();
 
+            // #380/#410: bind network_bin via ipam_bind_binary() (PARAM_LOB) so
+            // the backfilled rows are BLOB affinity from the start. The
+            // 2.9.0-blob-affinity migration would otherwise need to re-rewrite
+            // every row that this migration inserted.
             $up = $db->prepare("UPDATE subnets SET network_bin = :b WHERE id = :id");
             foreach ($rows as $r) {
                 $bin = @inet_pton(to_str($r['network']));
                 if ($bin === false) continue;
-                $up->execute([':b' => $bin, ':id' => to_int($r['id'])]);
+                ipam_bind_binary($up, ':b', $bin);
+                $up->bindValue(':id', to_int($r['id']), PDO::PARAM_INT);
+                $up->execute();
             }
 
             $db->exec("CREATE INDEX IF NOT EXISTS idx_subnets_ver_prefix_netbin ON subnets(ip_version, prefix, network_bin)");

--- a/Simple-PHP-IPAM/scan_history.php
+++ b/Simple-PHP-IPAM/scan_history.php
@@ -26,15 +26,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
 
+        // #380: dialect-routed upsert so future engines pick up the right idiom.
+        $d = ipam_dialect();
+        $upsertClause = $d->upsert('scan_schedules', ['subnet_id'], ['method', 'tcp_port', 'interval_minutes', 'is_active', 'updated_at']);
         $db->prepare("
             INSERT INTO scan_schedules (subnet_id, method, tcp_port, interval_minutes, is_active, updated_at)
-            VALUES (:sid, :method, :port, :interval, :active, datetime('now'))
-            ON CONFLICT(subnet_id) DO UPDATE SET
-                method           = excluded.method,
-                tcp_port         = excluded.tcp_port,
-                interval_minutes = excluded.interval_minutes,
-                is_active        = excluded.is_active,
-                updated_at       = datetime('now')
+            VALUES (:sid, :method, :port, :interval, :active, {$d->now()})
+            $upsertClause
         ")->execute([
             ':sid'      => $sid,
             ':method'   => $method,

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -236,16 +236,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
 
-        // UPSERT: insert or update the schedule for this subnet
+        // UPSERT: insert or update the schedule for this subnet.
+        // #380: route through the dialect so future engines pick up the right
+        // upsert + timestamp idioms automatically.
+        $d = ipam_dialect();
+        $upsertClause = $d->upsert('scan_schedules', ['subnet_id'], ['method', 'tcp_port', 'interval_minutes', 'is_active', 'updated_at']);
         $st = $db->prepare("
             INSERT INTO scan_schedules (subnet_id, method, tcp_port, interval_minutes, is_active, updated_at)
-            VALUES (:sid, :method, :port, :interval, :active, datetime('now'))
-            ON CONFLICT(subnet_id) DO UPDATE SET
-                method           = excluded.method,
-                tcp_port         = excluded.tcp_port,
-                interval_minutes = excluded.interval_minutes,
-                is_active        = excluded.is_active,
-                updated_at       = datetime('now')
+            VALUES (:sid, :method, :port, :interval, :active, {$d->now()})
+            $upsertClause
         ");
         $st->execute([
             ':sid'      => $id,


### PR DESCRIPTION
## Summary

Wave 5 SQL literal refactor. Routes the remaining non-`lib.php` SQL call sites through the Dialect abstraction (#378) and `ipam_bind_binary()` helper (#410). After this PR every production write path in the codebase uses the dialect layer — v2.10.0 `MysqlDialect` and v2.11.0 `PgsqlDialect` will slot in without touching application code.

## Call sites refactored

- **`api.php`** — scan_schedules upsert (`/api?resource=scan_schedules`) now builds ON CONFLICT via `\$d->upsert()` and the timestamp via `\$d->now()`.
- **`subnets.php`** — scan_schedules UPSERT handler (web UI path for creating/updating a scan schedule).
- **`scan_history.php`** — scan_schedules POST handler on the history page.
- **`migrations.php`** — migration 0.3 (subnets.network_bin backfill) now binds `:b` via `ipam_bind_binary()` so the backfilled rows are BLOB affinity from the start. Without this, 2.9.0-blob-affinity would need to re-rewrite every row that 0.3 inserted.
- **`db_tools.php`** — the DB import handler's three `PRAGMA foreign_keys` sites (disable before import, re-enable on success, re-enable in catch recovery) now call `\$d->pragma_foreign_keys(bool)` with a null check for engines that lack a connection-level toggle.

## Deferred to a follow-up PR (Wave 5b)

- **`migrations.php:666`** has `ON CONFLICT(key) DO NOTHING` in the 2.8.0-alert-recipients closure. The current `Dialect::upsert()` signature requires non-empty `updateCols` — "do nothing on conflict" is a distinct operation. Adding `\$dialect->upsert_or_ignore()` warrants its own PR with matching `DialectTest` coverage. Left as a literal for now.
- **`lib.php` migration-runner PRAGMA literals** (lines 74, 1386, 1391, 1409, 1416) — bootstrap path called from `apply_migrations()`, risk profile doesn't justify touching in this PR.
- **`lib.php` DB dump stream PRAGMA output** (2188, 2259) — generates SQLite-targeted backup text. Future engines need their own dump format.

## Test plan

- [x] **PHPUnit 158/158** (no test changes — pure refactor)
- [x] PHPStan level 9 clean
- [x] PHPCS clean
- [x] Semgrep 0 findings
- [x] **Live containerized harness**: subnets BLOB=13 / addresses BLOB=54 from a fresh seed, proving migration 0.3's refactor works end-to-end.
- [ ] CI green on the PR.

Refs #380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated database operations to use dialect abstraction layer for SQL generation, including scan schedule management and upsert operations.
  * Enhanced foreign key constraint handling to use dialect-specific commands instead of hardcoded statements.
  * Improved database migration and binary value binding to support multiple database backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->