### PR TITLE
feat(#508): skeleton loaders on slow tables

### DIFF
--- a/Simple-PHP-IPAM/addresses.php
+++ b/Simple-PHP-IPAM/addresses.php
@@ -356,6 +356,7 @@ if ($selectedSubnet && to_int($selectedSubnet['ip_version']) === 4) {
 }
 
 page_header('Addresses', ['page' => 'addresses']);
+ipam_skeleton_flush();
 ?>
 
 <div class="breadcrumbs">
@@ -629,4 +630,4 @@ page_header('Addresses', ['page' => 'addresses']);
   <?php endif; ?>
 </div>
 
-<?php page_footer();
+<?php ipam_skeleton_remove(); page_footer();

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -1251,6 +1251,13 @@ body.pw-toggle-hidden .pw-wrap .pw-input{padding-right:36px}
 .button-loading{min-width:80px;position:relative;color:transparent !important}
 .button-loading::after{content:"";position:absolute;left:50%;top:50%;width:16px;height:16px;margin:-8px 0 0 -8px;border:2px solid var(--btnfg);border-top-color:transparent;border-radius:50%;animation:spin .6s linear infinite}
 
+/* --- #508: skeleton loaders for slow tables --- */
+.skeleton-shell{padding:var(--space-8) 0}
+.skeleton-row{height:18px;margin:var(--space-6) 0;border-radius:var(--radius-sm);background:linear-gradient(90deg,var(--card-2) 25%,var(--border) 50%,var(--card-2) 75%);background-size:200% 100%;animation:shimmer 1.5s ease-in-out infinite}
+.skeleton-row:nth-child(odd){width:90%}
+.skeleton-row:nth-child(even){width:70%}
+@keyframes shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
+
 /* --- prefers-reduced-motion: suppress all animations/transitions --- */
 @media(prefers-reduced-motion:reduce){
   *,*::before,*::after{

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -4556,6 +4556,20 @@ function page_header(string $title, array $opts = []): void
     }
 }
 
+function ipam_skeleton_flush(int $rows = 8): void
+{
+    echo '<div id="skeleton-shell" class="skeleton-shell" aria-hidden="true">';
+    for ($i = 0; $i < $rows; $i++) echo '<div class="skeleton-row"></div>';
+    echo '</div>';
+    if (ob_get_level() > 0) ob_flush();
+    flush();
+}
+
+function ipam_skeleton_remove(): void
+{
+    echo '<script>document.getElementById("skeleton-shell")?.remove();</script>';
+}
+
 function page_footer(): void
 {
     global $config;

--- a/Simple-PHP-IPAM/subnets.php
+++ b/Simple-PHP-IPAM/subnets.php
@@ -811,6 +811,7 @@ function render_subnet_node_local(array $tree, array $direct, array $agg, array 
 }
 
 page_header('Subnets');
+ipam_skeleton_flush();
 ?>
 
 <div class="breadcrumbs">
@@ -957,4 +958,4 @@ page_header('Subnets');
   <?php endif; ?>
 </div>
 
-<?php page_footer();
+<?php ipam_skeleton_remove(); page_footer();

--- a/Simple-PHP-IPAM/unassigned.php
+++ b/Simple-PHP-IPAM/unassigned.php
@@ -154,6 +154,7 @@ function build_query_unassigned(array $overrides = []): string {
 }
 
 page_header('Unassigned IPs');
+ipam_skeleton_flush();
 ?>
 
 <div class="breadcrumbs">
@@ -281,4 +282,4 @@ page_header('Unassigned IPs');
   </div>
 <?php endif; ?>
 
-<?php page_footer();
+<?php ipam_skeleton_remove(); page_footer();


### PR DESCRIPTION
## Summary

- Add `ipam_skeleton_flush()` and `ipam_skeleton_remove()` helpers to lib.php
- Emit shimmer skeleton rows during TTFB wait on subnets.php, addresses.php, unassigned.php
- CSS-only animation with `@keyframes shimmer`, respects `prefers-reduced-motion` via #505
- Skeleton auto-removed by inline `<script>` once real content renders

## Test plan

- [x] php -l on all 4 changed PHP files
- [x] PHPStan, PHPCS, PHPUnit all clean
- [ ] CI green
- [ ] Manual: throttle to Fast 3G, verify skeleton rows appear before data on subnets page

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)