### PR TITLE
fix(db-import): graceful 413 when POST exceeds post_max_size

### DIFF
--- a/Simple-PHP-IPAM/.htaccess
+++ b/Simple-PHP-IPAM/.htaccess
@@ -1,6 +1,24 @@
-# Increase upload limits for db_tools.php SQL import
-php_value upload_max_filesize 200M
-php_value post_max_size 210M
+# Upload limits for db_tools.php SQL import.
+#
+# SQL dumps can be large on installs with long audit history, many subnets,
+# or extensive demo seed data. If your dump exceeds these limits, raise
+# both values here (they must both be raised — post_max_size must be at
+# least slightly larger than upload_max_filesize).
+#
+# These php_value directives only apply under Apache + mod_php. Under PHP-FPM
+# or CGI, set the same values in php.ini or the FPM pool config instead.
+php_value upload_max_filesize 512M
+php_value post_max_size 520M
+
+# Suppress PHP's request-startup warnings (e.g. "POST Content-Length ...
+# exceeds the limit of ..."). Those warnings are written to stdout BEFORE
+# any PHP script runs, which commits the HTTP response headers and causes
+# a cascade of "headers already sent" errors when init.php later calls
+# session_start(). db_tools.php has its own graceful handling for oversized
+# uploads via an early CONTENT_LENGTH check — suppressing startup warnings
+# lets that handler actually run. Startup errors still go to the PHP error
+# log for operators to see.
+php_flag display_startup_errors Off
 
 # Options -Indexes works for Apache.
 # Note: OpenLiteSpeed ignores this. For OLS, disable "Auto Index" in the WebAdmin Console.

--- a/Simple-PHP-IPAM/db_tools.php
+++ b/Simple-PHP-IPAM/db_tools.php
@@ -1,5 +1,56 @@
 <?php
 declare(strict_types=1);
+
+// Early guard: if this is a POST whose Content-Length exceeds php.ini's
+// post_max_size, PHP silently discards $_POST / $_FILES and emits a
+// "Request Startup" warning to stdout before any script runs. That warning
+// commits the HTTP response body, so every subsequent header()/session_start()
+// call from init.php cascades into "headers already sent" errors. Detect the
+// condition here before requiring init.php and emit a clean 413 with
+// actionable guidance (the PHP warning is suppressed at the server level via
+// `php_flag display_startup_errors Off` in .htaccess).
+$_contentLenRaw = $_SERVER['CONTENT_LENGTH'] ?? '0';
+$_contentLen    = is_numeric($_contentLenRaw) ? (int) $_contentLenRaw : 0;
+if (
+    ($_SERVER['REQUEST_METHOD'] ?? '') === 'POST'
+    && $_contentLen > 0
+    && $_POST === []
+    && $_FILES === []
+) {
+    /** @return int bytes — parses '512M', '2G', '4096k', '1024' */
+    $parseIniBytes = static function (string $raw): int {
+        $raw = trim($raw);
+        if ($raw === '') return 0;
+        $last = strtolower($raw[strlen($raw) - 1]);
+        $n = (int) $raw;
+        return match ($last) {
+            'g'     => $n * 1024 * 1024 * 1024,
+            'm'     => $n * 1024 * 1024,
+            'k'     => $n * 1024,
+            default => $n,
+        };
+    };
+    $postMaxBytes = $parseIniBytes((string) ini_get('post_max_size'));
+    if ($postMaxBytes > 0 && $_contentLen > $postMaxBytes) {
+        http_response_code(413);
+        header('Content-Type: text/html; charset=utf-8');
+        $mbLimit = (int) round($postMaxBytes / 1024 / 1024);
+        $mbSent  = (int) round($_contentLen / 1024 / 1024);
+        echo '<!DOCTYPE html><meta charset="utf-8"><title>Upload too large</title>';
+        echo '<style>body{font:16px system-ui,sans-serif;max-width:640px;margin:60px auto;padding:0 20px;color:#222}h1{font-size:24px}code{background:#f4f4f4;padding:2px 6px;border-radius:3px}</style>';
+        echo '<h1>413 — Uploaded file too large</h1>';
+        echo "<p>The upload was approximately <strong>{$mbSent}&nbsp;MB</strong>, which exceeds this server's <code>post_max_size</code> limit of <strong>{$mbLimit}&nbsp;MB</strong>.</p>";
+        echo '<p>To import a larger SQL dump, raise both <code>post_max_size</code> and <code>upload_max_filesize</code> in one of the following places and try again:</p>';
+        echo '<ul>';
+        echo '  <li><code>Simple-PHP-IPAM/.htaccess</code> (Apache + mod_php)</li>';
+        echo '  <li>PHP-FPM pool config (<code>/etc/php/*/fpm/pool.d/*.conf</code>)</li>';
+        echo '  <li><code>php.ini</code> (CGI / other SAPIs)</li>';
+        echo '</ul>';
+        echo '<p><a href="db_tools.php">&larr; Back to Database Tools</a></p>';
+        exit;
+    }
+}
+
 require __DIR__ . '/init.php';
 /** @var \PDO $db */
 /** @var IpamConfig $config */

--- a/docs/install.md
+++ b/docs/install.md
@@ -41,6 +41,23 @@ There are **no additional dependencies** for v2.x features. VLANs, VRFs, contact
 
 Optional: `php` CLI (for automatic DB migrations), `chown` (for ownership alignment).
 
+### Upload limits for DB import
+
+**⚙ Admin → Database Tools** lets you export and re-import the full SQLite database as a SQL dump. The bundled `Simple-PHP-IPAM/.htaccess` sets reasonable defaults (`upload_max_filesize 512M`, `post_max_size 520M`) that cover typical installs, but a dump with long audit history or a very large address space can exceed them.
+
+If you hit a "413 — Uploaded file too large" error page, raise **both** values in one of the following places (both must be raised; `post_max_size` should be slightly larger than `upload_max_filesize`):
+
+| Server type | Where to set |
+|---|---|
+| Apache + mod_php | `Simple-PHP-IPAM/.htaccess` — edit the `php_value` lines at the top |
+| PHP-FPM | `/etc/php/*/fpm/pool.d/*.conf` via `php_admin_value[...]` |
+| nginx / Caddy with PHP-FPM | Same as PHP-FPM above — `.htaccess` does not apply |
+| CGI or other SAPI | System `php.ini` |
+
+After raising the limits, restart the FPM pool or web server for the change to take effect. Apache + mod_php picks up `.htaccess` changes on the next request.
+
+The application itself also enforces a soft cap via the `import_sql_max_mb` setting in `config.php` (default **200 MB**), which prevents db_tools.php from accepting a file larger than this value even if PHP would allow it. Raise that value too if you need to import a larger dump.
+
 ---
 
 ## Step 1 — Download a release


### PR DESCRIPTION
## Summary

Fixes a user-reported cascade failure on the **⚙ Admin → Database Tools** SQL import: uploading a file larger than the configured `post_max_size` produced a wall of \"headers already sent\" warnings, left the session broken, and offered no useful feedback about why it failed.

## Reproduction (user report)

```
Warning: PHP Request Startup: POST Content-Length of 245736512 bytes exceeds the limit of 220200960 bytes in Unknown on line 0
Warning: session_name(): Session name cannot be changed after headers have already been sent in /var/www/html/testing/ipam/init.php on line 95
Warning: session_set_cookie_params(): Session cookie parameters cannot be changed after headers have already been sent ...
Warning: session_start(): Session cannot be started after headers have already been sent ...
Warning: Cannot modify header information - headers already sent in /var/www/html/testing/ipam/lib.php on line 265
```

**Root cause**: PHP emitted the \"Request Startup\" warning to stdout **before any script ran**, which committed the response body. Every subsequent `session_*()` / `header()` call from `init.php` cascaded into the same error.

## Three-part fix

1. **`Simple-PHP-IPAM/.htaccess`**:
   - Raised default upload limits from `200M / 210M` to `512M / 520M` (reasonable for typical dumps).
   - Added `php_flag display_startup_errors Off` so PHP's startup warnings never land in the response body. They still go to the PHP error log for operators.

2. **`Simple-PHP-IPAM/db_tools.php`** — early `CONTENT_LENGTH` check **before** `require init.php`:
   - If the request is a POST with `CONTENT_LENGTH > ini_get('post_max_size')` AND empty `$_POST`/`$_FILES` (the exact signature of PHP silently discarding oversized uploads), emit a clean 413 response with actionable guidance on which config file to edit for each SAPI (Apache + mod_php, PHP-FPM, CGI).
   - Narrow match — normal POSTs still flow through unchanged.

3. **`docs/install.md`** — new **Upload limits for DB import** subsection documenting the bundled defaults, the table of places to raise them per server type, and the app-level `import_sql_max_mb` soft cap in `config.php` (default 200 MB).

## Test plan

- [x] PHPStan level 9 clean
- [x] PHPCS clean
- [x] PHPUnit **158/158**
- [x] Semgrep 0 findings
- [x] **Containerized harness**: 20MB POST to db_tools.php → 302 to login (normal flow, .htaccess limits applied)
- [x] **Direct invocation** with `CONTENT_LENGTH=600000000` → emits the clean 413 page without touching init.php (no cascading warnings)
- [ ] CI green on the PR

## Version

Targets **v2.9.1** patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)