### PR TITLE
feat(db): route PRAGMA foreign_keys through Dialect (#483)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -71,7 +71,10 @@ function ipam_db(string $path): PDO
 
     $pdo->exec("PRAGMA journal_mode = WAL;");
     $pdo->exec("PRAGMA busy_timeout = 30000;");
-    $pdo->exec("PRAGMA foreign_keys = ON;");
+    $fk = ipam_dialect()->pragma_foreign_keys(true);
+    if ($fk !== null) {
+        $pdo->exec($fk);
+    }
     return $pdo;
 }
 
@@ -1372,23 +1375,36 @@ function apply_migrations(PDO $db): array
         // transactional so ROLLBACK cleanly undoes any partial work.
         $lastErr  = null;
         $applied  = false;
+        // Route FK toggling through the dialect so non-SQLite engines (MySQL
+        // via SET FOREIGN_KEY_CHECKS, Postgres via null / deferred constraints)
+        // get the engine-appropriate statement. Null means the engine has no
+        // per-connection FK toggle and we rely on other mechanisms instead.
+        $dialect = ipam_dialect();
+        $fkOff   = $dialect->pragma_foreign_keys(false);
+        $fkOn    = $dialect->pragma_foreign_keys(true);
+        $toggleFk = static function (PDO $db, ?string $stmt): void {
+            if ($stmt !== null) {
+                $db->exec($stmt);
+            }
+        };
         for ($attempt = 0; $attempt < 60 && !$applied; $attempt++) {
             if ($attempt > 0) {
                 sleep(1);
             }
 
-            // PRAGMA foreign_keys cannot be changed inside a transaction — it must
-            // be set here, outside BEGIN. When it is ON, SQLite executes an implicit
-            // DELETE on every row before DROP TABLE, which triggers ON DELETE CASCADE
-            // on all child tables (addresses, subnet_tags, etc.), wiping all data.
-            // Disabling it for the duration of each migration prevents that cascade.
-            // FK enforcement is restored unconditionally after the transaction ends.
-            $db->exec("PRAGMA foreign_keys = OFF");
+            // FK enforcement must be toggled outside the transaction. On
+            // SQLite, PRAGMA foreign_keys cannot be changed inside BEGIN; and
+            // with FK ON, DROP TABLE triggers an implicit row-by-row DELETE
+            // that cascades ON DELETE CASCADE children (addresses,
+            // subnet_tags, etc.), wiping all data. Disabling around each
+            // migration prevents the cascade. FK enforcement is restored
+            // unconditionally in every exit path.
+            $toggleFk($db, $fkOff);
 
             try {
                 $db->exec("BEGIN EXCLUSIVE");
             } catch (Throwable $e) {
-                $db->exec("PRAGMA foreign_keys = ON");
+                $toggleFk($db, $fkOn);
                 $lastErr = $e;
                 if (stripos($e->getMessage(), 'locked') !== false || stripos($e->getMessage(), 'busy') !== false) {
                     continue;
@@ -1406,14 +1422,14 @@ function apply_migrations(PDO $db): array
                 $lastErr = null;
             } catch (Throwable $e) {
                 try { $db->exec("ROLLBACK"); } catch (Throwable) {}
-                $db->exec("PRAGMA foreign_keys = ON");
+                $toggleFk($db, $fkOn);
                 $lastErr = $e;
                 if (stripos($e->getMessage(), 'locked') !== false || stripos($e->getMessage(), 'busy') !== false) {
                     continue;
                 }
                 throw $e;
             }
-            $db->exec("PRAGMA foreign_keys = ON");
+            $toggleFk($db, $fkOn);
         }
 
         if ($lastErr !== null) {


### PR DESCRIPTION
## Summary

- Routes the last five \`PRAGMA foreign_keys\` literals in \`lib.php\` through \`Dialect::pragma_foreign_keys()\`, finishing v2.9.0 #379's deferred work.
- Call sites: \`ipam_db()\` line 74, plus the four FK-toggle sites inside \`apply_migrations()\` (disable before BEGIN, re-enable on normal commit / BEGIN failure / migration throw).
- Refactored with a small static closure so the \`null\` guard is expressed once instead of five times.
- **Load-bearing null check**: v2.11.0 \`PgsqlDialect\` will return \`null\` from \`pragma_foreign_keys()\` because Postgres uses deferred constraints rather than a per-connection toggle. The migration path must degrade gracefully on that engine.

## Deliberately untouched

- \`lib.php:2198\`, \`2269\` — PRAGMA literals in \`ipam_db_dump_stream()\` stay as SQLite-format backup output. The dump format is engine-specific by design; MySQL/Postgres backups will need their own dump paths, not dialect-translated SQLite text.

## Test plan

- [x] \`php -l Simple-PHP-IPAM/lib.php\`
- [x] \`vendor/bin/phpunit\` — 158/158 green, including \`MigrationTest::testVrfMigrationPreservesAddresses\` (the v2.1.0-vrfs data-loss regression guard)
- [x] \`vendor/bin/phpstan analyse --memory-limit=1G\` — OK
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/\` — 0 findings

Closes #483. Unblocks #382 MysqlDialect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the database abstraction layer to dynamically handle foreign-key constraint enforcement across different database engines. This improves maintainability and system flexibility while preserving all existing database integrity checks and transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->