### PR TITLE
fix(#547): exclude 'free' status addresses from utilization counts

### DIFF
--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -617,7 +617,16 @@ function render_subnet_map_nodes(array $tree, array $agg, array $unassignedAgg, 
             $pct = (int)round(to_int($u['assigned_assignable']) / to_int($u['assignable_total']) * 100);
         } else {
             $a   = $agg[$id] ?? ['used' => 0, 'reserved' => 0, 'free' => 0, 'total' => 0];
-            $pct = (int)round((to_int($a['used']) + to_int($a['reserved'])) / max(1, to_int($a['total'])) * 100);
+            $assigned = to_int($a['used']) + to_int($a['reserved']);
+            $prefix = to_int($row['prefix']);
+            $ipVer = to_int($row['ip_version']);
+            if ($ipVer === 4 && $prefix <= 32) {
+                $rawHosts = 2 ** (32 - $prefix);
+                $capacity = $prefix >= 31 ? $rawHosts : max(1, $rawHosts - 2);
+            } else {
+                $capacity = max(1, $assigned);
+            }
+            $pct = (int)round($assigned / $capacity * 100);
         }
         $cls = $pct >= 90 ? 'util-bar-fill--crit' : ($pct >= 75 ? 'util-bar-fill--warn' : '');
         $indent = $depth * 22;


### PR DESCRIPTION
## Summary

- Fix map view fallback utilization calculation to use subnet capacity as denominator instead of total record count (which included 'free' status addresses)
- For IPv4: compute capacity from prefix length (same formula as api.php and dashboard.php)
- For IPv6: fall back to max(1, assigned) since IPv6 address space is too large for meaningful percentage

Most code paths already correctly filter to `status IN ('used','reserved')` — this fixes the one remaining path in `render_subnet_map_nodes()`.

## Test plan

- [x] PHPStan level 9 clean
- [x] PHPCS clean
- [x] PHPUnit 241 tests pass
- [x] CI green
- [ ] Manual: create subnet with free addresses, verify utilization bar excludes them

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)