### PR TITLE
feat(db): route bootstrap DDL through Dialect (#484)

### DIFF
--- a/Simple-PHP-IPAM/dialects/Dialect.php
+++ b/Simple-PHP-IPAM/dialects/Dialect.php
@@ -78,6 +78,24 @@ interface Dialect
     public function autoincrement(): string;
 
     /**
+     * Column type for a TEXT-like column that will be used in an INDEX,
+     * UNIQUE constraint, or primary key.
+     *
+     *  - SQLite  : `TEXT` (no key-length limit on loosely-typed BLOB/TEXT)
+     *  - MySQL   : `VARCHAR($maxLen)` — MySQL 8.0 rejects "BLOB/TEXT column
+     *              used in key specification without a key length", so
+     *              indexed text columns must be VARCHAR with an explicit
+     *              length. 191 is the utf8mb4 default that fits the
+     *              historical 767-byte index-key limit.
+     *  - Postgres: `TEXT` (native B-tree indexes on TEXT are unrestricted)
+     *
+     * Use for any TEXT column that appears in a CREATE INDEX, UNIQUE, or
+     * PRIMARY KEY declaration. Free-form text columns (descriptions, notes,
+     * etc.) that are never indexed should stay as the literal `TEXT`.
+     */
+    public function indexed_text_type(int $maxLen = 191): string;
+
+    /**
      * Column type for a fixed-length binary blob.
      *
      *  - SQLite: `BLOB`

--- a/Simple-PHP-IPAM/dialects/SqliteDialect.php
+++ b/Simple-PHP-IPAM/dialects/SqliteDialect.php
@@ -62,6 +62,16 @@ final class SqliteDialect implements Dialect
     }
 
     /**
+     * SQLite has no key-length limit on TEXT columns in indexes or unique
+     * constraints. The $maxLen argument is ignored on this engine but kept
+     * in the signature so MySQL can use it for strict typing.
+     */
+    public function indexed_text_type(int $maxLen = 191): string
+    {
+        return 'TEXT';
+    }
+
+    /**
      * SQLite's typing is loose — BLOB is the affinity, not a fixed-length
      * type. The $length argument is ignored on this engine but kept in the
      * signature so MySQL/Postgres can use it for strict typing.

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -78,13 +78,21 @@ function ipam_db(string $path): PDO
 /**
  * Create the audit_log table and its append-only triggers (idempotent).
  * Centralises DDL that was previously duplicated in 4 places.
+ *
+ * Routes type declarations and triggers through the active dialect so
+ * fresh MySQL / Postgres installs emit engine-valid DDL. On SQLite the
+ * resulting text matches the pre-v2.10.0 literals byte-for-byte. Per
+ * the v2.10.0 schema-files decision: historical migration closures are
+ * NOT refactored — schema.mysql.sql / schema.pgsql.sql pre-populate
+ * schema_migrations so replay is a no-op on fresh non-SQLite installs.
  */
 function ensure_audit_log_table(PDO $db): void
 {
+    $d = ipam_dialect();
     $db->exec("
         CREATE TABLE IF NOT EXISTS audit_log (
-          id          INTEGER PRIMARY KEY AUTOINCREMENT,
-          created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+          id          " . $d->autoincrement() . ",
+          created_at  TEXT NOT NULL DEFAULT (" . $d->now() . "),
           user_id     INTEGER, username TEXT, action TEXT NOT NULL,
           entity_type TEXT NOT NULL, entity_id INTEGER,
           ip TEXT, user_agent TEXT, details TEXT
@@ -92,12 +100,9 @@ function ensure_audit_log_table(PDO $db): void
     ");
     $db->exec("CREATE INDEX IF NOT EXISTS idx_audit_log_action ON audit_log(action)");
     $db->exec("CREATE INDEX IF NOT EXISTS idx_audit_log_created_at ON audit_log(created_at)");
-    $db->exec("CREATE TRIGGER IF NOT EXISTS audit_log_no_update
-        BEFORE UPDATE ON audit_log
-        BEGIN SELECT RAISE(ABORT, 'audit_log is append-only'); END");
-    $db->exec("CREATE TRIGGER IF NOT EXISTS audit_log_no_delete
-        BEFORE DELETE ON audit_log
-        BEGIN SELECT RAISE(ABORT, 'audit_log is append-only'); END");
+    foreach ($d->append_only_trigger('audit_log') as $stmt) {
+        $db->exec($stmt);
+    }
 }
 
 function ipam_db_init(PDO $db): void
@@ -1333,10 +1338,11 @@ function history_log_address(PDO $db, string $action, int $subnetId, string $ip,
 
 function ensure_migrations_table(PDO $db): void
 {
+    $d = ipam_dialect();
     $db->exec("CREATE TABLE IF NOT EXISTS schema_migrations (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        id " . $d->autoincrement() . ",
         version TEXT NOT NULL UNIQUE,
-        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        applied_at TEXT NOT NULL DEFAULT (" . $d->now() . ")
     )");
 }
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -92,11 +92,16 @@ function ipam_db(string $path): PDO
 function ensure_audit_log_table(PDO $db): void
 {
     $d = ipam_dialect();
+    // action and created_at are indexed below, so they must use the
+    // indexed text type (VARCHAR on MySQL, TEXT elsewhere). Free-form
+    // unindexed columns (username, entity_type, ip, user_agent, details)
+    // stay as plain TEXT.
+    $idxText = $d->indexed_text_type();
     $db->exec("
         CREATE TABLE IF NOT EXISTS audit_log (
           id          " . $d->autoincrement() . ",
-          created_at  TEXT NOT NULL DEFAULT (" . $d->now() . "),
-          user_id     INTEGER, username TEXT, action TEXT NOT NULL,
+          created_at  $idxText NOT NULL DEFAULT (" . $d->now() . "),
+          user_id     INTEGER, username TEXT, action $idxText NOT NULL,
           entity_type TEXT NOT NULL, entity_id INTEGER,
           ip TEXT, user_agent TEXT, details TEXT
         )
@@ -1342,9 +1347,11 @@ function history_log_address(PDO $db, string $action, int $subnetId, string $ip,
 function ensure_migrations_table(PDO $db): void
 {
     $d = ipam_dialect();
+    // version has a UNIQUE constraint so it must use the indexed text type
+    // (VARCHAR on MySQL, TEXT elsewhere).
     $db->exec("CREATE TABLE IF NOT EXISTS schema_migrations (
         id " . $d->autoincrement() . ",
-        version TEXT NOT NULL UNIQUE,
+        version " . $d->indexed_text_type() . " NOT NULL UNIQUE,
         applied_at TEXT NOT NULL DEFAULT (" . $d->now() . ")
     )");
 }

--- a/tests/DialectTest.php
+++ b/tests/DialectTest.php
@@ -46,6 +46,17 @@ final class DialectTest extends TestCase
         $this->assertSame('BLOB', $this->sqlite->binary_type(255));
     }
 
+    public function testIndexedTextTypeIsPlainTextOnSqlite(): void
+    {
+        // SQLite has no key-length limit on TEXT columns, so the maxLen
+        // argument is a no-op here. MysqlDialect will emit VARCHAR($maxLen)
+        // on the same call to satisfy MySQL 8.0's "BLOB/TEXT column used
+        // in key specification without a key length" error.
+        $this->assertSame('TEXT', $this->sqlite->indexed_text_type());
+        $this->assertSame('TEXT', $this->sqlite->indexed_text_type(191));
+        $this->assertSame('TEXT', $this->sqlite->indexed_text_type(255));
+    }
+
     public function testCaseSensitiveCollationIsNullOnSqlite(): void
     {
         $this->assertNull($this->sqlite->case_sensitive_collation());


### PR DESCRIPTION
## Summary

- Routes \`AUTOINCREMENT\` / \`datetime('now')\` / append-only triggers in \`lib.php\` bootstrap DDL through the Dialect abstraction so fresh MySQL and Postgres installs emit engine-valid DDL.
- Sites touched: \`ensure_audit_log_table()\` (id + created_at + triggers) and \`ensure_migrations_table()\` (id + applied_at).

## Scope decision — historical migrations NOT refactored

Historical migration closures in \`migrations.php\` are **deliberately untouched**. Rationale (now reflected in the updated #484 issue body):

- \`schema.mysql.sql\` (v2.10.0 #383) and \`schema.pgsql.sql\` (v2.11.0 #387) will be authoritative for fresh non-SQLite installs and will pre-seed \`schema_migrations\` with every historical version row. \`apply_migrations()\` then finds them all applied and the replay is a no-op on fresh MySQL / Postgres.
- Historical closures still execute as-is on SQLite installs upgrading through the chain — they **must** stay byte-identical on SQLite to preserve \`MigrationTest\` fixtures and the v2.1.0-vrfs data-loss regression guard.
- Routing historical closures through the dialect would risk fixture drift for zero benefit since on MySQL / Postgres they never run.

**#383 and #387 must include the \`schema_migrations\` pre-seed step in their installer wiring.** Tracked in those issues.

## SQLite byte-equivalence

\`SqliteDialect\` returns strings byte-identical to the pre-v2.10.0 literals:
- \`autoincrement()\` → \`INTEGER PRIMARY KEY AUTOINCREMENT\`
- \`now()\` → \`datetime('now')\`
- \`append_only_trigger('audit_log')\` → the same two BEFORE triggers with \`RAISE(ABORT)\`

After concatenation, the emitted DDL matches v2.9.0 exactly. No MigrationTest fixture updates needed.

## Test plan

- [x] \`php -l Simple-PHP-IPAM/lib.php\`
- [x] \`vendor/bin/phpunit\` — 158/158 green (MigrationTest + v2.1.0-vrfs data-loss regression guard still green)
- [x] \`vendor/bin/phpstan analyse --memory-limit=1G\` — OK
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/\` — 0 findings

Closes #484. Unblocks #382 \`MysqlDialect\` and #383 \`schema.mysql.sql\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated audit logging and migrations to use database-dialect-aware SQL fragments, improving compatibility across SQL databases.
* **Tests**
  * Added unit test covering dialect behavior for indexed text column types to ensure consistent cross-database behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->