### PR TITLE
docs: fix stale backups.php references post-v3.9.0 merge

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -5,7 +5,7 @@ nav_order: 9
 
 # Backup & Restore
 
-Simple PHP IPAM includes built-in backup infrastructure for all supported database engines (SQLite, MySQL, PostgreSQL). Backups are created via a CLI script and tracked in a `backup_history` table. A web-based admin page (`backups.php`) lets admins review history, verify integrity, and download backup files.
+Simple PHP IPAM includes built-in backup infrastructure for all supported database engines (SQLite, MySQL, PostgreSQL). Backups are created via a CLI script and tracked in a `backup_history` table. The **Admin → Database** page (`db_tools.php`) lets admins review backup history, verify integrity, and download backup files alongside the SQL export/import tools (SQLite only).
 
 **There is intentionally no one-click web restore.** Restoration is a CLI-only operation to prevent accidental data loss.
 
@@ -131,9 +131,11 @@ php /path/to/Simple-PHP-IPAM/migrate_db.php --from=sqlite --to=mysql
 
 ---
 
-## Admin UI (backups.php)
+## Admin UI (db_tools.php)
 
-**Admin → Backups** shows:
+> **v3.9.0:** The standalone `backups.php` page was merged into `db_tools.php` (Database Tools). Any existing bookmarks to `backups.php` redirect automatically via HTTP 301.
+
+**Admin → Database** shows the **Backup History** tab with:
 
 - Backup enabled/disabled status
 - Retention count and backup directory

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -69,13 +69,13 @@ Each backup is verified with SHA-256 and recorded in `backup_history`.
 
 ## Verifying Integrity
 
-In **Admin → Backups**, each row in the history table has a **Verify** button (POST, CSRF-protected). This re-computes the SHA-256 hash of the file on disk and compares it to the recorded hash. A mismatch means the file may be corrupted or tampered with.
+In **Admin → Database**, each row in the history table has a **Verify** button (POST, CSRF-protected). This re-computes the SHA-256 hash of the file on disk and compares it to the recorded hash. A mismatch means the file may be corrupted or tampered with.
 
 From the CLI:
 
 ```bash
 sha256sum /path/to/Simple-PHP-IPAM/data/backups/ipam-2026-04-22-020000.sqlite
-# Compare to the hash shown in Admin → Backups
+# Compare to the hash shown in Admin → Database
 ```
 
 ---
@@ -84,7 +84,7 @@ sha256sum /path/to/Simple-PHP-IPAM/data/backups/ipam-2026-04-22-020000.sqlite
 
 ### Step 1: Identify the backup file
 
-Find the file path from **Admin → Backups** (click "Restore…" for the CLI command pre-filled) or list files directly:
+Find the file path from **Admin → Database** (click "Restore…" for the CLI command pre-filled) or list files directly:
 
 ```bash
 ls -lh /path/to/Simple-PHP-IPAM/data/backups/

--- a/docs/sidebar-and-command-palette.md
+++ b/docs/sidebar-and-command-palette.md
@@ -63,7 +63,7 @@ The sidebar is divided into two sections:
 | API Keys | `api_keys.php` |
 | Webhooks | `webhooks.php` |
 | Import CSV | `import_csv.php` |
-| Database Tools | `db_tools.php` — backup history (all engines), SQL export/import (SQLite only) |
+| Database Tools | `db_tools.php` — backup history (all engines), SQL export/import and manual WAL backup (SQLite only) |
 | Health | `health.php` |
 
 ### User block

--- a/docs/sidebar-and-command-palette.md
+++ b/docs/sidebar-and-command-palette.md
@@ -63,8 +63,7 @@ The sidebar is divided into two sections:
 | API Keys | `api_keys.php` |
 | Webhooks | `webhooks.php` |
 | Import CSV | `import_csv.php` |
-| Database Tools | `db_tools.php` (SQLite only) |
-| Backups | `backups.php` |
+| Database Tools | `db_tools.php` — backup history (all engines), SQL export/import (SQLite only) |
 | Health | `health.php` |
 
 ### User block


### PR DESCRIPTION
## Summary

- **`docs/backup.md`**: fix stale `backups.php` → `db_tools.php` references — intro paragraph, section title, and 5 body-text nav path references updated to `Admin → Database`; v3.9.0 migration note added explaining the 301 redirect
- **`docs/sidebar-and-command-palette.md`**: remove the now-obsolete `backups.php` nav row; update the Database Tools description to reflect v3.9.0 unified scope — backup history (all engines), SQL export/import and manual WAL backup (SQLite only)

## Audit context

A full read of all 17 docs files and all 4 website PHP files was performed. These are the only two issues found. All other docs (api, configuration, custom-fields, devices, dhcp-export, install, oidc, scanning, security, smtp, upgrading, webhooks, advanced-networking, ci) are accurate for v3.9.0. The website (front-page.php, page-docs.php, header.php, page.php) is already correct.

## Test plan

- [ ] \`grep -r "Admin → Backups" docs/\` — expect zero matches
- [ ] \`grep -r "backups\.php" docs/\` — expect only the permitted 301-redirect note in backup.md (line 136)
- [ ] Verify backup.md renders correctly: section title, v3.9.0 note, admin page name
- [ ] Verify sidebar doc table has one Database Tools row, no Backups row

🤖 Generated with [Claude Code](https://claude.com/claude-code)