### PR TITLE
docs: v3.2.0 post-release doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Two cheap calls. The first loads your profile + preferences. The second returns 
 
 ## Project overview
 
-> **Current shipped version: v3.1.0** (see `Simple-PHP-IPAM/version.php`). This CLAUDE.md intentionally documents forward-looking policy for unreleased versions (v3.2.0 → v4.0.0+) so design intent survives across sessions. Any section or sentence that cites a version ≥ v3.2.0 describes future work — **do not apply it to current v3.1.x code**. Current-state rules are the ones that do not cite a future version.
+> **Current shipped version: v3.2.0** (see `Simple-PHP-IPAM/version.php`). This CLAUDE.md intentionally documents forward-looking policy for unreleased versions (v3.3.0 → v4.0.0+) so design intent survives across sessions. Any section or sentence that cites a version ≥ v3.3.0 describes future work — **do not apply it to current v3.2.x code**. Current-state rules are the ones that do not cite a future version.
 
 Simple PHP IPAM is a lightweight IPv4/IPv6 address management web application built with **PHP 8.2+ and SQLite**. It has **no npm build step** — all CSS and JavaScript are vanilla. Starting in v2.9.0, the application will ship a small, carefully curated set of Composer-managed runtime dependencies bundled into the release tarball, so end users still deploy by extracting the tarball with no build step. The web root is `Simple-PHP-IPAM/` (the subdirectory, not the repo root).
 
@@ -73,7 +73,10 @@ Dev tooling at the repo root (not deployed): `composer.json`, `composer.lock`, `
 | `tags.php` | yes | admin | Tag management (colour-coded tags attached to subnets and addresses) |
 | `users.php` | yes | admin | User management |
 | `api_keys.php` | yes | admin | REST API key management |
-| `change_password.php` | yes | any | Self-service password change |
+| `change_password.php` | yes | any | Account page: self-service password change, timezone preference, email change with verification (nav label: "Account") |
+| `forgot_password.php` | — | — | Email-based password recovery: submit username/email, sends reset link |
+| `reset_password.php` | — | — | Consumes password reset token, shows new-password form |
+| `devices.php` | yes | admin | Device and interface management (CRUD, filter by type/site, interface sub-section) |
 | `address_history.php` | yes | any | Per-address change history |
 | `oidc_login.php` | — | — | Initiates OIDC auth flow (PKCE) |
 | `oidc_callback.php` | — | — | Handles OIDC redirect callback |
@@ -184,7 +187,7 @@ Migrations live in `migrations.php` as an associative array of version string �
 
 **When adding a new version:** add the migration closure, bump `version.php`, update `CHANGELOG.md` (keepachangelog format).
 
-> **Current shipped version: v3.1.0.** The three subsections below (`Creating new data tables in post-v4.0.0 releases`, `Modifying the schema (multi-engine, from v2.9.0 onward)`, `Runtime dependencies`) describe **forward-looking policy** for unreleased versions. Do not apply them to work targeting v3.1.x or earlier. The rules become active on the version indicated in each heading; until then, treat them as design intent to preserve when new work approaches that version.
+> **Current shipped version: v3.2.0.** The three subsections below (`Creating new data tables in post-v4.0.0 releases`, `Modifying the schema (multi-engine, from v2.9.0 onward)`, `Runtime dependencies`) describe **forward-looking policy** for unreleased versions. Do not apply them to work targeting v3.2.x or earlier. The rules become active on the version indicated in each heading; until then, treat them as design intent to preserve when new work approaches that version.
 
 ### Creating new data tables in post-v4.0.0 releases *(applies from v4.1.0+)*
 
@@ -724,37 +727,46 @@ Normal feature PRs into `dev` through the session. Every feature/fix/docs commit
 
 Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in order** on `dev`:
 
-1. Update `docs/` (`api.md`, `configuration.md`, `oidc.md`, etc.) for any changed features or config keys.
-2. Update `testing/samples/large-db-sample/gen_large_db.php` and sample datasets if schema or data model changed.
-3. Update `testing/scripts/test_api.sh` if API endpoints were added or changed.
-4. Bump `Simple-PHP-IPAM/version.php` to `X.Y.Z`.
-5. Bump the asset cache-buster `?v=X.Y.Z` in `page_header()` (`lib.php`) **and** `demo_gate.php:74-75` if any CSS/JS changed.
-6. Update `CHANGELOG.md` with the full `## [X.Y.Z] - YYYY-MM-DD` entry and add the comparison link at the bottom.
-7. Update `README.md` — replace the existing `## What's new in vA.B.C` block **in place** with a vX.Y.Z summary (README only ever carries the single latest release).
-8. Run the full local gate until clean:
-   ```bash
-   for f in Simple-PHP-IPAM/<changed>.php; do php -l "$f"; done
-   vendor/bin/phpstan analyse --memory-limit=1G
-   vendor/bin/phpcs
-   vendor/bin/phpunit
-   semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/
-   ```
-9. Run the containerized Playwright harness end-to-end — not just the new spec. The full suite is the gate on release-readiness, not feature-completeness:
-   ```bash
-   bash testing/playwright/bootstrap-app.sh sqlite
-   (cd testing/playwright && \
-     IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
-     npx playwright test)
-   bash testing/playwright/teardown-app.sh
-   ```
-   Only proceed if the full suite is green (pre-existing flaky tests excepted — log them in the PR description).
-10. Run the dev-direct pipeline only if the release touches something the containerized harness can't cover (real-IdP OIDC, `test_api.sh` regressions, `timezone.spec.ts`).
-11. **Clean `Simple-PHP-IPAM/data/` of any local test debris** before building — the release script excludes `*.sqlite` but **not** `*.sqlite.*.bak`, `demo_last_reset.txt`, or any other runtime artifacts. Stray files get baked into the tarball otherwise:
+1. **Documentation audit — required, not optional.** Review every file in `docs/` and update for any changed features, new config keys, new pages, renamed UI elements, or deprecated behaviour. Specific checks:
+   - `docs/index.md` — features list and documentation table (add new guides, update feature bullets)
+   - `docs/api.md` — new resources, changed parameters, updated examples
+   - `docs/upgrading.md` — add a `### vX.Y.Z` section at the top of "Version-specific upgrade notes" listing new pages, features, breaking changes (if any), and nav/URL changes
+   - `docs/configuration.md` — new settings, changed defaults
+   - `docs/scanning.md`, `docs/smtp.md`, `docs/security.md`, `docs/oidc.md` — any area the release touched
+   - Any new `docs/*.md` file for a new major feature (e.g. `docs/devices.md`)
+   - **Stale version strings** — grep for the old version number: `grep -r "vX.(Y-1)" docs/`
+2. **Update `CLAUDE.md`** — update the "Current shipped version" line near the top, the page inventory table if new pages were added, and any policy section affected by the release. This file is the agent's source of truth; keeping it current prevents bad decisions in future sessions.
+3. **Update Memory MCP** — create or update the release entity `project:simple-php-ipam:roadmap:vX.Y.Z` with an observation recording what was built. Close out the previous roadmap entity with a "RELEASED" observation including the merge commit hash and bundle SHA256. Update the bare `project:simple-php-ipam` entity with the new current version if it has a version observation.
+4. Update `testing/samples/large-db-sample/gen_large_db.php` and sample datasets if schema or data model changed.
+5. Update `testing/scripts/test_api.sh` if API endpoints were added or changed.
+6. Bump `Simple-PHP-IPAM/version.php` to `X.Y.Z`.
+7. Bump the asset cache-buster `?v=X.Y.Z` in `page_header()` (`lib.php`) **and** `demo_gate.php:74-75` if any CSS/JS changed.
+8. Update `CHANGELOG.md` with the full `## [X.Y.Z] - YYYY-MM-DD` entry and add the comparison link at the bottom.
+9. Update `README.md` — replace the existing `## What's new in vA.B.C` block **in place** with a vX.Y.Z summary (README only ever carries the single latest release).
+10. Run the full local gate until clean:
+    ```bash
+    for f in Simple-PHP-IPAM/<changed>.php; do php -l "$f"; done
+    vendor/bin/phpstan analyse --memory-limit=1G
+    vendor/bin/phpcs
+    vendor/bin/phpunit
+    semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/
+    ```
+11. Run the containerized Playwright harness end-to-end — not just the new spec. The full suite is the gate on release-readiness, not feature-completeness:
+    ```bash
+    bash testing/playwright/bootstrap-app.sh sqlite
+    (cd testing/playwright && \
+      IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+      npx playwright test)
+    bash testing/playwright/teardown-app.sh
+    ```
+    Only proceed if the full suite is green (pre-existing flaky tests excepted — log them in the PR description).
+12. Run the dev-direct pipeline only if the release touches something the containerized harness can't cover (real-IdP OIDC, `test_api.sh` regressions, `timezone.spec.ts`).
+13. **Clean `Simple-PHP-IPAM/data/` of any local test debris** before building — the release script excludes `*.sqlite` but **not** `*.sqlite.*.bak`, `demo_last_reset.txt`, or any other runtime artifacts. Stray files get baked into the tarball otherwise:
     ```bash
     rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt
     ls Simple-PHP-IPAM/data/   # expect only ipam.sqlite, tmp/, possibly .htaccess
     ```
-12. **Build the bundle:**
+14. **Build the bundle:**
     ```bash
     ./releases/make_releases.sh Simple-PHP-IPAM X.Y.Z
     ```
@@ -763,7 +775,7 @@ Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in orde
     - Both `.htaccess` files (root and `data/`)
     - `settings.php`, `lib.php`, and any other newly-added PHP files
     - **No** `data/ipam.sqlite`, no `data/.db_initialized`, no `data/*.bak`
-13. Move the bundle into its permanent home and commit:
+15. Move the bundle into its permanent home and commit:
     ```bash
     mkdir -p releases/ipam-X.Y.Z
     mv ipam-X.Y.Z/ipam-X.Y.Z.tar.gz ipam-X.Y.Z/SHA256SUMS releases/ipam-X.Y.Z/
@@ -771,7 +783,7 @@ Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in orde
     git add releases/ipam-X.Y.Z/
     git commit -m "chore(release): add vX.Y.Z release bundle and SHA256SUMS"
     ```
-14. Push `dev` and open the release PR `dev → main`. CodeRabbit + CI review the full changeset — code, docs, tests, and bundle — in one cycle.
+16. Push `dev` and open the release PR `dev → main`. CodeRabbit + CI review the full changeset — code, docs, tests, and bundle — in one cycle.
 
 #### Phase 3 — responding to review comments
 
@@ -818,17 +830,34 @@ If CodeRabbit or a human reviewer asks for a change on the open PR:
    ssh root@192.168.80.23 "chown -R nobody:nogroup /usr/local/lsws/vhosts/demo.simplephpipam.com/html/ && php /usr/local/lsws/vhosts/demo.simplephpipam.com/html/migrate.php"
    ```
    Verify: browse `https://demo.simplephpipam.com/` and confirm the version shown in the footer.
-7. **Deploy website theme** if any theme files changed (`website/` in the main repo, tracked in the private `simple-php-ipam-website` repo). From inside `website/`:
+7. **Deploy to 4 testing instances** (`root@192.168.80.15`):
    ```bash
+   for dir in ipam ipam-maria ipam-mysql ipam-postgres; do
+     rsync -az --delete --exclude='data/' --exclude='config.php' \
+       Simple-PHP-IPAM/ root@192.168.80.15:/opt/container_data/dev.seanmousseau.com/html/testing/$dir/
+     ssh root@192.168.80.15 "chown -R www-data:www-data /opt/container_data/dev.seanmousseau.com/html/testing/$dir/ && docker exec dev_seanmousseau_com-apache-php-1 php /var/www/html/testing/$dir/migrate.php"
+   done
+   ```
+8. **Update the marketing website** (`simplephpipam.com`) — required on every release, not optional. The version number appears in multiple places in `website/front-page.php`:
+   - Hero badge: `vX.Y.Z — <tagline>`
+   - Download button label (appears twice: hero CTA and quickstart section)
+   - Quickstart `tar` command: `ipam-X.Y.Z.tar.gz`
+   - Update or add feature cards for significant new features
+   Then push and deploy:
+   ```bash
+   cd website/
+   git add -A && git commit -m "chore(release): bump to vX.Y.Z, update feature cards"
    git push origin main
-   ssh root@192.168.80.23 "cd /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simple-php-ipam && git pull"
-   ```
-   Or rsync directly:
-   ```bash
+   cd ..
    rsync -az --delete \
-     website/ root@192.168.80.23:/usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simple-php-ipam/
-   ssh root@192.168.80.23 "chown -R nobody:nogroup /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simple-php-ipam/"
+     website/ root@192.168.80.23:/usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/
+   ssh root@192.168.80.23 "chown -R nobody:nogroup /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/"
    ```
+9. **Close milestone issues** — close every GitHub issue in the vX.Y.Z milestone:
+   ```bash
+   gh issue close <N> --comment "Released in vX.Y.Z. See https://github.com/seanmousseau/Simple-PHP-IPAM/releases/tag/vX.Y.Z"
+   ```
+10. **Update Memory MCP** — write a final "RELEASED" observation to the `project:simple-php-ipam:roadmap:vX.Y.Z` entity with: merge commit hash, bundle SHA256, tag, deploy confirmation, and all issues closed. Also update the bare `project:simple-php-ipam` entity if it has a "current version" observation.
 
 ### Commit style
 ```

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,0 +1,82 @@
+# Devices
+
+Simple PHP IPAM v3.2.0 adds a first-class **Devices** model. A device represents a physical or virtual piece of network infrastructure (router, switch, server, VM, firewall, or other). Each device can have named interfaces, and each IP address record can be linked to a device and optionally to one of its interfaces.
+
+---
+
+## Data model
+
+```
+devices
+  id, name (unique), type, site_id (FK → sites), vendor, model, serial, note
+  created_at, updated_at
+
+device_interfaces
+  id, device_id (FK → devices, CASCADE), name, description
+  UNIQUE(device_id, name)
+  created_at, updated_at
+
+addresses
+  ...existing columns...
+  device_id    (FK → devices, SET NULL on delete)
+  interface_id (FK → device_interfaces, SET NULL on delete)
+```
+
+Deleting a device cascades to its interfaces and sets `device_id`/`interface_id` to NULL on any linked addresses.
+
+---
+
+## Admin workflow
+
+### Managing devices
+
+Navigate to **⚙ Admin → Devices**. The page requires admin role.
+
+- **Add Device** — fill in name (required), type, site, vendor, model, serial, and note.
+- **Edit / Interfaces** — expand a row to update the device fields, manage its interfaces (add or delete), or delete the device entirely.
+- **Type badges** — each type renders a colour-coded badge: router (blue), switch (cyan), server (green), vm (purple), firewall (red), other (grey).
+- **Filter bar** — filter by type, site, or free-text search across name, vendor, model, and serial.
+
+### Linking an address to a device
+
+Open **Addresses** for any subnet. In the **Add address** form or the per-row **Edit/Delete** form, use the **Device** and **Interface** dropdowns. Selecting a device dynamically populates the Interface dropdown with that device's interfaces.
+
+The **Device** column in the address table is hidden by default — enable it via the column chooser (the ⚙ icon above the table).
+
+### CSV import
+
+The CSV import wizard (`import_csv.php`) accepts two optional columns:
+
+| Column | Description |
+|--------|-------------|
+| `device_name` | Name of the device to link. Created automatically if it does not exist (type defaults to `other`). |
+| `interface_name` | Interface on the device (requires `device_name`). Created automatically if it does not exist. |
+
+If `interface_name` is set without `device_name`, the row is rejected with a validation error.
+
+---
+
+## Global search
+
+Device names and interface names are searchable from the global **Search** page. Matching devices appear in a dedicated "Matching Devices" section below the address and subnet results.
+
+---
+
+## API
+
+See [api.md](api.md) for full endpoint documentation. Quick reference:
+
+| Method | Resource | Description |
+|--------|----------|-------------|
+| `GET` | `?resource=devices` | List devices (`?type=`, `?site_id=`, `?q=`, pagination) |
+| `GET` | `?resource=devices&id=N` | Single device |
+| `POST` | `?resource=devices` | Create device (write key) |
+| `PUT` | `?resource=devices&id=N` | Update device (write key) |
+| `DELETE` | `?resource=devices&id=N` | Delete device (write key) |
+| `GET` | `?resource=device_interfaces&device_id=N` | Interfaces for a device |
+| `GET` | `?resource=device_interfaces&id=N` | Single interface |
+| `POST` | `?resource=device_interfaces` | Create interface (write key) |
+| `PUT` | `?resource=device_interfaces&id=N` | Update interface (write key) |
+| `DELETE` | `?resource=device_interfaces&id=N` | Delete interface (write key) |
+
+Addresses returned by `?resource=addresses` include `device_id` and `interface_id` fields when set.


### PR DESCRIPTION
## Summary

- `docs/index.md`: add Devices and Advanced Networking to features list and documentation table
- `docs/upgrading.md`: add v3.2.0 upgrade notes section
- `docs/scanning.md`: remove stale "v2.3.0" from title
- `docs/api.md`: note that global search covers devices/interfaces
- `docs/devices.md`: add to git tracking (was untracked, missed in v3.2.0 PR)
- `CLAUDE.md`: bump current shipped version to v3.2.0, expand release gate checklist with doc/memory/website steps, add new pages to page inventory

The `docs/devices.md` file was committed after the v3.2.0 merge and is needed by the marketing site (`simplephpipam.com/docs/devices/`) which fetches markdown from `main`.

## Test plan
- [ ] `https://simplephpipam.com/docs/devices/` renders content (currently shows "Failed to load documentation")
- [ ] `https://simplephpipam.com/docs/advanced-networking/` renders content
- [ ] Left nav and header dropdown show Devices and Advanced Networking

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Devices feature enabling device and network interface management linked to addresses.
  * Added admin UI workflows for creating, editing, and managing devices and interfaces with filtering and search support.
  * Extended CSV import to support device and interface name columns with automatic creation and validation.

* **Documentation**
  * Added comprehensive Devices feature documentation including admin workflows, CSV import behavior, global search, and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->