### PR TITLE
feat(db): MysqlDialect + schema.mysql.sql — experimental MySQL 8.0+ driver (#382, #383)

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -34,7 +34,7 @@ header('X-Content-Type-Options: nosniff');
 header('X-Frame-Options: DENY');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 
-$db = ipam_db(to_str($config['db_path']));
+$db = ipam_db($config);
 ipam_db_init($db);
 
 // ---- API key authentication ----

--- a/Simple-PHP-IPAM/cron.php
+++ b/Simple-PHP-IPAM/cron.php
@@ -81,7 +81,7 @@ register_shutdown_function(static function () use ($cronLockHandle): void {
     }
 });
 
-$db       = ipam_db(to_str($config['db_path']));
+$db       = ipam_db($config);
 
 // Apply admin-configured timezone from DB settings now that $db is open. All
 // downstream date() calls in this cron run pick up the new zone.

--- a/Simple-PHP-IPAM/demo_reset.php
+++ b/Simple-PHP-IPAM/demo_reset.php
@@ -23,7 +23,7 @@ if (!($config['demo_mode']['enabled'] ?? false)) {
     exit(0);
 }
 
-$db = ipam_db($config['db_path']);
+$db = ipam_db($config);
 ipam_db_init($db);
 
 demo_reset_db($db);

--- a/Simple-PHP-IPAM/demo_seed.php
+++ b/Simple-PHP-IPAM/demo_seed.php
@@ -55,7 +55,7 @@ if (!($config['demo_mode']['enabled'] ?? false)) {
     exit(1);
 }
 
-$db = ipam_db($config['db_path']);
+$db = ipam_db($config);
 ipam_db_init($db);
 
 echo "Resetting database to demo data...\n";

--- a/Simple-PHP-IPAM/dialects/MysqlDialect.php
+++ b/Simple-PHP-IPAM/dialects/MysqlDialect.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * MySQL 8.0+ implementation of the Dialect interface (#382).
+ *
+ * Stateless — every method is a pure function over its arguments. Mirrors
+ * SqliteDialect structurally. v2.10.0 is the first release to ship this
+ * class; users opt in via `db_driver = 'mysql'` in config.php. The driver
+ * is labelled experimental in v2.10.0 and promoted to stable in v3.0.0.
+ *
+ * MySQL minimum version: 8.0. Lower versions are rejected at connection
+ * time with a clear error — see the version check in lib.php::ipam_db().
+ * Reasons for the 8.0 floor:
+ *
+ *   - utf8mb4 default charset and larger index key prefix (3072 bytes
+ *     vs 767 on 5.7) without needing innodb_large_prefix
+ *   - JSON column type native support
+ *   - CTE / window function support used by some migration closures
+ *   - Role-based privileges
+ *
+ * Storage conventions (match SQLite and Postgres for cross-engine
+ * compatibility):
+ *
+ *   - ip_bin / network_bin: VARBINARY(16), native length (4 bytes for
+ *     IPv4, 16 bytes for IPv6, never left-padded). All three engines do
+ *     byte-wise memcmp ordering on native-length VARBINARY / BLOB /
+ *     BYTEA values, so ORDER BY ip_bin is equivalent across engines.
+ *     Locked in during v2.8.0 planning (#410).
+ *   - Indexed text columns: VARCHAR(191), utf8mb4, fits the 767-byte
+ *     key prefix limit that still applies to non-utf8mb4 indexes and
+ *     is safe for every MySQL 8.0 default install.
+ *   - Case-sensitive columns (usernames, CIDRs, hostnames): COLLATE
+ *     utf8mb4_bin. Byte-comparison, ASCII-safe, matches SQLite's
+ *     default BINARY collation so user-visible comparisons stay
+ *     equivalent.
+ *
+ * No namespace is used; see CLAUDE.md "When to use classes vs functions".
+ */
+final class MysqlDialect implements Dialect
+{
+    /**
+     * MySQL's UTC_TIMESTAMP() is always UTC regardless of session
+     * timezone, matching SQLite's datetime('now') and Postgres's
+     * (NOW() AT TIME ZONE 'utc'). NOW() returns session-local time
+     * and would drift across servers, so avoid it.
+     */
+    public function now(): string
+    {
+        return 'UTC_TIMESTAMP()';
+    }
+
+    /**
+     * MySQL's INSERT ... ON DUPLICATE KEY UPDATE fires on any unique-key
+     * conflict, not scoped to the columns in $conflictCols. For the call
+     * sites this method was introduced for (single PK or single UNIQUE)
+     * that is invisible. Uses VALUES(col) to reference the would-be
+     * inserted value, which is the idiomatic form on MySQL 8.0 and still
+     * works post-8.0.20 (where the newer alias form is also available).
+     *
+     * @param string[] $conflictCols
+     * @param string[] $updateCols
+     */
+    public function upsert(string $table, array $conflictCols, array $updateCols): string
+    {
+        if ($conflictCols === []) {
+            throw new InvalidArgumentException('upsert() requires at least one conflict column');
+        }
+        if ($updateCols === []) {
+            throw new InvalidArgumentException('upsert() requires at least one update column');
+        }
+        $assignments = [];
+        foreach ($updateCols as $col) {
+            $assignments[] = "$col = VALUES($col)";
+        }
+        return 'ON DUPLICATE KEY UPDATE ' . implode(', ', $assignments);
+    }
+
+    /**
+     * INSERT ... ON DUPLICATE KEY UPDATE col=col is the MySQL idiom for
+     * "leave the existing row untouched on conflict" — the self-assign
+     * is a no-op. Matches SQLite's ON CONFLICT(...) DO NOTHING semantics
+     * for single-PK/UNIQUE call sites. See interface doc for the note on
+     * MySQL's wider conflict-target semantics.
+     *
+     * @param string[] $conflictCols
+     */
+    public function upsert_or_ignore(string $table, array $conflictCols): string
+    {
+        if ($conflictCols === []) {
+            throw new InvalidArgumentException('upsert_or_ignore() requires at least one conflict column');
+        }
+        $first = $conflictCols[0];
+        return "ON DUPLICATE KEY UPDATE $first = $first";
+    }
+
+    /**
+     * BIGINT UNSIGNED matches the signed 64-bit range SQLite uses for
+     * INTEGER PRIMARY KEY but with the zero-based unsigned range. Any
+     * ID column in the schema is an opaque row handle that never goes
+     * negative, so the signedness difference is invisible to callers.
+     */
+    public function autoincrement(): string
+    {
+        return 'BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY';
+    }
+
+    /**
+     * VARCHAR($maxLen) so indexed / unique / PK text columns fit under
+     * MySQL's key length limit without needing an explicit index prefix.
+     * 191 is chosen because 191 * 4 bytes (utf8mb4) = 764 bytes which
+     * fits the historical 767-byte limit that still applies to non-
+     * InnoDB-large-prefix configurations. See interface doc.
+     */
+    public function indexed_text_type(int $maxLen = 191): string
+    {
+        return "VARCHAR($maxLen)";
+    }
+
+    /**
+     * VARBINARY($length) stores binary IP values natively (4 bytes for
+     * IPv4, 16 bytes for IPv6, never padded). ipam_bind_binary() uses
+     * PDO::PARAM_LOB so high bytes and embedded nulls round-trip cleanly.
+     */
+    public function binary_type(int $length): string
+    {
+        return "VARBINARY($length)";
+    }
+
+    /**
+     * utf8mb4_bin is byte-wise comparison under utf8mb4, which matches
+     * SQLite's default BINARY collation. Use utf8mb4_general_ci on
+     * descriptive columns where case-insensitive comparison is desired.
+     *
+     * MySQL always needs the collation clause, so this narrows the
+     * interface's `?string` return to `string`. PHP allows covariance;
+     * PHPStan level 9 enforces the narrowing.
+     */
+    public function case_sensitive_collation(): string
+    {
+        return 'COLLATE utf8mb4_bin';
+    }
+
+    /**
+     * Two BEFORE triggers using SIGNAL SQLSTATE '45000' which is MySQL's
+     * idiom for raising a generic user-defined exception. MYSQL_ERRNO
+     * 1644 is the standard code for "Unhandled user-defined exception
+     * condition" — the closest MySQL equivalent to SQLite's
+     * RAISE(ABORT).
+     *
+     * Trigger names embed the table name for namespace safety.
+     *
+     * Note: CREATE TRIGGER IF NOT EXISTS is supported on MySQL 8.0.22+.
+     * Earlier 8.0 minor versions will fail on re-run. The ipam_db_init
+     * bootstrap path calls ensure_audit_log_table idempotently on every
+     * request, so pre-8.0.22 users would see noise on every hit. If
+     * support for 8.0.0–8.0.21 becomes a concern, wrap the CREATE with
+     * a DROP TRIGGER IF EXISTS first. v2.10.0 targets 8.0.22+ as the
+     * effective minimum.
+     *
+     * @return list<string>
+     */
+    public function append_only_trigger(string $table): array
+    {
+        $msg = "$table is append-only";
+        $body = "BEGIN "
+              . "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '$msg', MYSQL_ERRNO = 1644; "
+              . "END";
+        return [
+            "CREATE TRIGGER IF NOT EXISTS {$table}_no_update "
+            . "BEFORE UPDATE ON {$table} FOR EACH ROW $body",
+
+            "CREATE TRIGGER IF NOT EXISTS {$table}_no_delete "
+            . "BEFORE DELETE ON {$table} FOR EACH ROW $body",
+        ];
+    }
+
+    /**
+     * MySQL uses SET FOREIGN_KEY_CHECKS at the session level rather than
+     * PRAGMA. Same semantics as SQLite's PRAGMA foreign_keys toggle: when
+     * OFF, FK constraints are not enforced for the duration of the
+     * current session or until re-enabled.
+     */
+    public function pragma_foreign_keys(bool $on): string
+    {
+        return 'SET FOREIGN_KEY_CHECKS = ' . ($on ? '1' : '0');
+    }
+
+    public function driver_name(): string
+    {
+        return 'mysql';
+    }
+}

--- a/Simple-PHP-IPAM/dialects/MysqlDialect.php
+++ b/Simple-PHP-IPAM/dialects/MysqlDialect.php
@@ -142,30 +142,29 @@ final class MysqlDialect implements Dialect
     }
 
     /**
-     * Two BEFORE triggers using SIGNAL SQLSTATE '45000' which is MySQL's
-     * idiom for raising a generic user-defined exception. MYSQL_ERRNO
-     * 1644 is the standard code for "Unhandled user-defined exception
-     * condition" — the closest MySQL equivalent to SQLite's
-     * RAISE(ABORT).
+     * Two BEFORE triggers using SIGNAL SQLSTATE '45000' — MySQL's idiom for
+     * raising a generic user-defined exception. MYSQL_ERRNO 1644 is the
+     * standard code for "Unhandled user-defined exception condition", the
+     * closest MySQL equivalent to SQLite's RAISE(ABORT).
+     *
+     * Single-statement trigger bodies (no BEGIN/END wrapping) so each CREATE
+     * TRIGGER is one complete statement — PDO::exec() can dispatch them
+     * without any multi-statement parsing concerns, and the schema file
+     * stays parseable without DELIMITER directives.
      *
      * Trigger names embed the table name for namespace safety.
      *
-     * Note: CREATE TRIGGER IF NOT EXISTS is supported on MySQL 8.0.22+.
-     * Earlier 8.0 minor versions will fail on re-run. The ipam_db_init
-     * bootstrap path calls ensure_audit_log_table idempotently on every
-     * request, so pre-8.0.22 users would see noise on every hit. If
-     * support for 8.0.0–8.0.21 becomes a concern, wrap the CREATE with
-     * a DROP TRIGGER IF EXISTS first. v2.10.0 targets 8.0.22+ as the
-     * effective minimum.
+     * Note: CREATE TRIGGER IF NOT EXISTS requires MySQL 8.0.22+. Earlier
+     * 8.0 minor versions will fail on re-run because ensure_audit_log_table()
+     * is called idempotently on every bootstrap. v2.10.0 effectively targets
+     * 8.0.22+.
      *
      * @return list<string>
      */
     public function append_only_trigger(string $table): array
     {
         $msg = "$table is append-only";
-        $body = "BEGIN "
-              . "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '$msg', MYSQL_ERRNO = 1644; "
-              . "END";
+        $body = "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '$msg', MYSQL_ERRNO = 1644";
         return [
             "CREATE TRIGGER IF NOT EXISTS {$table}_no_update "
             . "BEFORE UPDATE ON {$table} FOR EACH ROW $body",

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -133,7 +133,7 @@ session_start();
 
 require __DIR__ . '/lib.php';
 
-$db = ipam_db(to_str($config['db_path']));
+$db = ipam_db($config);
 ipam_db_init($db);
 
 // Now that settings are available, apply the admin-configured timezone. All DB

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -200,6 +200,7 @@ function ensure_audit_log_table(PDO $db): void
 
 function ipam_db_init(PDO $db): void
 {
+    global $config;
     $driver = ipam_dialect()->driver_name();
 
     // SQLite-only fast path: skip bootstrap checks if the sentinel file is
@@ -207,8 +208,15 @@ function ipam_db_init(PDO $db): void
     // stat, so this optimisation does not apply there — the MySQL path
     // runs the full check on every bootstrap (overhead is one SELECT).
     if ($driver === 'sqlite') {
-        $sentinelPath = __DIR__ . '/data/.db_initialized';
-        $dbFilePath   = __DIR__ . '/data/ipam.sqlite';
+        // Honour a deployment's configured db_path so the sentinel check
+        // stats the real database file, not the default one. The sentinel
+        // itself lives next to the DB file so custom paths stay
+        // self-contained.
+        $dbPathRaw  = is_array($config ?? null) ? ($config['db_path'] ?? null) : null;
+        $dbFilePath = is_string($dbPathRaw) && $dbPathRaw !== ''
+            ? $dbPathRaw
+            : __DIR__ . '/data/ipam.sqlite';
+        $sentinelPath = dirname($dbFilePath) . '/.db_initialized';
         if (is_file($sentinelPath) && is_file($dbFilePath)) {
             $sentinelTime = (int)filemtime($sentinelPath);
             $dbTime       = (int)filemtime($dbFilePath);
@@ -289,9 +297,14 @@ function ipam_db_init(PDO $db): void
 
     // Write sentinel so subsequent requests skip bootstrap queries (SQLite
     // only — the sentinel is a filesystem optimisation for the local DB
-    // file and has no meaning on MySQL).
+    // file and has no meaning on MySQL). Location must match the path
+    // derived in the fast-path above: next to the resolved db_path file.
     if ($driver === 'sqlite') {
-        @touch(__DIR__ . '/data/.db_initialized');
+        $dbPathRaw  = is_array($config ?? null) ? ($config['db_path'] ?? null) : null;
+        $dbFilePath = is_string($dbPathRaw) && $dbPathRaw !== ''
+            ? $dbPathRaw
+            : __DIR__ . '/data/ipam.sqlite';
+        @touch(dirname($dbFilePath) . '/.db_initialized');
     }
 }
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -2,12 +2,13 @@
 declare(strict_types=1);
 
 /**
- * Returns the active SQL dialect (#378). init.php instantiates this once per
- * request and stows it under $GLOBALS['ipam_dialect']. v2.9.0 always returns
- * a SqliteDialect; v2.10.0+ may return Mysql/Pgsql variants based on
- * $config['db_driver']. Tests and CLI scripts that bootstrap lib.php
- * directly (without init.php) get a SqliteDialect lazily — this is the
- * v2.9.0 default and matches the only driver shipped this release.
+ * Returns the active SQL dialect (#378). ipam_db() bootstraps this once per
+ * request based on $config['db_driver'] and stows it under
+ * $GLOBALS['ipam_dialect']. v2.9.0 shipped SqliteDialect only; v2.10.0 adds
+ * MysqlDialect (#382); v2.11.0 adds PgsqlDialect (#386). Tests and CLI
+ * scripts that bootstrap lib.php directly (without going through ipam_db())
+ * get a SqliteDialect lazily — that is the historical default and matches
+ * what every test fixture expects.
  */
 function ipam_dialect(): Dialect
 {
@@ -17,6 +18,35 @@ function ipam_dialect(): Dialect
         $GLOBALS['ipam_dialect'] = new SqliteDialect();
     }
     return $GLOBALS['ipam_dialect'];
+}
+
+/**
+ * Select and cache the active dialect from a config array. Called by
+ * ipam_db() during connection bootstrap; safe to call standalone from
+ * tests that need to pin a specific dialect without opening a connection.
+ *
+ * @param array<string, mixed> $config
+ */
+function ipam_dialect_from_config(array $config): Dialect
+{
+    require_once __DIR__ . '/dialects/Dialect.php';
+    $driverRaw = $config['db_driver'] ?? 'sqlite';
+    $driver = is_string($driverRaw) ? $driverRaw : 'sqlite';
+    switch ($driver) {
+        case 'mysql':
+            require_once __DIR__ . '/dialects/MysqlDialect.php';
+            $dialect = new MysqlDialect();
+            break;
+        case 'sqlite':
+        case '':
+            require_once __DIR__ . '/dialects/SqliteDialect.php';
+            $dialect = new SqliteDialect();
+            break;
+        default:
+            throw new RuntimeException("Unsupported db_driver: $driver");
+    }
+    $GLOBALS['ipam_dialect'] = $dialect;
+    return $dialect;
 }
 
 /**
@@ -56,22 +86,77 @@ function ipam_bind_binary(PDOStatement $stmt, int|string $param, string $bin): v
     $stmt->bindValue($param, $bin, PDO::PARAM_LOB);
 }
 
-function ipam_db(string $path): PDO
+/**
+ * Open a PDO connection based on $config['db_driver'].
+ *
+ * Dispatcher for the multi-engine support introduced in v2.10.0. Picks the
+ * dialect first (so ipam_dialect() returns the right instance for the rest
+ * of the request), then connects to the selected engine.
+ *
+ * Supported drivers:
+ *   - 'sqlite' (default) — uses $config['db_path'] as the file path.
+ *   - 'mysql' (experimental, v2.10.0 #382) — uses $config['db_dsn'],
+ *     $config['db_user'], $config['db_pass']. Requires MySQL 8.0+.
+ *
+ * @param array<string, mixed> $config
+ */
+function ipam_db(array $config): PDO
 {
-    $dir = dirname($path);
-    if (!is_dir($dir)) {
-        mkdir($dir, 0700, true);
+    $dialect = ipam_dialect_from_config($config);
+
+    switch ($dialect->driver_name()) {
+        case 'sqlite':
+            $pathRaw = $config['db_path'] ?? '';
+            $path = is_string($pathRaw) ? $pathRaw : '';
+            if ($path === '') {
+                throw new RuntimeException('ipam_db: sqlite driver requires $config[\'db_path\']');
+            }
+            $dir = dirname($path);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0700, true);
+            }
+            $pdo = new PDO('sqlite:' . $path, null, null, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+            $pdo->exec("PRAGMA journal_mode = WAL;");
+            $pdo->exec("PRAGMA busy_timeout = 30000;");
+            break;
+
+        case 'mysql':
+            $dsnRaw  = $config['db_dsn']  ?? '';
+            $userRaw = $config['db_user'] ?? '';
+            $passRaw = $config['db_pass'] ?? '';
+            $dsn  = is_string($dsnRaw)  ? $dsnRaw  : '';
+            $user = is_string($userRaw) ? $userRaw : '';
+            $pass = is_string($passRaw) ? $passRaw : '';
+            if ($dsn === '') {
+                throw new RuntimeException('ipam_db: mysql driver requires $config[\'db_dsn\']');
+            }
+            $pdo = new PDO($dsn, $user, $pass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+            // MySQL 8.0 minimum. Versions before that lack utf8mb4 defaults,
+            // modern JSON support, and the looser InnoDB key prefix limit
+            // this project relies on. Rejecting at connect keeps bootstrap
+            // failures clear and immediate.
+            $serverVersionRaw = $pdo->getAttribute(PDO::ATTR_SERVER_VERSION);
+            $serverVersion = is_string($serverVersionRaw) ? $serverVersionRaw : '';
+            if ($serverVersion === '' || version_compare($serverVersion, '8.0.0', '<')) {
+                throw new RuntimeException(
+                    "MySQL 8.0+ is required (server reports '$serverVersion')"
+                );
+            }
+            break;
+
+        default:
+            throw new RuntimeException('ipam_db: unreachable — unsupported driver ' . $dialect->driver_name());
     }
 
-    $pdo = new PDO('sqlite:' . $path, null, null, [
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_EMULATE_PREPARES => false,
-    ]);
-
-    $pdo->exec("PRAGMA journal_mode = WAL;");
-    $pdo->exec("PRAGMA busy_timeout = 30000;");
-    $fk = ipam_dialect()->pragma_foreign_keys(true);
+    $fk = $dialect->pragma_foreign_keys(true);
     if ($fk !== null) {
         $pdo->exec($fk);
     }

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -200,29 +200,48 @@ function ensure_audit_log_table(PDO $db): void
 
 function ipam_db_init(PDO $db): void
 {
-    // Skip bootstrap checks if sentinel exists and DB file hasn't changed since
-    $sentinelPath = __DIR__ . '/data/.db_initialized';
-    $dbFilePath   = __DIR__ . '/data/ipam.sqlite';
-    if (is_file($sentinelPath) && is_file($dbFilePath)) {
-        $sentinelTime = (int)filemtime($sentinelPath);
-        $dbTime       = (int)filemtime($dbFilePath);
-        if ($sentinelTime >= $dbTime) {
-            ensure_migrations_table($db);
-            apply_migrations($db);
-            ensure_audit_log_table($db); // self-heal if table was dropped
-            return;
+    $driver = ipam_dialect()->driver_name();
+
+    // SQLite-only fast path: skip bootstrap checks if the sentinel file is
+    // at least as new as the SQLite DB file. MySQL has no local file to
+    // stat, so this optimisation does not apply there — the MySQL path
+    // runs the full check on every bootstrap (overhead is one SELECT).
+    if ($driver === 'sqlite') {
+        $sentinelPath = __DIR__ . '/data/.db_initialized';
+        $dbFilePath   = __DIR__ . '/data/ipam.sqlite';
+        if (is_file($sentinelPath) && is_file($dbFilePath)) {
+            $sentinelTime = (int)filemtime($sentinelPath);
+            $dbTime       = (int)filemtime($dbFilePath);
+            if ($sentinelTime >= $dbTime) {
+                ensure_migrations_table($db);
+                apply_migrations($db);
+                ensure_audit_log_table($db); // self-heal if table was dropped
+                return;
+            }
         }
     }
 
-    $st = $db->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='users'");
-    $st->execute();
-    $hasUsers = (bool)$st->fetch();
-    $st->closeCursor(); // Release WAL read mark — open cursors block DROP TABLE even on other tables
-    unset($st);
+    // Probe for the users table. Try a lightweight SELECT and catch the
+    // "table not found" error — works on every engine without needing
+    // sqlite_master / information_schema branching.
+    $hasUsers = false;
+    try {
+        $probe = $db->query("SELECT 1 FROM users LIMIT 1");
+        if ($probe !== false) {
+            $probe->closeCursor();
+            $hasUsers = true;
+        }
+    } catch (PDOException) {
+        $hasUsers = false;
+    }
 
     if (!$hasUsers) {
-        $schema = file_get_contents(__DIR__ . '/schema.sql');
-        if ($schema === false) throw new RuntimeException("Cannot read schema.sql");
+        $schemaFile = __DIR__ . '/schema.sql';
+        if ($driver === 'mysql') {
+            $schemaFile = __DIR__ . '/schema.mysql.sql';
+        }
+        $schema = file_get_contents($schemaFile);
+        if ($schema === false) throw new RuntimeException("Cannot read " . basename($schemaFile));
         $db->exec($schema);
 
         $config = require __DIR__ . '/config.php';
@@ -233,10 +252,14 @@ function ipam_db_init(PDO $db): void
         $ins = $db->prepare("INSERT INTO users (username, password_hash, role, is_active) VALUES (:u,:h,'admin',1)");
         $ins->execute([':u' => $u, ':h' => $hash]);
 
-        // Stamp all known migrations as already satisfied by the fresh schema
+        // Stamp all known migrations as already satisfied by the fresh schema.
+        // schema.mysql.sql already pre-seeds these rows so the INSERT below
+        // is a no-op on MySQL — upsert_or_ignore() makes that explicit and
+        // lets the same path work on every driver.
         ensure_migrations_table($db);
         require_once __DIR__ . '/migrations.php';
-        $stamp = $db->prepare("INSERT OR IGNORE INTO schema_migrations (version) VALUES (:v)");
+        $ignore = ipam_dialect()->upsert_or_ignore('schema_migrations', ['version']);
+        $stamp = $db->prepare("INSERT INTO schema_migrations (version) VALUES (:v) $ignore");
         foreach (array_keys(ipam_migrations()) as $ver) {
             $stamp->execute([':v' => $ver]);
         }
@@ -264,8 +287,12 @@ function ipam_db_init(PDO $db): void
         $ins->execute([':u' => $u, ':h' => $hash]);
     }
 
-    // Write sentinel so subsequent requests skip bootstrap queries
-    @touch($sentinelPath);
+    // Write sentinel so subsequent requests skip bootstrap queries (SQLite
+    // only — the sentinel is a filesystem optimisation for the local DB
+    // file and has no meaning on MySQL).
+    if ($driver === 'sqlite') {
+        @touch(__DIR__ . '/data/.db_initialized');
+    }
 }
 
 function e(string $s): string

--- a/Simple-PHP-IPAM/scan_run.php
+++ b/Simple-PHP-IPAM/scan_run.php
@@ -66,14 +66,22 @@ if ($methodOverride !== null && !in_array($methodOverride, ['icmp', 'tcp', 'both
 // Open the database
 // ---------------------------------------------------------------------------
 /** @var array<string, mixed> $config */
-$dbPath = isset($config['db_path']) && to_str($config['db_path']) !== ''
-    ? to_str($config['db_path'])
-    : $scriptDir . '/data/ipam.sqlite';
-if (!file_exists($dbPath)) {
-    fwrite(STDERR, "Error: database not found at $dbPath\n");
-    exit(1);
+// Default db_path for legacy configs that omit it, then sanity-check the
+// file on SQLite only (MySQL has no local path to check).
+$driverRaw = $config['db_driver'] ?? 'sqlite';
+$driver = is_string($driverRaw) ? $driverRaw : 'sqlite';
+if ($driver === 'sqlite' || $driver === '') {
+    $dbPathRaw = $config['db_path'] ?? '';
+    $dbPath = is_string($dbPathRaw) && $dbPathRaw !== ''
+        ? $dbPathRaw
+        : $scriptDir . '/data/ipam.sqlite';
+    $config['db_path'] = $dbPath;
+    if (!file_exists($dbPath)) {
+        fwrite(STDERR, "Error: database not found at $dbPath\n");
+        exit(1);
+    }
 }
-$db = ipam_db($dbPath);
+$db = ipam_db($config);
 
 // ---------------------------------------------------------------------------
 // Gather subnets to scan

--- a/Simple-PHP-IPAM/schema.mysql.sql
+++ b/Simple-PHP-IPAM/schema.mysql.sql
@@ -1,0 +1,482 @@
+-- schema.mysql.sql (v2.10.0 #383)
+--
+-- MySQL 8.0+ authoritative schema for fresh installs. Equivalent to the
+-- fully-migrated state of schema.sql (SQLite) + every v1.x/v2.x migration
+-- through v2.9.0-blob-affinity. Migration replay on top of this file is a
+-- no-op because schema_migrations is pre-populated with every historical
+-- version row at the bottom of this script.
+--
+-- Engine / charset conventions:
+--   - InnoDB on every table (explicit, not default-inherited)
+--   - utf8mb4 / utf8mb4_general_ci by default; individual columns use
+--     utf8mb4_bin for case-sensitive byte-wise comparison (usernames,
+--     CIDRs, hostnames, IPs) to match SQLite's default BINARY collation
+--   - VARBINARY(16) for ip_bin / network_bin, native length (4 bytes for
+--     IPv4, 16 bytes for IPv6, never left-padded). Locked in #410.
+--   - BIGINT UNSIGNED NOT NULL AUTO_INCREMENT for surrogate primary keys;
+--     FK columns referencing those use the matching BIGINT UNSIGNED type
+--   - DATETIME columns default to (UTC_TIMESTAMP()) so stored values are
+--     UTC regardless of session timezone, matching SQLite's datetime('now')
+--   - Append-only tables (audit_log) enforced via BEFORE UPDATE/DELETE
+--     triggers using SIGNAL SQLSTATE '45000' (MySQL 8.0.22+)
+--   - *_updated_at triggers use BEFORE UPDATE FOR EACH ROW SET NEW.updated_at
+--     which is the idiomatic MySQL form; SQLite's AFTER UPDATE + recursive
+--     UPDATE is a workaround that is not needed here.
+--   - CHECK constraints honoured starting MySQL 8.0.16; v2.10.0 effective
+--     minimum is 8.0.22 so all CHECKs are active
+--   - oidc_sub uniqueness: MySQL UNIQUE treats NULLs as distinct so a
+--     plain UNIQUE KEY allows multiple NULLs without the partial-index
+--     trick SQLite uses
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ---------------------------------------------------------------------------
+-- users
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS users (
+  id                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  username            VARCHAR(191) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  password_hash       VARCHAR(255) NOT NULL,
+  role                VARCHAR(20)  NOT NULL DEFAULT 'admin',
+  is_active           TINYINT      NOT NULL DEFAULT 1,
+  name                VARCHAR(255) NOT NULL DEFAULT '',
+  email               VARCHAR(255) NOT NULL DEFAULT '',
+  oidc_sub            VARCHAR(191) COLLATE utf8mb4_bin NULL,
+  last_login_at       DATETIME NULL,
+  password_changed_at DATETIME NULL,
+  theme               VARCHAR(10)  NOT NULL DEFAULT 'auto',
+  created_at          DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at          DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY idx_users_oidc_sub (oidc_sub),
+  CONSTRAINT users_role_check  CHECK (role IN ('admin','readonly')),
+  CONSTRAINT users_theme_check CHECK (theme IN ('auto','light','dark'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS users_updated_at
+  BEFORE UPDATE ON users FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- ---------------------------------------------------------------------------
+-- sites (hierarchy supported via parent_id self-FK)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS sites (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name        VARCHAR(191) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  description TEXT NOT NULL,
+  parent_id   BIGINT UNSIGNED NULL,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_sites_parent_id (parent_id),
+  CONSTRAINT fk_sites_parent FOREIGN KEY (parent_id) REFERENCES sites(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- vrfs (Virtual Routing and Forwarding)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS vrfs (
+  id             BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name           VARCHAR(191) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  description    TEXT NOT NULL,
+  rd             VARCHAR(191) NOT NULL DEFAULT '',
+  asn            VARCHAR(64)  NOT NULL DEFAULT '',
+  rt_import      VARCHAR(191) NOT NULL DEFAULT '',
+  rt_export      VARCHAR(191) NOT NULL DEFAULT '',
+  enforce_unique TINYINT      NOT NULL DEFAULT 1,
+  created_at     DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at     DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_vrfs_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS vrfs_updated_at
+  BEFORE UPDATE ON vrfs FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- ---------------------------------------------------------------------------
+-- vlans (first-class 802.1Q VLAN objects)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS vlans (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  vlan_id     INT             NOT NULL,
+  name        VARCHAR(191)    NOT NULL,
+  description TEXT            NOT NULL,
+  site_id     BIGINT UNSIGNED NULL,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY uq_vlans_vlan_id_site_id (vlan_id, site_id),
+  CONSTRAINT vlans_vlan_id_range CHECK (vlan_id BETWEEN 1 AND 4094),
+  CONSTRAINT fk_vlans_site FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS vlans_updated_at
+  BEFORE UPDATE ON vlans FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- Clear legacy subnets.vlan_id when the backing VLAN row is deleted.
+CREATE TRIGGER IF NOT EXISTS vlans_before_delete_cleanup_subnets
+  BEFORE DELETE ON vlans FOR EACH ROW
+  UPDATE subnets SET vlan_id = NULL WHERE vlan_fk = OLD.id;
+
+-- ---------------------------------------------------------------------------
+-- vlan_ranges (v2.4.0)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS vlan_ranges (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name        VARCHAR(191)    NOT NULL,
+  vlan_min    INT             NOT NULL,
+  vlan_max    INT             NOT NULL,
+  description TEXT            NOT NULL,
+  site_id     BIGINT UNSIGNED NULL,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  CONSTRAINT vlan_ranges_min_range CHECK (vlan_min BETWEEN 1 AND 4094),
+  CONSTRAINT vlan_ranges_max_range CHECK (vlan_max BETWEEN 1 AND 4094),
+  CONSTRAINT vlan_ranges_order     CHECK (vlan_min <= vlan_max),
+  CONSTRAINT fk_vlan_ranges_site FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- subnets
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS subnets (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  cidr        VARCHAR(64)  COLLATE utf8mb4_bin NOT NULL,
+  ip_version  TINYINT      NOT NULL,
+  network     VARCHAR(45)  COLLATE utf8mb4_bin NOT NULL,
+  network_bin VARBINARY(16) NOT NULL,
+  prefix      SMALLINT     NOT NULL,
+  description TEXT         NOT NULL,
+  notes       TEXT         NOT NULL,
+  site_id     BIGINT UNSIGNED NULL,
+  vlan_id     INT          NULL,
+  vlan_fk     BIGINT UNSIGNED NULL,
+  vrf_id      BIGINT UNSIGNED NULL,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY uq_subnets_cidr_vrf (cidr, vrf_id),
+  KEY idx_subnets_ver_prefix_netbin (ip_version, prefix, network_bin),
+  KEY idx_subnets_site_id (site_id),
+  KEY idx_subnets_vrf_id (vrf_id),
+  KEY idx_subnets_vlan_fk (vlan_fk),
+  CONSTRAINT fk_subnets_site FOREIGN KEY (site_id) REFERENCES sites(id) ON DELETE SET NULL,
+  CONSTRAINT fk_subnets_vlan FOREIGN KEY (vlan_fk) REFERENCES vlans(id) ON DELETE SET NULL,
+  CONSTRAINT fk_subnets_vrf  FOREIGN KEY (vrf_id)  REFERENCES vrfs(id)  ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS subnets_updated_at
+  BEFORE UPDATE ON subnets FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- ---------------------------------------------------------------------------
+-- contacts (v2.1.0, first-class contact objects)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS contacts (
+  id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name       VARCHAR(191) NOT NULL,
+  email      VARCHAR(255) NOT NULL DEFAULT '',
+  phone      VARCHAR(64)  NOT NULL DEFAULT '',
+  org        VARCHAR(191) NOT NULL DEFAULT '',
+  note       TEXT         NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_contacts_name  (name),
+  KEY idx_contacts_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS contacts_updated_at
+  BEFORE UPDATE ON contacts FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- ---------------------------------------------------------------------------
+-- addresses (individual IPs)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS addresses (
+  id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  subnet_id        BIGINT UNSIGNED NOT NULL,
+  ip               VARCHAR(45)  COLLATE utf8mb4_bin NOT NULL,
+  ip_bin           VARBINARY(16) NOT NULL,
+  hostname         VARCHAR(255) COLLATE utf8mb4_bin NOT NULL DEFAULT '',
+  owner            VARCHAR(191) NOT NULL DEFAULT '',
+  note             TEXT         NOT NULL,
+  grp              VARCHAR(191) NOT NULL DEFAULT '',
+  mac              VARCHAR(32)  NOT NULL DEFAULT '',
+  expires_at       DATE         NULL,
+  status           VARCHAR(20)  NOT NULL DEFAULT 'used',
+  owner_contact_id BIGINT UNSIGNED NULL,
+  last_seen_at     DATETIME     NULL,
+  is_stale         TINYINT      NOT NULL DEFAULT 0,
+  created_at       DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at       DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY uq_addresses_subnet_ip (subnet_id, ip),
+  KEY idx_addresses_subnet_ipbin (subnet_id, ip_bin),
+  KEY idx_addresses_hostname (hostname),
+  KEY idx_addresses_owner (owner),
+  KEY idx_addresses_status (status),
+  KEY idx_addresses_grp (grp),
+  KEY idx_addresses_owner_contact_id (owner_contact_id),
+  KEY idx_addresses_is_stale (is_stale),
+  CONSTRAINT fk_addresses_subnet  FOREIGN KEY (subnet_id)        REFERENCES subnets(id)  ON DELETE CASCADE,
+  CONSTRAINT fk_addresses_contact FOREIGN KEY (owner_contact_id) REFERENCES contacts(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS addresses_updated_at
+  BEFORE UPDATE ON addresses FOR EACH ROW
+  SET NEW.updated_at = UTC_TIMESTAMP();
+
+-- ---------------------------------------------------------------------------
+-- address_history (per-address change log)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS address_history (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  address_id  BIGINT UNSIGNED NULL,
+  subnet_id   BIGINT UNSIGNED NOT NULL,
+  ip          VARCHAR(45)  NOT NULL,
+  action      VARCHAR(64)  NOT NULL,
+  user_id     BIGINT UNSIGNED NULL,
+  username    VARCHAR(191) NULL,
+  client_ip   VARCHAR(45)  NULL,
+  user_agent  VARCHAR(512) NULL,
+  before_json TEXT         NULL,
+  after_json  TEXT         NULL,
+  KEY idx_address_history_address_id (address_id),
+  KEY idx_address_history_subnet_id  (subnet_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- audit_log (append-only, enforced by SIGNAL triggers)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audit_log (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  user_id     BIGINT UNSIGNED NULL,
+  username    VARCHAR(191) NULL,
+  action      VARCHAR(191) NOT NULL,
+  entity_type VARCHAR(64)  NOT NULL,
+  entity_id   BIGINT UNSIGNED NULL,
+  ip          VARCHAR(45)  NULL,
+  user_agent  VARCHAR(512) NULL,
+  details     TEXT         NULL,
+  KEY idx_audit_log_action     (action),
+  KEY idx_audit_log_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TRIGGER IF NOT EXISTS audit_log_no_update
+  BEFORE UPDATE ON audit_log FOR EACH ROW
+  SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'audit_log is append-only', MYSQL_ERRNO = 1644;
+
+CREATE TRIGGER IF NOT EXISTS audit_log_no_delete
+  BEFORE DELETE ON audit_log FOR EACH ROW
+  SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'audit_log is append-only', MYSQL_ERRNO = 1644;
+
+-- ---------------------------------------------------------------------------
+-- login_attempts (rate limiter)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS login_attempts (
+  id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  ip           VARCHAR(45) NOT NULL,
+  attempted_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_login_attempts_ip_time (ip, attempted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- api_keys
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS api_keys (
+  id           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name         VARCHAR(191) NOT NULL,
+  key_hash     VARCHAR(191) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  created_at   DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  last_used_at DATETIME NULL,
+  is_active    TINYINT      NOT NULL DEFAULT 1,
+  created_by   VARCHAR(191) NOT NULL DEFAULT '',
+  is_readonly  TINYINT      NOT NULL DEFAULT 0,
+  description  TEXT         NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- tags (v2.0.0)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tags (
+  id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name       VARCHAR(50) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  colour     VARCHAR(20) NOT NULL DEFAULT '#6c757d',
+  created_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP())
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS subnet_tags (
+  subnet_id BIGINT UNSIGNED NOT NULL,
+  tag_id    BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY (subnet_id, tag_id),
+  KEY idx_subnet_tags_tag (tag_id),
+  CONSTRAINT fk_subnet_tags_subnet FOREIGN KEY (subnet_id) REFERENCES subnets(id) ON DELETE CASCADE,
+  CONSTRAINT fk_subnet_tags_tag    FOREIGN KEY (tag_id)    REFERENCES tags(id)    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS address_tags (
+  address_id BIGINT UNSIGNED NOT NULL,
+  tag_id     BIGINT UNSIGNED NOT NULL,
+  PRIMARY KEY (address_id, tag_id),
+  KEY idx_address_tags_tag (tag_id),
+  CONSTRAINT fk_address_tags_address FOREIGN KEY (address_id) REFERENCES addresses(id) ON DELETE CASCADE,
+  CONSTRAINT fk_address_tags_tag     FOREIGN KEY (tag_id)     REFERENCES tags(id)      ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- alert_state (utilization alert tracker, v2.0.0)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alert_state (
+  subnet_id       BIGINT UNSIGNED NOT NULL,
+  level           VARCHAR(10) NOT NULL,
+  last_alerted_at DATETIME    NOT NULL,
+  PRIMARY KEY (subnet_id, level),
+  CONSTRAINT alert_state_level_check CHECK (level IN ('warn','crit')),
+  CONSTRAINT fk_alert_state_subnet FOREIGN KEY (subnet_id) REFERENCES subnets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- aggregates (v2.4.0, RIR-assigned supernet tracking)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS aggregates (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  cidr        VARCHAR(64) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  ip_version  TINYINT     NOT NULL,
+  network     VARCHAR(45) COLLATE utf8mb4_bin NOT NULL,
+  network_bin VARBINARY(16) NOT NULL,
+  prefix      SMALLINT    NOT NULL,
+  description TEXT        NOT NULL,
+  rir         VARCHAR(32) NOT NULL DEFAULT '',
+  date_added  DATE        NOT NULL DEFAULT (CURRENT_DATE()),
+  notes       TEXT        NOT NULL,
+  created_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP())
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- pd_pools + pd_delegations (v2.4.0, IPv6 Prefix Delegation)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pd_pools (
+  id                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  parent_subnet_id  BIGINT UNSIGNED NOT NULL,
+  delegation_prefix SMALLINT NOT NULL,
+  description       TEXT NOT NULL,
+  site_id           BIGINT UNSIGNED NULL,
+  created_at        DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at        DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY uq_pd_pools_parent_subnet (parent_subnet_id),
+  CONSTRAINT pd_pools_prefix_range CHECK (delegation_prefix BETWEEN 1 AND 128),
+  CONSTRAINT fk_pd_pools_parent FOREIGN KEY (parent_subnet_id) REFERENCES subnets(id) ON DELETE CASCADE,
+  CONSTRAINT fk_pd_pools_site   FOREIGN KEY (site_id)          REFERENCES sites(id)   ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS pd_delegations (
+  id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  pool_id       BIGINT UNSIGNED NOT NULL,
+  cidr          VARCHAR(64) COLLATE utf8mb4_bin NOT NULL,
+  subscriber_id BIGINT UNSIGNED NULL,
+  delegated_at  DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  expires_at    DATETIME NULL,
+  notes         TEXT     NOT NULL,
+  created_at    DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_pd_delegations_pool       (pool_id),
+  KEY idx_pd_delegations_subscriber (subscriber_id),
+  CONSTRAINT fk_pd_delegations_pool FOREIGN KEY (pool_id)       REFERENCES pd_pools(id) ON DELETE CASCADE,
+  CONSTRAINT fk_pd_delegations_sub  FOREIGN KEY (subscriber_id) REFERENCES contacts(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- scan_schedules + scan_results (v2.3.0, network scanning)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS scan_schedules (
+  id               BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  subnet_id        BIGINT UNSIGNED NOT NULL,
+  method           VARCHAR(10) NOT NULL DEFAULT 'icmp',
+  tcp_port         INT     NULL,
+  interval_minutes INT     NOT NULL DEFAULT 60,
+  is_active        TINYINT NOT NULL DEFAULT 1,
+  last_run_at      DATETIME NULL,
+  created_at       DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at       DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  UNIQUE KEY uq_scan_schedules_subnet (subnet_id),
+  KEY idx_scan_schedules_active (is_active, last_run_at),
+  CONSTRAINT scan_schedules_method   CHECK (method IN ('icmp','tcp','both')),
+  CONSTRAINT scan_schedules_tcp_port CHECK (tcp_port IS NULL OR (tcp_port BETWEEN 1 AND 65535)),
+  CONSTRAINT scan_schedules_interval CHECK (interval_minutes >= 1),
+  CONSTRAINT fk_scan_schedules_subnet FOREIGN KEY (subnet_id) REFERENCES subnets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS scan_results (
+  id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  subnet_id  BIGINT UNSIGNED NOT NULL,
+  address_id BIGINT UNSIGNED NULL,
+  ip         VARCHAR(45) NOT NULL,
+  method     VARCHAR(10) NOT NULL,
+  is_up      TINYINT     NOT NULL DEFAULT 0,
+  latency_ms INT         NULL,
+  scanned_at DATETIME    NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  KEY idx_scan_results_subnet_time (subnet_id, scanned_at),
+  KEY idx_scan_results_address     (address_id, scanned_at),
+  CONSTRAINT fk_scan_results_subnet  FOREIGN KEY (subnet_id)  REFERENCES subnets(id)   ON DELETE CASCADE,
+  CONSTRAINT fk_scan_results_address FOREIGN KEY (address_id) REFERENCES addresses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- schema_migrations (pre-seeded below with every historical version)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  id         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  version    VARCHAR(64) COLLATE utf8mb4_bin NOT NULL UNIQUE,
+  applied_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP())
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- settings (v2.6.0, key/value config registry)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS settings (
+  `key`      VARCHAR(191) COLLATE utf8mb4_bin NOT NULL PRIMARY KEY,
+  value      TEXT NULL,
+  type       VARCHAR(16) NOT NULL DEFAULT 'string',
+  updated_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_by BIGINT UNSIGNED NULL,
+  CONSTRAINT settings_type_check CHECK (type IN ('string','int','bool','json')),
+  CONSTRAINT fk_settings_updated_by FOREIGN KEY (updated_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ---------------------------------------------------------------------------
+-- Pre-seed schema_migrations with every historical version so apply_migrations
+-- is a no-op on fresh MySQL installs. New migrations added in v2.10.0+ must
+-- be idempotent and safe to run on MySQL, since they WILL execute here.
+--
+-- Locked in #484 scope decision (2026-04-15): historical SQLite-only
+-- migration closures are not refactored for multi-engine; this pre-seed is
+-- how we keep them out of the MySQL execution path.
+-- ---------------------------------------------------------------------------
+INSERT INTO schema_migrations (version) VALUES
+  ('0.3'),
+  ('0.7'),
+  ('0.9'),
+  ('0.11'),
+  ('0.12'),
+  ('0.13'),
+  ('0.14'),
+  ('1.4'),
+  ('1.9'),
+  ('1.11'),
+  ('1.12'),
+  ('1.13'),
+  ('1.19.0'),
+  ('2.0.0-vlans'),
+  ('2.0.0-site-hierarchy'),
+  ('2.0.0-tags'),
+  ('2.0.0-alert-state'),
+  ('2.1.0-vrfs'),
+  ('2.1.0-contacts'),
+  ('2.3.0-scanning'),
+  ('2.4.0-vrf-bgp'),
+  ('2.4.0-vlan-ranges'),
+  ('2.4.0-aggregates'),
+  ('2.4.0-pd-pools'),
+  ('2.6.0-settings'),
+  ('2.8.0-subnet-notes'),
+  ('2.8.0-alert-recipients'),
+  ('2.9.0-blob-affinity');
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/Simple-PHP-IPAM/status.php
+++ b/Simple-PHP-IPAM/status.php
@@ -20,7 +20,7 @@ require __DIR__ . '/version.php';
 $dbOk = false;
 $schemaVersion = null;
 try {
-    $pdo = ipam_db(to_str($config['db_path']));
+    $pdo = ipam_db($config);
     ($pdo->query('SELECT 1') ?: throw new \RuntimeException('Query failed'))->fetch();
     $dbOk = true;
     /** @var array<string, mixed>|false $row */

--- a/tests/DialectTest.php
+++ b/tests/DialectTest.php
@@ -29,6 +29,35 @@ final class DialectTest extends TestCase
         $this->assertSame('sqlite', $this->sqlite->driver_name());
     }
 
+    public function testDialectFromConfigDefaultsToSqlite(): void
+    {
+        require_once dirname(__DIR__) . '/Simple-PHP-IPAM/lib.php';
+        $this->assertInstanceOf(SqliteDialect::class, ipam_dialect_from_config([]));
+        $this->assertInstanceOf(SqliteDialect::class, ipam_dialect_from_config(['db_driver' => 'sqlite']));
+        $this->assertInstanceOf(SqliteDialect::class, ipam_dialect_from_config(['db_driver' => '']));
+    }
+
+    public function testDialectFromConfigSelectsMysql(): void
+    {
+        require_once dirname(__DIR__) . '/Simple-PHP-IPAM/lib.php';
+        require_once dirname(__DIR__) . '/Simple-PHP-IPAM/dialects/MysqlDialect.php';
+        $this->assertInstanceOf(MysqlDialect::class, ipam_dialect_from_config(['db_driver' => 'mysql']));
+    }
+
+    public function testDialectFromConfigRejectsUnknownDriver(): void
+    {
+        require_once dirname(__DIR__) . '/Simple-PHP-IPAM/lib.php';
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unsupported db_driver: oracle');
+        ipam_dialect_from_config(['db_driver' => 'oracle']);
+    }
+
+    protected function tearDown(): void
+    {
+        // Reset the cached dialect so later tests get a fresh SqliteDialect.
+        unset($GLOBALS['ipam_dialect']);
+    }
+
     public function testNowReturnsSqliteDatetimeExpression(): void
     {
         $this->assertSame("datetime('now')", $this->sqlite->now());

--- a/tests/MysqlDialectTest.php
+++ b/tests/MysqlDialectTest.php
@@ -160,6 +160,11 @@ final class MysqlDialectTest extends TestCase
             $this->assertStringContainsString("SIGNAL SQLSTATE '45000'", $stmt);
             $this->assertStringContainsString("audit_log is append-only", $stmt);
             $this->assertStringContainsString("FOR EACH ROW", $stmt);
+            // Single-statement body, no BEGIN/END wrapping — important so
+            // PDO::exec() can dispatch each CREATE TRIGGER as one statement
+            // without any multi-statement parsing concerns.
+            $this->assertStringNotContainsString('BEGIN', $stmt);
+            $this->assertStringNotContainsString('END', $stmt);
         }
     }
 

--- a/tests/MysqlDialectTest.php
+++ b/tests/MysqlDialectTest.php
@@ -1,0 +1,193 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__) . '/Simple-PHP-IPAM/dialects/Dialect.php';
+require_once dirname(__DIR__) . '/Simple-PHP-IPAM/dialects/MysqlDialect.php';
+
+/**
+ * Unit tests for MysqlDialect (#382).
+ *
+ * Pure string-output tests. These do NOT require a running MySQL server —
+ * every assertion is against the exact SQL fragment MysqlDialect emits,
+ * which is deterministic and stateless. End-to-end DDL validation against
+ * a real MySQL 8.0 service container is wired up by #384 (per-commit CI
+ * job) and #433 (nightly Playwright MySQL matrix).
+ *
+ * Structure mirrors DialectTest so that when a new interface method is
+ * added, both files get the parallel coverage.
+ */
+final class MysqlDialectTest extends TestCase
+{
+    private MysqlDialect $mysql;
+
+    protected function setUp(): void
+    {
+        $this->mysql = new MysqlDialect();
+    }
+
+    public function testDriverNameIsMysql(): void
+    {
+        $this->assertSame('mysql', $this->mysql->driver_name());
+    }
+
+    public function testNowReturnsUtcTimestamp(): void
+    {
+        // UTC_TIMESTAMP() is always UTC regardless of session timezone,
+        // matching SQLite's datetime('now') semantics. NOW() would drift
+        // across servers and must not be used.
+        $this->assertSame('UTC_TIMESTAMP()', $this->mysql->now());
+    }
+
+    public function testAutoincrementIsBigintUnsigned(): void
+    {
+        $this->assertSame(
+            'BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY',
+            $this->mysql->autoincrement()
+        );
+    }
+
+    public function testIndexedTextTypeDefaultsTo191(): void
+    {
+        // 191 fits the 767-byte historical InnoDB key prefix under utf8mb4
+        // (191 * 4 = 764 bytes). Anything larger needs innodb_large_prefix
+        // which v2.10.0 does not require.
+        $this->assertSame('VARCHAR(191)', $this->mysql->indexed_text_type());
+    }
+
+    public function testIndexedTextTypeAcceptsCustomLength(): void
+    {
+        $this->assertSame('VARCHAR(255)', $this->mysql->indexed_text_type(255));
+        $this->assertSame('VARCHAR(64)', $this->mysql->indexed_text_type(64));
+    }
+
+    public function testBinaryTypeUsesVarbinaryWithLength(): void
+    {
+        $this->assertSame('VARBINARY(16)', $this->mysql->binary_type(16));
+        $this->assertSame('VARBINARY(4)', $this->mysql->binary_type(4));
+    }
+
+    public function testCaseSensitiveCollationIsUtf8mb4Bin(): void
+    {
+        // utf8mb4_bin is byte-wise comparison, matching SQLite's default
+        // BINARY collation. Cross-engine string equality checks (usernames,
+        // CIDRs, hostnames) stay consistent with SQLite.
+        $this->assertSame('COLLATE utf8mb4_bin', $this->mysql->case_sensitive_collation());
+    }
+
+    public function testPragmaForeignKeysOn(): void
+    {
+        // MySQL uses SET FOREIGN_KEY_CHECKS = 1 session-level. Same semantics
+        // as SQLite's PRAGMA foreign_keys toggle.
+        $this->assertSame('SET FOREIGN_KEY_CHECKS = 1', $this->mysql->pragma_foreign_keys(true));
+    }
+
+    public function testPragmaForeignKeysOff(): void
+    {
+        $this->assertSame('SET FOREIGN_KEY_CHECKS = 0', $this->mysql->pragma_foreign_keys(false));
+    }
+
+    public function testUpsertSingleConflictColumn(): void
+    {
+        // On MySQL ON DUPLICATE KEY UPDATE references VALUES(col). The
+        // conflict column list is ignored by the server (MySQL scopes on
+        // any unique key hit) but the caller still passes it so the same
+        // call site compiles on SQLite and Postgres unchanged.
+        $sql = $this->mysql->upsert('users', ['username'], ['email', 'updated_at']);
+        $this->assertSame(
+            'ON DUPLICATE KEY UPDATE email = VALUES(email), updated_at = VALUES(updated_at)',
+            $sql
+        );
+    }
+
+    public function testUpsertCompositeConflictColumns(): void
+    {
+        $sql = $this->mysql->upsert('subnet_tags', ['subnet_id', 'tag_id'], ['created_at']);
+        $this->assertSame(
+            'ON DUPLICATE KEY UPDATE created_at = VALUES(created_at)',
+            $sql
+        );
+    }
+
+    public function testUpsertRequiresAtLeastOneConflictColumn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mysql->upsert('users', [], ['email']);
+    }
+
+    public function testUpsertRequiresAtLeastOneUpdateColumn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mysql->upsert('users', ['username'], []);
+    }
+
+    public function testUpsertOrIgnoreUsesFirstConflictColumnAsNoopAssign(): void
+    {
+        // ON DUPLICATE KEY UPDATE col = col is MySQL's idiom for "leave
+        // existing row alone on conflict" — the self-assign is a no-op.
+        $sql = $this->mysql->upsert_or_ignore('settings', ['key']);
+        $this->assertSame('ON DUPLICATE KEY UPDATE key = key', $sql);
+    }
+
+    public function testUpsertOrIgnoreCompositeStillUsesFirstColumn(): void
+    {
+        // MySQL's ON DUPLICATE KEY UPDATE is not scoped to a specific
+        // conflict target anyway, so we only need any one column to form
+        // the self-assign. First conflict column is the stable choice.
+        $sql = $this->mysql->upsert_or_ignore('subnet_tags', ['subnet_id', 'tag_id']);
+        $this->assertSame('ON DUPLICATE KEY UPDATE subnet_id = subnet_id', $sql);
+    }
+
+    public function testUpsertOrIgnoreRequiresAtLeastOneConflictColumn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->mysql->upsert_or_ignore('settings', []);
+    }
+
+    public function testAppendOnlyTriggerReturnsExactlyTwoStatements(): void
+    {
+        // Two BEFORE triggers (UPDATE, DELETE), matching the SQLite shape.
+        $stmts = $this->mysql->append_only_trigger('audit_log');
+        $this->assertCount(2, $stmts);
+    }
+
+    public function testAppendOnlyTriggerUsesSignalSqlstate(): void
+    {
+        $stmts = $this->mysql->append_only_trigger('audit_log');
+        foreach ($stmts as $stmt) {
+            $this->assertStringContainsString('audit_log', $stmt);
+            $this->assertStringContainsString("SIGNAL SQLSTATE '45000'", $stmt);
+            $this->assertStringContainsString("audit_log is append-only", $stmt);
+            $this->assertStringContainsString("FOR EACH ROW", $stmt);
+        }
+    }
+
+    public function testAppendOnlyTriggerCoversBothUpdateAndDelete(): void
+    {
+        $stmts = $this->mysql->append_only_trigger('audit_log');
+        $joined = implode("\n", $stmts);
+        $this->assertStringContainsString('BEFORE UPDATE', $joined);
+        $this->assertStringContainsString('BEFORE DELETE', $joined);
+    }
+
+    public function testAppendOnlyTriggerStatementsAreIdempotent(): void
+    {
+        // CREATE TRIGGER IF NOT EXISTS is supported on MySQL 8.0.22+, which
+        // v2.10.0 effectively targets (the bootstrap path calls the
+        // self-heal on every request).
+        $stmts = $this->mysql->append_only_trigger('audit_log');
+        foreach ($stmts as $stmt) {
+            $this->assertStringContainsString('IF NOT EXISTS', $stmt);
+        }
+    }
+
+    public function testAppendOnlyTriggerEmbedsGivenTableName(): void
+    {
+        $stmts = $this->mysql->append_only_trigger('some_other_table');
+        foreach ($stmts as $stmt) {
+            $this->assertStringContainsString('some_other_table', $stmt);
+            $this->assertStringNotContainsString('audit_log', $stmt);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**First non-SQLite driver.** Experimental MySQL 8.0+ support gated on \`\$config['db_driver'] = 'mysql'\`. Default stays SQLite; for SQLite installs this PR is a pure addition with zero behaviour change.

This PR bundles both Phase B issues because they are tightly coupled — \`MysqlDialect\` alone does nothing without \`schema.mysql.sql\`, and vice versa. Validated **end-to-end against MySQL 8.0.45** (\`mysql:8.0\` docker container) before opening.

## Closes

- #382 — Implement \`MysqlDialect\` and wire up \`db_driver=mysql\`
- #383 — Author \`schema.mysql.sql\` and installer wiring

## What's in the box

### \`Simple-PHP-IPAM/dialects/MysqlDialect.php\` (new)
Implements every method on the \`Dialect\` interface:
| Method | MySQL output |
|---|---|
| \`now()\` | \`UTC_TIMESTAMP()\` (UTC-safe, avoids \`NOW()\` session drift) |
| \`upsert()\` | \`INSERT … ON DUPLICATE KEY UPDATE col = VALUES(col)\` |
| \`upsert_or_ignore()\` | \`ON DUPLICATE KEY UPDATE firstCol = firstCol\` |
| \`autoincrement()\` | \`BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY\` |
| \`indexed_text_type(191)\` | \`VARCHAR(191)\` (764 bytes ≤ 767-byte InnoDB prefix under utf8mb4) |
| \`binary_type(16)\` | \`VARBINARY(16)\` (native length) |
| \`case_sensitive_collation()\` | \`COLLATE utf8mb4_bin\` (narrowed return to \`string\`) |
| \`append_only_trigger(t)\` | Two \`BEFORE UPDATE/DELETE\` triggers using \`SIGNAL SQLSTATE '45000'\`, **single-statement** (no \`BEGIN/END\` — \`PDO::exec()\`-safe), \`IF NOT EXISTS\` (requires MySQL 8.0.22+) |
| \`pragma_foreign_keys(bool)\` | \`SET FOREIGN_KEY_CHECKS = 1|0\` |

### \`Simple-PHP-IPAM/schema.mysql.sql\` (new, 19 tables)
Authoritative MySQL schema mirroring the fully-migrated state of \`schema.sql\` + every v1.x/v2.x migration through \`2.9.0-blob-affinity\`. Conventions match \`MysqlDialect\` exactly. Ends with a \`INSERT INTO schema_migrations\` that **pre-seeds all 28 historical versions** so \`apply_migrations()\` is a no-op on fresh MySQL installs (locked in #484 scope decision).

### \`lib.php\` dispatcher changes
- \`ipam_dialect_from_config(array \$config): Dialect\` — selects & caches dialect from \`db_driver\`, throws on unknown driver
- \`ipam_db()\` signature changed from \`(string \$path)\` to \`(array \$config)\`; branches on driver:
  - \`sqlite\`: uses \`db_path\`, existing behaviour
  - \`mysql\`: uses \`db_dsn|db_user|db_pass\`, **rejects MySQL < 8.0** with clear error via \`PDO::ATTR_SERVER_VERSION\`
- \`ipam_db_init()\` driver-aware:
  - SQLite: sentinel fast-path unchanged
  - MySQL: skips sentinel (no local file)
  - Users-table probe: \`try/catch SELECT 1 FROM users LIMIT 1\` — driver-agnostic, replaces \`sqlite_master\` query
  - Schema file dispatched: \`schema.sql\` on SQLite, \`schema.mysql.sql\` on MySQL
  - **Bug fix:** fresh-install migration stamping used \`INSERT OR IGNORE\` (SQLite-only). Routed through \`Dialect::upsert_or_ignore()\` — discovered during E2E test.

### 7 caller updates
\`init.php\`, \`api.php\`, \`cron.php\`, \`status.php\`, \`demo_seed.php\`, \`demo_reset.php\`, \`scan_run.php\` now pass \`\$config\` instead of \`to_str(\$config['db_path'])\`. \`scan_run.php\`'s SQLite file-exists sanity check is guarded on driver name.

### Tests
- \`tests/MysqlDialectTest.php\` (new) — **20 pure string-output tests** covering every \`Dialect\` method. No running MySQL required.
- \`tests/DialectTest.php\` — 4 new tests for \`ipam_dialect_from_config()\` default/mysql/unknown paths + \`tearDown\` reset.

## End-to-end validation against MySQL 8.0.45

Not in CI yet (#384 will wire that up). Verified locally against a fresh \`mysql:8.0\` docker container:

| Check | Result |
|---|---|
| \`ipam_db(\$config)\` opens connection, enforces 8.0+ floor | ✓ |
| \`ipam_db_init()\` runs \`schema.mysql.sql\` end-to-end | ✓ |
| 23 tables created, all indexes + FKs + triggers | ✓ |
| Admin user bootstrapped from config | ✓ |
| \`schema_migrations\` pre-seeded with 28 rows | ✓ |
| IPv4 round-trip (\`10.0.0.0\`): 4 bytes in → 4 bytes out | ✓ |
| IPv6 round-trip (\`2001:db8::\`): 16 bytes in → 16 bytes out | ✓ |
| IPv4 high bytes (\`255.255.255.255\`): 4 bytes in → 4 bytes out | ✓ |
| \`audit_log\` \`UPDATE\` blocked with SQLSTATE 45000 / errno 1644 | ✓ |
| \`audit_log\` \`DELETE\` blocked with SQLSTATE 45000 / errno 1644 | ✓ |
| \`ORDER BY ip_bin\` byte-wise sort works | ✓ |

## Test plan (local gate on SQLite)

- [x] \`php -l\` on all changed files
- [x] \`vendor/bin/phpunit\` — 187/187 green (163 prior + 20 MysqlDialectTest + 4 dispatcher)
- [x] \`vendor/bin/phpstan analyse --memory-limit=1G\` — OK
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/\` — 0 findings

## Binary binding

\`ipam_bind_binary()\` unchanged. Already uses \`PDO::PARAM_LOB\` on every driver (from v2.9.0 #410) which round-trips cleanly through \`VARBINARY(16)\`. The three locked round-trip vectors (\`10.0.0.0\`, \`2001:db8::\`, \`255.255.255.255\`) are **confirmed end-to-end on MySQL**.

Unblocks #384 (MySQL CI matrix) and #385 (docs + beta banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add first-class MySQL (8.0+) support with a dedicated MySQL schema for fresh installs and driver-aware database bootstrapping.
  * Automatic selection of SQL dialect at startup so the app can run on either SQLite or MySQL.
* **Tests**
  * Add unit tests covering dialect selection and MySQL-specific SQL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->