### PR TITLE
fix(css): action-pill text invisible in both themes (#594)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -375,6 +375,7 @@ tr.highlight{
   border-radius:var(--radius-2xl);
   background:var(--card-2);
   border:1px solid var(--border);
+  color:var(--fg);
 }
 .action-pill:hover{
   text-decoration:none;


### PR DESCRIPTION
## Summary

- Adds `color: var(--fg)` to the `.action-pill` base rule in `assets/app.css:370`
- Action-pill text was invisible in both light and dark mode because it inherited `--btnfg` from an ancestor element (used for button text on `--btn`-colored backgrounds, not for pills on `--card-2` backgrounds)
- `--fg` is the correct neutral foreground token — no new design token needed

## Regression check

| Selector | Specificity | Color set? | Override? |
|---|---|---|---|
| `.action-pill` | (0,1,0) | `var(--fg)` ← this fix | base |
| `.action-pill.button-secondary` | (0,2,0) | `var(--btn-secondary-fg)` | ✓ overrides |
| `.action-pill.button-danger` | (0,2,0) | `#fff` | ✓ overrides |
| `.subnet-view-btn.active` | (0,2,0) | `var(--btnfg)` | ✓ overrides |

## Test plan

- [x] Playwright 444 passed, 0 failed on SQLite
- [x] Visual: action-pill Edit/Scan/etc. buttons readable in light and dark modes

Closes #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)