### PR TITLE
feat(#507): loading states on every POST form — disable submit + spinner

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -1247,6 +1247,10 @@ body.pw-toggle-hidden .pw-wrap .pw-input{padding-right:36px}
 /* --- #317: keyboard shortcut hint badge --- */
 .kbd-hint{display:inline-block;margin-left:0.4em;padding:0 0.35em;border:1px solid var(--border);border-radius:var(--radius-xs);font:0.78em/1.4 ui-monospace,Menlo,monospace;color:var(--muted);background:transparent;vertical-align:middle}
 
+/* --- #507: loading state on POST form submit --- */
+.button-loading{min-width:80px;position:relative;color:transparent !important}
+.button-loading::after{content:"";position:absolute;left:50%;top:50%;width:16px;height:16px;margin:-8px 0 0 -8px;border:2px solid var(--btnfg);border-top-color:transparent;border-radius:50%;animation:spin .6s linear infinite}
+
 /* --- prefers-reduced-motion: suppress all animations/transitions --- */
 @media(prefers-reduced-motion:reduce){
   *,*::before,*::after{

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -313,6 +313,21 @@
       }
     });
 
+    // --- Loading state on POST form submit (#507) ---
+    document.addEventListener("submit", function(e) {
+      if (e.defaultPrevented) return;
+      var form = e.target;
+      if (form.method !== "post" || form.hasAttribute("data-no-loading")) return;
+      var btn = form.querySelector("button[type=submit], input[type=submit]");
+      if (!btn || btn.disabled) return;
+      btn.disabled = true;
+      btn.setAttribute("aria-busy", "true");
+      btn.dataset.originalLabel = btn.textContent;
+      var reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      btn.textContent = reduced ? "Working\u2026" : "";
+      if (!reduced) btn.classList.add("button-loading");
+    });
+
     // --- Confirm on buttons/links (data-confirm on non-form elements) ---
     document.addEventListener("click", function(e) {
       var el = e.target.closest("[data-confirm]:not(form)");


### PR DESCRIPTION
## Summary

- Delegated `submit` handler on all `form[method=post]` (23 pages) via `app.js`
- Disables submit button + sets `aria-busy="true"` + shows CSS spinner
- `prefers-reduced-motion`: shows static "Working…" text instead of spinner
- Opt-out: `data-no-loading` attribute on forms that manage their own state
- Fires after confirm-dialog handler — cancelled confirms skip loading state

## Test plan

- [x] PHPStan, PHPCS, PHPUnit all clean
- [ ] CI green
- [ ] Manual: submit a form, verify button shows spinner and is disabled

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)