### PR TITLE
fix(#510): darken --muted in light mode for WCAG AA contrast

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -1,7 +1,7 @@
 :root{
   --bg:#ffffff;
   --fg:#111111;
-  --muted:#667085;
+  --muted:#586174;
   --border:#d9dde5;
   --border-strong:#c5cbd6;
   --card:#fafbfc;
@@ -45,7 +45,7 @@
 html[data-theme="light"]{
   --bg:#ffffff;
   --fg:#111111;
-  --muted:#667085;
+  --muted:#586174;
   --border:#d9dde5;
   --border-strong:#c5cbd6;
   --card:#fafbfc;


### PR DESCRIPTION
## Summary

Darken `--muted` from `#667085` to `#586174` in both `:root` and forced-light theme blocks.

| Combo | Before | After |
|-------|--------|-------|
| `--muted` on `--bg` (#fff) | 4.97:1 | 6.22:1 |
| `--muted` on `--card` (#fafbfc) | 4.80:1 | 6.00:1 |
| `--muted` on `--card-2` (#f3f5f8) | 4.56:1 | 5.68:1 |

All now exceed WCAG AA 4.5:1. Dark-mode `--muted` unchanged (already 7.8:1).

## Test plan

- [x] Contrast ratios verified via WCAG formula
- [ ] CI green
- [ ] Visual: muted text slightly darker in light mode (intentional)

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)