### PR TITLE
feat(csv): v3.5.0 custom_fields round-trip through export + import (#313, #599)

### DIFF
--- a/Simple-PHP-IPAM/export_addresses.php
+++ b/Simple-PHP-IPAM/export_addresses.php
@@ -13,11 +13,11 @@ if ($subnetId <= 0) {
     $filename = safe_export_filename('ipam-addresses-all');
     csv_download_headers($filename);
 
-    csv_out(['subnet_cidr', 'site', 'ip', 'hostname', 'owner', 'group', 'mac', 'expires_at', 'status', 'note', 'updated_at']);
+    csv_out(['subnet_cidr', 'site', 'ip', 'hostname', 'owner', 'group', 'mac', 'expires_at', 'status', 'note', 'updated_at', 'custom_fields']);
 
     $st = $db->query("
         SELECT s.cidr AS subnet_cidr, COALESCE(si.name, '') AS site_name,
-               a.ip, a.hostname, a.owner, a.grp, a.mac, a.expires_at, a.status, a.note, a.updated_at
+               a.ip, a.hostname, a.owner, a.grp, a.mac, a.expires_at, a.status, a.note, a.updated_at, a.custom_fields
         FROM addresses a
         JOIN subnets s ON s.id = a.subnet_id
         LEFT JOIN sites si ON si.id = s.site_id
@@ -37,6 +37,7 @@ if ($subnetId <= 0) {
             to_str($r['status']),
             to_str($r['note']),
             to_str($r['updated_at']),
+            to_str($r['custom_fields'] ?? '{}'),
         ]);
     }
 
@@ -56,10 +57,10 @@ if (!$subnet) {
 $filename = safe_export_filename('ipam-addresses-subnet-' . $subnetId);
 csv_download_headers($filename);
 
-csv_out(['subnet_cidr', 'ip', 'hostname', 'owner', 'group', 'mac', 'expires_at', 'status', 'note', 'updated_at']);
+csv_out(['subnet_cidr', 'ip', 'hostname', 'owner', 'group', 'mac', 'expires_at', 'status', 'note', 'updated_at', 'custom_fields']);
 
 $st = $db->prepare("
-    SELECT a.ip, a.hostname, a.owner, a.grp AS grp, a.mac, a.expires_at, a.status, a.note, a.updated_at
+    SELECT a.ip, a.hostname, a.owner, a.grp AS grp, a.mac, a.expires_at, a.status, a.note, a.updated_at, a.custom_fields
     FROM addresses a
     WHERE a.subnet_id = :sid
     ORDER BY a.ip_bin ASC
@@ -78,6 +79,7 @@ foreach ($st->fetchAll() as $r) {
         to_str($r['status']),
         to_str($r['note']),
         to_str($r['updated_at']),
+        to_str($r['custom_fields'] ?? '{}'),
     ]);
 }
 

--- a/Simple-PHP-IPAM/import_csv.php
+++ b/Simple-PHP-IPAM/import_csv.php
@@ -121,6 +121,9 @@ function analyze_import(PDO $db, array $wiz): array
         'duplicate_in_csv' => 0,
     ];
 
+    /** @var list<array<string,mixed>> $addressDefs */
+    $addressDefs = custom_field_def_list($db, 'address');
+
     /** @var list<array<string, mixed>> $existingSubnets */
     $existingSubnets = ($db->query("SELECT id, cidr FROM subnets")
         ?: throw new \RuntimeException('Query failed'))->fetchAll();
@@ -175,11 +178,32 @@ function analyze_import(PDO $db, array $wiz): array
             'netmask_hint' => trim(to_str($get('netmask') ?? '')),
             'device_name' => $get('device_name') !== null ? substr(trim(to_str($get('device_name'))), 0, 255) : null,
             'interface_name' => $get('interface_name') !== null ? substr(trim(to_str($get('interface_name'))), 0, 255) : null,
+            'custom_fields' => '{}',
         ];
 
         $rawExpires = trim(to_str($get('expires_at') ?? ''));
         if ($rawExpires !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $rawExpires)) {
             $entry['expires_at'] = $rawExpires;
+        }
+
+        $rawCf = trim(to_str($get('custom_fields') ?? ''));
+        if ($rawCf !== '' && $rawCf !== '{}') {
+            $parsedCf = json_decode($rawCf, true);
+            if (!is_array($parsedCf)) {
+                $entry['reason'] = 'custom_fields: invalid JSON';
+                $summary['invalid']++;
+                $planRows[] = $entry;
+                continue;
+            }
+            try {
+                validate_custom_fields_payload($addressDefs, $parsedCf);
+                $entry['custom_fields'] = serialize_custom_fields_row($parsedCf);
+            } catch (\InvalidArgumentException $ex) {
+                $entry['reason'] = 'custom_fields: ' . $ex->getMessage();
+                $summary['invalid']++;
+                $planRows[] = $entry;
+                continue;
+            }
         }
 
         // Field length validation
@@ -560,6 +584,7 @@ if ($step === 2) {
             'description' => 'Subnet description (optional, used only when creating subnet)',
             'device_name' => 'Device name (optional)',
             'interface_name' => 'Interface name (optional, requires device name)',
+            'custom_fields' => 'Custom fields (JSON, optional)',
         ];
 
         echo "<table><tbody>";
@@ -720,10 +745,10 @@ if (demo_mode_enabled()) {
 
         $db->beginTransaction();
 
-        $sel = $db->prepare("SELECT id, ip, hostname, owner, note, grp, mac, expires_at, status, device_id, interface_id FROM addresses WHERE subnet_id=:sid AND ip=:ip");
-        $ins = $db->prepare("INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, note, grp, mac, expires_at, status, device_id, interface_id)
-                             VALUES (:sid,:ip,:bin,:hn,:ow,:nt,:grp,:mac,:exp,:st,:did,:iid)");
-        $upd = $db->prepare("UPDATE addresses SET hostname=:hn, owner=:ow, note=:nt, grp=:grp, mac=:mac, expires_at=:exp, status=:st, device_id=:did, interface_id=:iid WHERE id=:id");
+        $sel = $db->prepare("SELECT id, ip, hostname, owner, note, grp, mac, expires_at, status, device_id, interface_id, custom_fields FROM addresses WHERE subnet_id=:sid AND ip=:ip");
+        $ins = $db->prepare("INSERT INTO addresses (subnet_id, ip, ip_bin, hostname, owner, note, grp, mac, expires_at, status, device_id, interface_id, custom_fields)
+                             VALUES (:sid,:ip,:bin,:hn,:ow,:nt,:grp,:mac,:exp,:st,:did,:iid,:cf)");
+        $upd = $db->prepare("UPDATE addresses SET hostname=:hn, owner=:ow, note=:nt, grp=:grp, mac=:mac, expires_at=:exp, status=:st, device_id=:did, interface_id=:iid, custom_fields=:cf WHERE id=:id");
 
         // Device/interface lookup+create helpers used inside the row loop
         $selDevice = $db->prepare("SELECT id FROM devices WHERE name=:name");
@@ -890,6 +915,7 @@ if (demo_mode_enabled()) {
                 $ins->bindValue(':st',   to_str($r['status'] ?? 'used'));
                 $ins->bindValue(':did',  $devLink['device_id'], $devLink['device_id'] === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
                 $ins->bindValue(':iid',  $devLink['interface_id'], $devLink['interface_id'] === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+                $ins->bindValue(':cf',   to_str($r['custom_fields'] ?? '{}'));
                 $ins->execute();
                 $aid = ipam_last_insert_id($db, 'addresses');
 
@@ -903,6 +929,7 @@ if (demo_mode_enabled()) {
                     'status'       => to_str($r['status'] ?? 'used'),
                     'device_id'    => $devLink['device_id'],
                     'interface_id' => $devLink['interface_id'],
+                    'custom_fields' => to_str($r['custom_fields'] ?? '{}'),
                 ]);
                 $createdAddresses++;
 
@@ -928,6 +955,7 @@ if (demo_mode_enabled()) {
                 $newMac = to_str($r['mac'] ?? '');
                 $newExpAt = isset($r['expires_at']) && to_str($r['expires_at']) !== '' ? to_str($r['expires_at']) : null;
                 $newSt = to_str($r['status'] ?? 'used');
+                $newCf = to_str($r['custom_fields'] ?? '{}');
 
                 $devLink = $resolveDevice(
                     isset($r['device_name']) ? to_str($r['device_name']) : null,
@@ -959,29 +987,36 @@ if (demo_mode_enabled()) {
                         $newDevId = to_int($existing['device_id']);
                         $newIfaceId = $existing['interface_id'] !== null ? to_int($existing['interface_id']) : null;
                     }
+                    // fill_empty: keep existing custom_fields if already populated
+                    $existingCf = to_str($existing['custom_fields'] ?? '{}');
+                    if ($existingCf !== '' && $existingCf !== '{}') {
+                        $newCf = $existingCf;
+                    }
                 }
 
                 $before = [
-                    'hostname'     => to_str($existing['hostname']),
-                    'owner'        => to_str($existing['owner']),
-                    'note'         => to_str($existing['note']),
-                    'grp'          => to_str($existing['grp']),
-                    'mac'          => to_str($existing['mac']),
-                    'expires_at'   => $existing['expires_at'] !== null ? to_str($existing['expires_at']) : null,
-                    'status'       => to_str($existing['status']),
-                    'device_id'    => $existing['device_id'] !== null ? to_int($existing['device_id']) : null,
-                    'interface_id' => $existing['interface_id'] !== null ? to_int($existing['interface_id']) : null,
+                    'hostname'      => to_str($existing['hostname']),
+                    'owner'         => to_str($existing['owner']),
+                    'note'          => to_str($existing['note']),
+                    'grp'           => to_str($existing['grp']),
+                    'mac'           => to_str($existing['mac']),
+                    'expires_at'    => $existing['expires_at'] !== null ? to_str($existing['expires_at']) : null,
+                    'status'        => to_str($existing['status']),
+                    'device_id'     => $existing['device_id'] !== null ? to_int($existing['device_id']) : null,
+                    'interface_id'  => $existing['interface_id'] !== null ? to_int($existing['interface_id']) : null,
+                    'custom_fields' => to_str($existing['custom_fields'] ?? '{}'),
                 ];
                 $after = [
-                    'hostname'     => $newHn,
-                    'owner'        => $newOw,
-                    'note'         => $newNt,
-                    'grp'          => $newGrp,
-                    'mac'          => $newMac,
-                    'expires_at'   => $newExpAt,
-                    'status'       => $newSt,
-                    'device_id'    => $newDevId,
-                    'interface_id' => $newIfaceId,
+                    'hostname'      => $newHn,
+                    'owner'         => $newOw,
+                    'note'          => $newNt,
+                    'grp'           => $newGrp,
+                    'mac'           => $newMac,
+                    'expires_at'    => $newExpAt,
+                    'status'        => $newSt,
+                    'device_id'     => $newDevId,
+                    'interface_id'  => $newIfaceId,
+                    'custom_fields' => $newCf,
                 ];
 
                 $upd->bindValue(':hn',  $newHn);
@@ -993,6 +1028,7 @@ if (demo_mode_enabled()) {
                 $upd->bindValue(':st',  $newSt);
                 $upd->bindValue(':did', $newDevId, $newDevId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
                 $upd->bindValue(':iid', $newIfaceId, $newIfaceId === null ? PDO::PARAM_NULL : PDO::PARAM_INT);
+                $upd->bindValue(':cf',  $newCf);
                 $upd->bindValue(':id',  to_int($existing['id']), PDO::PARAM_INT);
                 $upd->execute();
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -7145,7 +7145,7 @@ function parse_custom_fields_row(string $json): array
  * Canonical JSON serialization for the custom_fields column.
  * Null values are stripped so the stored JSON stays compact.
  *
- * @param array<string,mixed> $values
+ * @param array<mixed,mixed> $values
  */
 function serialize_custom_fields_row(array $values): string
 {
@@ -7159,7 +7159,7 @@ function serialize_custom_fields_row(array $values): string
  * Throws InvalidArgumentException on the first type mismatch or missing required field.
  *
  * @param list<array<string,mixed>> $defs     Output of custom_field_def_list()
- * @param array<string,mixed>       $payload  Flat key→raw-value map from $_POST (keys without the 'cf_' prefix)
+ * @param array<mixed,mixed>        $payload  Flat key→raw-value map from $_POST or json_decode (keys without the 'cf_' prefix)
  * @return array<string,mixed>
  */
 function validate_custom_fields_payload(array $defs, array $payload): array

--- a/testing/playwright/tests/custom-fields-csv.spec.ts
+++ b/testing/playwright/tests/custom-fields-csv.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Phase 5: custom_fields round-trip through export_addresses.php and import_csv.php.
+ * Tests that the custom_fields JSON column:
+ *   - appears in the per-subnet CSV export header
+ *   - can be imported via the CSV wizard (mapping + apply) and persists
+ *   - rejects invalid JSON in the mapped column
+ */
+import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import {
+  login, fetchGet, fetchPost, fetchPostForm, deleteSubnet, subnetIdFor, appUrl,
+  ADMIN_USER, ADMIN_PASS,
+  newAuthContext,
+} from '../fixtures/ipam';
+
+const CF_CSV_CIDR    = '10.93.0.0/24';
+const CF_CSV_IP      = '10.93.0.5';
+const CF_CSV_IMPORT  = '10.93.0.6';
+const CF_CSV_INVALID = '10.93.0.7';
+const CF_KEY         = 'cf_csv_spec_txt';
+const CF_LABEL       = 'CSV Spec Test';
+const CF_VALUE       = 'round-trip-ok';
+
+let ctx:      BrowserContext;
+let page:     Page;
+let subnetId: number | null = null;
+let cfDefId:  number | null = null;
+
+test.beforeAll(async ({ browser }: { browser: Browser }) => {
+  ctx  = await newAuthContext(browser);
+  page = await ctx.newPage();
+  await login(page, ADMIN_USER, ADMIN_PASS);
+
+  // Clean up any leftover state
+  await page.goto('subnets.php');
+  await deleteSubnet(page, CF_CSV_CIDR);
+
+  // Create test subnet
+  await fetchPost(page, appUrl('subnets.php'), {
+    action: 'create', cidr: CF_CSV_CIDR, description: 'CF CSV spec', confirm_overlap: '1',
+  });
+  await page.goto('subnets.php');
+  subnetId = await subnetIdFor(page, CF_CSV_CIDR);
+
+  // Create an address CF definition via the admin page
+  await fetchPost(page, appUrl('custom_fields.php'), {
+    action: 'create', entity_type: 'address', key: CF_KEY,
+    label: CF_LABEL, type: 'text', options: '[]', sort_order: '95', is_required: '0',
+  });
+
+  // Navigate to the admin page and find the definition ID from the delete form
+  await page.goto('custom_fields.php');
+  cfDefId = await page.evaluate((key: string) => {
+    // Look for a form or link with data-id or a delete input that matches the key
+    const rows = document.querySelectorAll('tr');
+    for (const row of rows) {
+      if (row.textContent?.includes(key)) {
+        // Try button or input with name="id"
+        const inp = row.querySelector<HTMLInputElement>('input[name="id"]');
+        if (inp) return parseInt(inp.value, 10);
+        // Try data-id attribute on a button
+        const btn = row.querySelector<HTMLElement>('[data-id]');
+        if (btn) return parseInt(btn.getAttribute('data-id') ?? '0', 10);
+        // Try form action with id= in query string
+        const form = row.querySelector<HTMLFormElement>('form[action*="id="]');
+        if (form) {
+          const m = form.action.match(/id=(\d+)/);
+          if (m) return parseInt(m[1], 10);
+        }
+      }
+    }
+    return null;
+  }, CF_KEY);
+
+  // Create a seed address for export tests
+  if (subnetId !== null) {
+    await fetchPost(page, appUrl('addresses.php'), {
+      action: 'create', subnet_id: String(subnetId),
+      ip: CF_CSV_IP, hostname: 'cf-export-host', status: 'used',
+    });
+  }
+});
+
+test.afterAll(async () => {
+  try {
+    // Delete CF definition
+    if (cfDefId !== null) {
+      await fetchPost(page, appUrl('custom_fields.php'), {
+        action: 'delete', id: String(cfDefId),
+      });
+    }
+    // Delete test subnet (cascades addresses)
+    await page.goto('subnets.php');
+    await deleteSubnet(page, CF_CSV_CIDR);
+    // Reset wizard state
+    await fetchGet(page, appUrl('import_csv.php?reset=1'));
+  } finally {
+    await ctx?.close();
+  }
+});
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+test('custom_fields column present in per-subnet CSV export', async () => {
+  if (!subnetId) { test.skip(); return; }
+  const r = await fetchGet(page, appUrl(`export_addresses.php?subnet_id=${subnetId}`));
+  expect(r.status).toBe(200);
+  const header = r.body.split('\n')[0] ?? '';
+  expect(header).toContain('custom_fields');
+  expect(r.body).toContain(CF_CSV_IP);
+});
+
+test('custom_fields column present in cross-subnet CSV export', async () => {
+  const r = await fetchGet(page, appUrl('export_addresses.php'));
+  expect(r.status).toBe(200);
+  const header = r.body.split('\n')[0] ?? '';
+  expect(header).toContain('custom_fields');
+});
+
+// ── Import ─────────────────────────────────────────────────────────────────────
+
+test('import CSV: address created with custom_fields value round-trips in export', async () => {
+  if (!subnetId || cfDefId === null) { test.skip(); return; }
+
+  await fetchGet(page, appUrl('import_csv.php?reset=1'));
+
+  // CSV with custom_fields JSON cell (double-quoted JSON inside CSV requires escaped quotes)
+  const cfJson = JSON.stringify({ [CF_KEY]: CF_VALUE });
+  const csvContent = [
+    'ip,hostname,status,cidr,custom_fields',
+    `${CF_CSV_IMPORT},cf-import-host,used,${CF_CSV_CIDR},"${cfJson.replace(/"/g, '""')}"`,
+  ].join('\n');
+
+  // Step 1 — upload
+  await fetchPostForm(page, appUrl('import_csv.php?step=1'), { action: 'upload' }, {
+    name: 'csv', content: csvContent, filename: 'cf-test.csv', type: 'text/csv',
+  });
+
+  // Step 2 — set mapping (0=ip, 1=hostname, 2=status, 3=cidr, 4=custom_fields)
+  await fetchPost(page, appUrl('import_csv.php?step=2'), {
+    action: 'set_mapping', delimiter: ',', has_header: 'yes', dup_mode: 'overwrite',
+    'map[ip]': '0', 'map[hostname]': '1', 'map[status]': '2',
+    'map[cidr]': '3', 'map[custom_fields]': '4',
+  });
+
+  // Step 3 — navigate to dry-run page
+  await page.goto('import_csv.php?step=3');
+  const dryRunBody = await page.content();
+  // Row should be classified as 'create', not 'report-invalid'
+  expect(dryRunBody).toContain(CF_CSV_IMPORT);
+  expect(dryRunBody).toContain('report-create');
+  expect(dryRunBody).not.toContain('report-invalid');
+
+  // Step 4 — apply import
+  await fetchPost(page, appUrl('import_csv.php?step=4'), { action: 'apply' });
+
+  // Verify round-trip: the exported CSV should contain the CF value
+  const exportR = await fetchGet(page, appUrl(`export_addresses.php?subnet_id=${subnetId}`));
+  expect(exportR.status).toBe(200);
+  expect(exportR.body).toContain(CF_CSV_IMPORT);
+  expect(exportR.body).toContain(CF_VALUE);
+});
+
+test('import CSV: invalid JSON in custom_fields column marks row invalid', async () => {
+  if (!subnetId || cfDefId === null) { test.skip(); return; }
+
+  await fetchGet(page, appUrl('import_csv.php?reset=1'));
+
+  const csvContent = [
+    'ip,custom_fields',
+    `${CF_CSV_INVALID},not-valid-json`,
+  ].join('\n');
+
+  await fetchPostForm(page, appUrl('import_csv.php?step=1'), { action: 'upload' }, {
+    name: 'csv', content: csvContent, filename: 'cf-bad.csv', type: 'text/csv',
+  });
+
+  await fetchPost(page, appUrl('import_csv.php?step=2'), {
+    action: 'set_mapping', delimiter: ',', has_header: 'yes', dup_mode: 'skip',
+    'map[ip]': '0', 'map[custom_fields]': '1',
+  });
+
+  await page.goto('import_csv.php?step=3');
+  const dryRunBody = await page.content();
+  expect(dryRunBody).toContain('report-invalid');
+});

--- a/testing/playwright/tests/exports.spec.ts
+++ b/testing/playwright/tests/exports.spec.ts
@@ -68,7 +68,7 @@ test('export subnets: 200 response, CSV content', async () => {
   expect(r.body).toContain(TEST_CIDR2);
 });
 
-test('export addresses: contains test IP + mac + expires_at columns', async () => {
+test('export addresses: contains test IP + mac + expires_at + custom_fields columns', async () => {
   if (!subnetId) { test.skip(); return; }
   await page.goto(`addresses.php?subnet_id=${subnetId}`);
   const r = await fetchGet(page, appUrl(`export_addresses.php?subnet_id=${subnetId}`));
@@ -78,6 +78,7 @@ test('export addresses: contains test IP + mac + expires_at columns', async () =
   // Column headers
   expect(r.body.toLowerCase()).toContain('mac');
   expect(r.body.toLowerCase()).toContain('expires_at');
+  expect(r.body.toLowerCase()).toContain('custom_fields');
 });
 
 test('export audit: 200 response, CSV content', async () => {

--- a/testing/scripts/test_api.sh
+++ b/testing/scripts/test_api.sh
@@ -1173,6 +1173,88 @@ else
 fi
 
 # ====================================================================
+log "=== Custom Fields CSV Export (v3.5.0) ==="
+# ====================================================================
+
+# Seed an address CF definition, run API + CSV export round-trip, then clean up
+CF_ADDR_DEF_ID=""
+if [[ -n "${DOCKER_CONTAINER:-}" ]]; then
+    CF_ADDR_DEF_ID=$(db_php "$(container_api_key_php "
+\$stmt = \$db->prepare(\"INSERT INTO custom_field_defs (entity_type, key, label, type, options, sort_order, is_required) VALUES ('address','csv_test_txt','CSV Test','text','[]',97,0)\");
+\$stmt->execute();
+echo ipam_last_insert_id(\$db, 'custom_field_defs');
+")" 2>/dev/null | tr -d '[:space:]')
+fi
+
+if [[ -n "${CF_ADDR_DEF_ID:-}" && "$CF_ADDR_DEF_ID" != "" && -n "${ADDR_ID:-}" && "$ADDR_ID" != "None" && -n "${SUBNET_ID:-}" && "$SUBNET_ID" != "None" ]]; then
+    # Valid text value → 200, verify via DB (GET addresses has no id filter — list endpoint only)
+    call_api PUT "addresses&id=$ADDR_ID" '{"custom_fields":{"csv_test_txt":"hello-csv"}}'
+    assert_http 200 "PUT address with text cf value → 200"
+
+    ADDR_TXT_VAL=$(db_php "$(container_api_key_php "
+\$st = \$db->prepare(\"SELECT custom_fields FROM addresses WHERE id = :id\");
+\$st->execute([':id' => $ADDR_ID]);
+\$r = \$st->fetch();
+\$cf = json_decode(\$r ? \$r['custom_fields'] : '{}', true);
+echo \$cf['csv_test_txt'] ?? 'MISSING';
+")" 2>/dev/null | tr -d '[:space:]')
+    [[ "$ADDR_TXT_VAL" == "hello-csv" ]] && pass "address text cf stored in DB: 'hello-csv'" || fail "address text cf not stored: $ADDR_TXT_VAL"
+
+    # Type violation: integer in text field → 422
+    call_api PUT "addresses&id=$ADDR_ID" '{"custom_fields":{"csv_test_txt":123}}'
+    [[ "$HTTP_CODE" == "422" ]] && pass "PUT address with integer in text field → 422" || fail "PUT address with integer in text field → expected 422, got $HTTP_CODE"
+
+    # Session login to download the CSV export
+    _SESS_JAR=$(mktemp /tmp/ipam_sess_XXXXXXXX.txt)
+    _ADMIN_USER="${IPAM_ADMIN_USER:-demo}"
+    _ADMIN_PASS="${IPAM_ADMIN_PASS:-demo}"
+    LOGIN_HTML=$(curl -s --noproxy '*' "${_ba_args[@]+"${_ba_args[@]}"}" -k \
+        -c "$_SESS_JAR" -b "$_SESS_JAR" \
+        "$BASE_URL/login.php" 2>/dev/null || echo "")
+    LOGIN_CSRF=$(echo "$LOGIN_HTML" | grep -oE 'name="csrf" value="[^"]*"' | head -1 | sed 's/.*value="//;s/"//' || echo "")
+
+    if [[ -n "$LOGIN_CSRF" ]]; then
+        curl -s --noproxy '*' "${_ba_args[@]+"${_ba_args[@]}"}" -k \
+            -c "$_SESS_JAR" -b "$_SESS_JAR" -L \
+            --data-urlencode "username=$_ADMIN_USER" \
+            --data-urlencode "password=$_ADMIN_PASS" \
+            --data-urlencode "csrf=$LOGIN_CSRF" \
+            -o /dev/null "$BASE_URL/login.php" 2>/dev/null || true
+
+        # Download the per-subnet CSV export
+        SUBNET_CSV=$(curl -s --noproxy '*' "${_ba_args[@]+"${_ba_args[@]}"}" -k \
+            -c "$_SESS_JAR" -b "$_SESS_JAR" \
+            "$BASE_URL/export_addresses.php?subnet_id=$SUBNET_ID" 2>/dev/null || echo "")
+
+        CSV_HEADER=$(echo "$SUBNET_CSV" | head -1)
+        [[ "$CSV_HEADER" == *"custom_fields"* ]] && pass "export_addresses.php CSV header contains 'custom_fields'" || fail "export_addresses.php CSV header missing 'custom_fields': $CSV_HEADER"
+
+        CSV_CF_VAL=$(python3 -c "
+import csv, io, sys
+data = sys.stdin.read()
+reader = csv.DictReader(io.StringIO(data))
+for row in reader:
+    print(row.get('custom_fields', 'MISSING'))
+    break
+" <<< "$SUBNET_CSV" 2>/dev/null || echo "MISSING")
+        [[ "$CSV_CF_VAL" == *"hello-csv"* ]] && pass "export CSV row custom_fields contains 'hello-csv'" || fail "export CSV row custom_fields: expected 'hello-csv', got $CSV_CF_VAL"
+    else
+        skip "CSV export download — could not get session CSRF token"
+    fi
+    rm -f "$_SESS_JAR"
+
+    # Clean up address CF def and reset address custom_fields
+    db_php "$(container_api_key_php "
+\$db->prepare(\"DELETE FROM custom_field_defs WHERE id = :id\")->execute([':id' => $CF_ADDR_DEF_ID]);
+\$db->prepare(\"UPDATE addresses SET custom_fields = '{}' WHERE id = :id\")->execute([':id' => $ADDR_ID]);
+")" 2>/dev/null || true
+    pass "Cleaned up address CF definition (id=$CF_ADDR_DEF_ID)"
+else
+    [[ -z "${CF_ADDR_DEF_ID:-}" ]] && skip "CSV CF tests — DB seed skipped (not containerized)" \
+                                    || skip "CSV CF tests — no ADDR_ID or SUBNET_ID"
+fi
+
+# ====================================================================
 log "=== OpenAPI Spec ==="
 # ====================================================================
 


### PR DESCRIPTION
## Summary

- `export_addresses.php`: adds `custom_fields` column to both per-subnet and cross-subnet CSV exports (header, SELECT, `csv_out` row)
- `import_csv.php`: accepts `custom_fields` in the column-map step; per-row JSON parse + `validate_custom_fields_payload()` + strict-type rejection; persists via `:cf` binding on INSERT/UPDATE; invalid rows written to import_report
- `lib.php`: widen `@param` types on `serialize_custom_fields_row()` / `validate_custom_fields_payload()` to `array<mixed,mixed>` (required because `json_decode` returns `array<mixed,mixed>` at PHPStan level 9)
- `test_api.sh`: Phase 5 CSV export section — seeds CF def, PUTs address with CF, session-logins for export, verifies header + value, tests 422 on type mismatch
- `custom-fields-csv.spec.ts`: new Playwright spec (4 tests — export column presence ×2, import round-trip, invalid JSON rejection)
- `exports.spec.ts`: added `custom_fields` column assertion to existing address export test

## Test plan

- [x] PHPStan level 9 clean
- [x] PHPCS clean
- [x] PHPUnit green
- [x] Semgrep clean
- [x] SQLite: test_api.sh 197 PASS, 0 FAIL — Playwright 420 passed
- [x] MySQL: test_api.sh 197 PASS, 0 FAIL — Playwright 420 passed
- [x] PostgreSQL: test_api.sh 197 PASS, 0 FAIL — Playwright 420 passed

Closes #599. Part of epic #313 (v3.5.0 custom fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)