### PR TITLE
feat(db): add Dialect::upsert_or_ignore() (#482)

### DIFF
--- a/Simple-PHP-IPAM/dialects/Dialect.php
+++ b/Simple-PHP-IPAM/dialects/Dialect.php
@@ -46,6 +46,29 @@ interface Dialect
     public function upsert(string $table, array $conflictCols, array $updateCols): string;
 
     /**
+     * Returns an INSERT ... ON CONFLICT DO NOTHING fragment.
+     *
+     * Semantically distinct from upsert(): this variant leaves any existing
+     * row untouched on conflict, rather than updating it. Used by migrations
+     * and bootstrap code that want "insert if absent, otherwise noop" without
+     * racing against concurrent writers.
+     *
+     *  - SQLite  : `ON CONFLICT(col, ...) DO NOTHING`
+     *  - MySQL   : `ON DUPLICATE KEY UPDATE col = col` (no-op self-assign)
+     *  - Postgres: `ON CONFLICT (col, ...) DO NOTHING`
+     *
+     * MySQL note: `ON DUPLICATE KEY UPDATE` fires on *any* unique-key
+     * conflict, not just the columns named in $conflictCols. For the call
+     * sites this method was introduced for (single PK or single UNIQUE
+     * constraint), that difference is invisible. If a future caller has
+     * multiple unique keys on the same table and needs conflict-target
+     * scoping, use upsert() with a self-assign updateCols list instead.
+     *
+     * @param string[] $conflictCols
+     */
+    public function upsert_or_ignore(string $table, array $conflictCols): string;
+
+    /**
      * Column definition for an auto-incrementing integer primary key.
      *
      *  - SQLite: `INTEGER PRIMARY KEY AUTOINCREMENT`

--- a/Simple-PHP-IPAM/dialects/SqliteDialect.php
+++ b/Simple-PHP-IPAM/dialects/SqliteDialect.php
@@ -43,6 +43,19 @@ final class SqliteDialect implements Dialect
         return "ON CONFLICT$target DO UPDATE SET " . implode(', ', $assignments);
     }
 
+    /**
+     * SQLite's `ON CONFLICT(col, ...) DO NOTHING` is the direct native idiom.
+     *
+     * @param string[] $conflictCols
+     */
+    public function upsert_or_ignore(string $table, array $conflictCols): string
+    {
+        if ($conflictCols === []) {
+            throw new InvalidArgumentException('upsert_or_ignore() requires at least one conflict column');
+        }
+        return 'ON CONFLICT(' . implode(', ', $conflictCols) . ') DO NOTHING';
+    }
+
     public function autoincrement(): string
     {
         return 'INTEGER PRIMARY KEY AUTOINCREMENT';

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -668,9 +668,9 @@ function ipam_migrations(): array
             if (!in_array('settings', $tables, true)) return;
 
             // Insert the new row with default '[]' if not already present.
+            $ignore = ipam_dialect()->upsert_or_ignore('settings', ['key']);
             $db->prepare(
-                "INSERT INTO settings (key, value, type) VALUES (:k, '[]', 'json')
-                 ON CONFLICT(key) DO NOTHING"
+                "INSERT INTO settings (key, value, type) VALUES (:k, '[]', 'json') $ignore"
             )->execute([':k' => 'alert.recipient_user_ids']);
 
             // CodeRabbit M1 (PR #450): re-run safety. If alert.recipient_user_ids

--- a/tests/DialectTest.php
+++ b/tests/DialectTest.php
@@ -91,6 +91,43 @@ final class DialectTest extends TestCase
         $this->sqlite->upsert('users', ['username'], []);
     }
 
+    public function testUpsertOrIgnoreSingleConflictColumn(): void
+    {
+        $sql = $this->sqlite->upsert_or_ignore('settings', ['key']);
+        $this->assertSame('ON CONFLICT(key) DO NOTHING', $sql);
+    }
+
+    public function testUpsertOrIgnoreCompositeConflictColumns(): void
+    {
+        $sql = $this->sqlite->upsert_or_ignore('subnet_tags', ['subnet_id', 'tag_id']);
+        $this->assertSame('ON CONFLICT(subnet_id, tag_id) DO NOTHING', $sql);
+    }
+
+    public function testUpsertOrIgnoreRequiresAtLeastOneConflictColumn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->sqlite->upsert_or_ignore('settings', []);
+    }
+
+    public function testUpsertOrIgnoreComposesIntoValidSqliteInsert(): void
+    {
+        // End-to-end: the fragment the dialect returns must compose into a
+        // real INSERT that a real SQLite DB will accept and that leaves an
+        // existing row untouched on conflict.
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo->query("CREATE TABLE kv (k TEXT PRIMARY KEY, v TEXT NOT NULL)");
+        $pdo->prepare("INSERT INTO kv (k, v) VALUES (:k, :v)")
+            ->execute([':k' => 'greeting', ':v' => 'hello']);
+
+        $ignore = $this->sqlite->upsert_or_ignore('kv', ['k']);
+        $st = $pdo->prepare("INSERT INTO kv (k, v) VALUES (:k, :v) $ignore");
+        $st->execute([':k' => 'greeting', ':v' => 'overwritten']);
+
+        $row = $pdo->query("SELECT v FROM kv WHERE k = 'greeting'")->fetch(PDO::FETCH_ASSOC);
+        $this->assertSame('hello', $row['v']);
+    }
+
     public function testAppendOnlyTriggerReturnsExactlyTwoStatements(): void
     {
         // SQLite needs two BEFORE triggers; MySQL needs two SIGNAL triggers;


### PR DESCRIPTION
## Summary

- Adds `Dialect::upsert_or_ignore(string \$table, array \$conflictCols): string` for the `INSERT ... ON CONFLICT DO NOTHING` pattern (distinct from `upsert()` which updates on conflict).
- `SqliteDialect` emits `ON CONFLICT(col, ...) DO NOTHING`. `MysqlDialect` and `PgsqlDialect` implementations land in v2.10.0 / v2.11.0; interface contract documents MySQL's wider unique-key conflict semantics.
- Refactors the last deferred literal `ON CONFLICT DO NOTHING` site in `migrations.php:673` (v2.8.0-alert-recipients closure) through the new method. Finishes v2.9.0 #380's deferred work.
- Unblocks #382 `MysqlDialect`.

## Test plan

- [x] `php -l` on all changed files
- [x] `vendor/bin/phpunit` — 162/162 green (+4 new `DialectTest` cases: single col, composite cols, empty guard, end-to-end SQLite round-trip)
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` — OK
- [x] `vendor/bin/phpcs` — clean
- [x] `semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/` — 0 findings
- [x] Containerized Playwright (optional for this interface-only change)

Closes #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified database conflict handling across SQLite, PostgreSQL, and MySQL dialects for consistent INSERT behavior when duplicate records are encountered.
  * Enhanced alert recipient settings migration to use dialect-specific conflict resolution.

* **Tests**
  * Expanded test coverage for conflict scenarios with validation of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->