### PR TITLE
docs(v3.17.0): post-release polish + release-procedure update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -946,7 +946,7 @@ If CodeRabbit or a human reviewer asks for a change on the open PR:
    - Quickstart `tar` command: `ipam-X.Y.Z.tar.gz`
    - Update or add feature cards for significant new features
    - **If the release introduces new `docs/*.md` guides, link them from the relevant feature card.** WordPress serves them under `/docs/<slug>/` (e.g. `docs/backups.md` → `/docs/backups/`). Use `<a href="<?php echo esc_url(home_url('/docs/<slug>/')); ?>">Guide name</a>` inside the feature card description. Verify the URL resolves on the live site after deploy.
-   - **Cloudflare cache purge** after deploy: `curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" -H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json" --data '{"purge_everything":true}'` (zone ID + token in `~/.claude/dev-secrets.env`).
+   - **Cache purge** after deploy — `simplephpipam.com` is fronted by **QUIC.cloud CDN**, not Cloudflare. Use the **LiteSpeed Cache (LSCache) WordPress plugin** to purge all three layers in one shot: LSCache (page cache), OPcache (PHP), and QUIC.cloud CDN. Via WP-CLI on the OLS host: `ssh root@192.168.80.23 "wp --path=/usr/local/lsws/vhosts/simplephpipam.com/html --allow-root litespeed-purge all && wp --path=/usr/local/lsws/vhosts/simplephpipam.com/html --allow-root litespeed-purge cdn"`. Verify by hitting the site with cache-buster query string and confirming new HTML hits the origin. Cloudflare purge applies only to `demo.simplephpipam.com`, not the marketing site.
    Then push and deploy:
    ```bash
    cd website/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -945,6 +945,8 @@ If CodeRabbit or a human reviewer asks for a change on the open PR:
    - Download button label (appears twice: hero CTA and quickstart section)
    - Quickstart `tar` command: `ipam-X.Y.Z.tar.gz`
    - Update or add feature cards for significant new features
+   - **If the release introduces new `docs/*.md` guides, link them from the relevant feature card.** WordPress serves them under `/docs/<slug>/` (e.g. `docs/backups.md` → `/docs/backups/`). Use `<a href="<?php echo esc_url(home_url('/docs/<slug>/')); ?>">Guide name</a>` inside the feature card description. Verify the URL resolves on the live site after deploy.
+   - **Cloudflare cache purge** after deploy: `curl -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" -H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json" --data '{"purge_everything":true}'` (zone ID + token in `~/.claude/dev-secrets.env`).
    Then push and deploy:
    ```bash
    cd website/

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -173,7 +173,7 @@ Schedules are created at **Admin → Backup → Schedules** (the Schedules tab o
 | `retain_monthly` | no | How many monthly backup files to keep. Default: `12`. |
 | `is_active` | yes | Toggle the schedule on/off without deleting it. |
 
-`next_run_at` is computed when the schedule is saved and after each run. `cron.php` sets `next_run_at` to the next fire time in UTC immediately after dispatching the backup job.
+`next_run_at` is computed when the schedule is created or edited (any change to the timing fields recomputes it from `frequency` / `time_of_day` / `day_of_week` / `day_of_month`) and again after each run. `cron.php` sets `next_run_at` to the next fire time in UTC after a successful run; failed runs leave `next_run_at` unchanged so the next cron tick will retry rather than skipping ahead. Schema-level CHECK constraints on `backup_schedules` enforce valid values for `frequency`, `day_of_week` (0–6), `day_of_month` (1–28), and the retention counts (≥0); `time_of_day` is validated to `00:00–23:59` at the form layer.
 
 ---
 
@@ -316,10 +316,14 @@ All backup and destination operations are recorded in the audit log:
 | `destination.update` | An existing destination is edited. |
 | `destination.delete` | A destination is deleted (cascades to associated schedules). |
 | `destination.test` | Test Connection is clicked; result (ok/fail) is in the detail. |
+| `schedule.create` | A new schedule is saved (`next_run_at` is computed at create). |
+| `schedule.update` | A schedule is edited (`next_run_at` is recomputed from the new timing fields). |
+| `schedule.delete` | A schedule is deleted. |
 | `backup.run` | A backup job completes successfully (via `BackupEngine` or legacy `backup.php`). |
 | `backup.failed` | A backup job fails (via `BackupEngine` or legacy `backup.php`). |
 | `backup.retention_pruned` | GFS pruning deleted one or more files from a destination. |
 | `remote_backup.delete` | A file is deleted from the Remote Backup Browser. |
+| `remote_backup.delete_failed` | A delete is requested but the destination reports the file did not exist or rejected the request. |
 | `remote_backup.verify` | A file's checksum is verified from the Remote Backup Browser. |
 | `remote_backup.download` | A file is downloaded via `download_remote_backup.php`. |
 | `remote_backup.download_failed` | A remote file download fails. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -525,11 +525,23 @@ Encrypted blobs carry the magic header `IPAMBKP1` (8 bytes, format version 1). T
 
 Every restore operation performed via the web wizard (`restore_web.php`) is recorded in two places:
 
-1. **`audit_log`** — actions `db.restore_stage` (when a remote file is staged in `data/tmp/`), `db.restore_dryrun` (when the wizard runs the dry-run preview), and `db.restore` (when the live apply completes successfully).
-2. **`backup_log`** — a row with `triggered_by = 'web_restore'`, with `status` updated to `running` / `success` / `failed` as the operation progresses, and the destination and filename linked to any existing backup entries.
+1. **`audit_log`** — actions `db.restore_stage` / `db.restore_stage_failed`, `db.restore_dryrun` / `db.restore_dryrun_failed`, `db.restore` / `db.restore_failed`. Failure variants capture the truncated error message in the detail field.
+2. **`backup_log`** — a row with `type = 'restore'`, `triggered_by = 'web_restore'`, with `status` updated `running` → `success` / `failed` as the operation progresses, and the destination linked from the explicit `staged_destination_id` field signed into the wizard token (not inferred from filename — same backup name on multiple destinations would otherwise be ambiguous).
 
-Restore entries are visible on the Backup History page and are filterable via the Type column.
+Restore entries are visible on the Backup History page and are filterable via the Type column. The `backup_log.type` column is the canonical discriminator (`'backup'` vs `'restore'`).
 
 The web restore wizard requires admin role and CSRF on every step. Live apply additionally requires the user to type `RESTORE` exactly into the confirmation field before the Apply button is enabled. This typing gate is enforced server-side — the AJAX handler verifies the submitted confirmation string and rejects the request if it does not match exactly.
+
+### Token signing
+
+The wizard threads four pieces of state across the three steps via signed tokens: the staged file path, original filename, destination id, and size. The signature is an HMAC-SHA256 of all four fields under an HKDF-derived sub-key (`'ipam-v3:restore-stage'`). An attacker who tampers with any individual field produces a signature mismatch — the wizard cannot, for example, be tricked into applying a backup that originated from a different destination by flipping `staged_destination_id` between dryrun and apply.
+
+### Path containment
+
+`prepareForRestore()` rejects any remote name containing `/`, `\`, null bytes, or a leading `.` before passing it to a backup client (defence-in-depth — direct POSTs to `download_remote_backup.php` bypass the `remote_backups.php` form-level guard). `verifySigned()` then resolves both the staged path and the `data/tmp/` root through `realpath()` so symlinked deployment paths resolve consistently. `readStagedSql()` re-asserts the containment guard before opening the staged file.
+
+### Checksum verification
+
+If the originating backup row in `backup_log` (filtered to `type = 'backup'`) has a non-empty `checksum`, `prepareForRestore()` recomputes SHA-256 of the on-the-wire blob (BEFORE decryption) and refuses to stage the file on mismatch. The downloaded blob is unlinked and a `RuntimeException` is thrown — no audit success row, no staged file leftover.
 
 See [Restore from a backup](restore.md) for the full wizard workflow.

--- a/docs/superpowers/plans/2026-04-26-v3.15.0.md
+++ b/docs/superpowers/plans/2026-04-26-v3.15.0.md
@@ -1,0 +1,1946 @@
+# v3.15.0 — Passkeys (WebAuthn) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add WebAuthn/Passkey authentication as a third 2FA option alongside TOTP and Email OTP, controlled by a new `mfa.passkeys_enabled` setting.
+
+**Architecture:** `lbuchs/webauthn` (Composer, zero transitive deps, MIT) handles all server-side challenge/response cryptography. Registration uses a two-round AJAX exchange from `change_password.php` via a new `passkey_register.php` endpoint. Authentication follows the established `totp_verify.php` / `email_otp_verify.php` pattern: `login.php` generates an assertion challenge, stores it in session, redirects to `passkey_verify.php`, which handles both GET (render + inline JS options) and POST (verify assertion + complete login). Priority order when multiple 2FA methods are enrolled: TOTP > Email OTP > Passkey.
+
+**Tech Stack:** PHP 8.2+, SQLite/MySQL/PostgreSQL, `lbuchs/webauthn ^2.1`, `navigator.credentials` browser WebAuthn API (no JS library), Playwright virtual authenticator via `context.addVirtualAuthenticator()`.
+
+---
+
+## GitHub Issues
+
+| # | Title |
+|---|-------|
+| #687 | Add lbuchs/WebAuthn Composer dependency |
+| #688 | webauthn_credentials table and passkey registration flow |
+| #689 | Passkey authentication flow and mfa_passkeys_enabled setting |
+| #718 | test(v3.15.0): Playwright — Passkey registration and authentication |
+
+## Pre-Work Checklist
+
+- [ ] Verify all v3.14.0 and earlier milestone issues are closed on GitHub (they are: milestone #40 shows 0 open issues)
+- [ ] Verify branch state: only `origin/dev` and `origin/main` exist — no stale branches to delete
+- [ ] Create feature branch `feat/v3.15.0` from `dev`
+
+## File Map
+
+**New files:**
+- `Simple-PHP-IPAM/passkey_register.php` — CSRF-protected POST-only AJAX endpoint; two actions: `get_challenge` (generates registration options) and `complete` (verifies attestation, stores credential)
+- `Simple-PHP-IPAM/passkey_verify.php` — mid-login challenge page; GET renders page+inline JS options; POST verifies assertion and calls `login_user()`
+- `testing/playwright/tests/passkeys.spec.ts` — Playwright E2E tests using virtual authenticator
+
+**Modified files:**
+- `composer.json` — add `lbuchs/webauthn: ^2.1`
+- `Simple-PHP-IPAM/migrations.php` — add `3.15.0-passkeys` migration (all three engines)
+- `Simple-PHP-IPAM/schema.sql` — add `webauthn_credentials` table
+- `Simple-PHP-IPAM/schema.mysql.sql` — add `webauthn_credentials` table
+- `Simple-PHP-IPAM/schema.pgsql.sql` — add `webauthn_credentials` table
+- `Simple-PHP-IPAM/lib.php` — add `mfa.passkeys_enabled` settings registry entry, six passkey helper functions
+- `Simple-PHP-IPAM/login.php` — add passkey challenge dispatch after Email OTP check; update `mfa.require` guard to exclude users with passkeys
+- `Simple-PHP-IPAM/change_password.php` — add passkey management card (list credentials, add, delete, disable all)
+- `Simple-PHP-IPAM/users.php` — add admin passkey reset action + passkey count column
+- `Simple-PHP-IPAM/demo_seed.php` — add `SEED_PASSKEY_TEST_USER` seeding block
+- `testing/playwright/bootstrap-app.sh` — export `SEED_PASSKEY_TEST_USER=1` and write env var
+- `testing/playwright/tests/pages.spec.ts` — add `passkey_verify.php` and `passkey_register.php` to page-load guard
+- `Simple-PHP-IPAM/version.php` — bump to `3.15.0`
+- `CHANGELOG.md` — add `## [3.15.0]` entry
+- `README.md` — replace "What's new" section in-place
+- `CLAUDE.md` — update current version + page inventory (two new pages)
+- `docs/configuration.md` — document `mfa.passkeys_enabled`
+- `docs/security.md` — add passkeys section
+- `docs/upgrading.md` — add `### v3.15.0` at top of version-specific notes
+
+---
+
+## Task 1: Feature branch
+
+**Files:** (none yet)
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/v3.15.0
+```
+
+Expected: on branch `feat/v3.15.0`, clean working tree.
+
+- [ ] **Step 2: Commit branch creation marker**
+
+```bash
+git commit --allow-empty -m "chore: begin v3.15.0 — Passkeys (WebAuthn)"
+```
+
+---
+
+## Task 2: Add lbuchs/webauthn dependency (#687)
+
+**Files:**
+- Modify: `composer.json`
+- Modify: `CLAUDE.md` — dep whitelist table
+
+- [ ] **Step 1: Install the dependency**
+
+```bash
+composer require lbuchs/webauthn:^2.1
+```
+
+Expected output ends with: `lbuchs/webauthn (vX.Y.Z)` installed, `vendor/` updated, `composer.lock` updated.
+
+- [ ] **Step 2: Verify package installs cleanly**
+
+```bash
+php -r "require 'vendor/autoload.php'; \$c = new \lbuchs\WebAuthn\WebAuthn('Test','localhost'); echo get_class(\$c) . PHP_EOL;"
+```
+
+Expected: `lbuchs\WebAuthn\WebAuthn`
+
+- [ ] **Step 3: Add dep to CLAUDE.md whitelist table**
+
+In `CLAUDE.md`, locate the **Current runtime dependency whitelist** table and add a row:
+
+```markdown
+| lbuchs/webauthn | ^2.1 | WebAuthn server-side challenge/response — attestation verification, assertion verification, COSE key parsing. Hand-rolling WebAuthn is a security risk (CBOR-encoded COSE keys, cryptographic signature chains, RP ID binding); this library has zero transitive runtime deps, MIT license, pure PHP 8.2+. | #687, v3.15.0 |
+```
+
+- [ ] **Step 4: Static analysis**
+
+```bash
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composer.json composer.lock CLAUDE.md
+git commit -m "feat(passkeys): add lbuchs/webauthn ^2.1 Composer dependency (#687)"
+```
+
+---
+
+## Task 3: Schema migration (#688)
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/migrations.php`
+- Modify: `Simple-PHP-IPAM/schema.sql`
+- Modify: `Simple-PHP-IPAM/schema.mysql.sql`
+- Modify: `Simple-PHP-IPAM/schema.pgsql.sql`
+
+- [ ] **Step 1: Write the PHPUnit migration test (TDD — write first)**
+
+In `tests/MigrationTest.php`, add a test that verifies the `webauthn_credentials` table exists and has the correct columns after `apply_migrations()` runs:
+
+```php
+public function testPasskeysMigrationAddsWebAuthnCredentialsTable(): void
+{
+    // Re-use the same $db created in setUp() after all migrations run
+    $cols = [];
+    foreach ($this->db->query("PRAGMA table_info(webauthn_credentials)")->fetchAll() as $row) {
+        $cols[] = $row['name'];
+    }
+    sort($cols);
+    $expected = ['created_at', 'credential_id', 'id', 'last_used_at', 'name', 'public_key', 'sign_count', 'user_id'];
+    $this->assertSame($expected, $cols);
+}
+```
+
+- [ ] **Step 2: Run the test — expect FAIL**
+
+```bash
+vendor/bin/phpunit tests/MigrationTest.php --filter testPasskeysMigrationAddsWebAuthnCredentialsTable
+```
+
+Expected: FAIL — `webauthn_credentials` does not exist yet.
+
+- [ ] **Step 3: Add `3.15.0-passkeys` migration to `migrations.php`**
+
+In `Simple-PHP-IPAM/migrations.php`, locate the array returned by `ipam_migrations()`. Add after the last `3.14.0-*` key:
+
+```php
+'3.15.0-passkeys' => static function (PDO $db): void {
+    $driver = $db->getAttribute(PDO::ATTR_DRIVER_NAME);
+    $tables = [];
+    if ($driver === 'sqlite') {
+        foreach ($db->query("SELECT name FROM sqlite_master WHERE type='table'")->fetchAll() as $t) {
+            $tables[] = $t['name'];
+        }
+    } elseif ($driver === 'mysql') {
+        foreach ($db->query("SHOW TABLES")->fetchAll(PDO::FETCH_COLUMN) as $t) {
+            $tables[] = $t;
+        }
+    } else {
+        foreach ($db->query("SELECT tablename FROM pg_tables WHERE schemaname='public'")->fetchAll(PDO::FETCH_COLUMN) as $t) {
+            $tables[] = $t;
+        }
+    }
+
+    if (in_array('webauthn_credentials', $tables, true)) {
+        return; // idempotent
+    }
+
+    if ($driver === 'sqlite') {
+        $db->exec("
+            CREATE TABLE webauthn_credentials (
+              id            INTEGER PRIMARY KEY AUTOINCREMENT,
+              user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              credential_id BLOB    NOT NULL UNIQUE,
+              public_key    TEXT    NOT NULL,
+              sign_count    INTEGER NOT NULL DEFAULT 0,
+              name          TEXT    NOT NULL DEFAULT 'Passkey',
+              created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+              last_used_at  TEXT
+            )
+        ");
+        $db->exec("CREATE INDEX idx_webauthn_credentials_user ON webauthn_credentials(user_id)");
+    } elseif ($driver === 'mysql') {
+        $db->exec("
+            CREATE TABLE webauthn_credentials (
+              id            INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              user_id       INT UNSIGNED NOT NULL,
+              credential_id VARBINARY(255) NOT NULL,
+              public_key    TEXT NOT NULL,
+              sign_count    INT UNSIGNED NOT NULL DEFAULT 0,
+              name          VARCHAR(255) NOT NULL DEFAULT 'Passkey',
+              created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              last_used_at  DATETIME,
+              UNIQUE KEY uq_wac_cred_id (credential_id),
+              CONSTRAINT fk_wac_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+              INDEX idx_webauthn_credentials_user (user_id)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ");
+    } else {
+        $db->exec("
+            CREATE TABLE webauthn_credentials (
+              id            SERIAL PRIMARY KEY,
+              user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              credential_id BYTEA   NOT NULL UNIQUE,
+              public_key    TEXT    NOT NULL,
+              sign_count    INTEGER NOT NULL DEFAULT 0,
+              name          VARCHAR(255) NOT NULL DEFAULT 'Passkey',
+              created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+              last_used_at  TIMESTAMP
+            )
+        ");
+        $db->exec("CREATE INDEX idx_webauthn_credentials_user ON webauthn_credentials(user_id)");
+    }
+},
+```
+
+- [ ] **Step 4: Update `schema.sql` (SQLite)**
+
+After the `backup_history` table block, add:
+
+```sql
+-- v3.15.0 #688: WebAuthn/Passkey credentials
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  credential_id BLOB    NOT NULL UNIQUE,
+  public_key    TEXT    NOT NULL,
+  sign_count    INTEGER NOT NULL DEFAULT 0,
+  name          TEXT    NOT NULL DEFAULT 'Passkey',
+  created_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+  last_used_at  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_user ON webauthn_credentials(user_id);
+```
+
+- [ ] **Step 5: Update `schema.mysql.sql`**
+
+After the `backup_history` table block, add:
+
+```sql
+-- v3.15.0 #688: WebAuthn/Passkey credentials
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+  id            INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  user_id       INT UNSIGNED NOT NULL,
+  credential_id VARBINARY(255) NOT NULL,
+  public_key    TEXT NOT NULL,
+  sign_count    INT UNSIGNED NOT NULL DEFAULT 0,
+  name          VARCHAR(255) NOT NULL DEFAULT 'Passkey',
+  created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at  DATETIME,
+  UNIQUE KEY uq_wac_cred_id (credential_id),
+  CONSTRAINT fk_wac_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  INDEX idx_webauthn_credentials_user (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+```
+
+- [ ] **Step 6: Update `schema.pgsql.sql`**
+
+After the `backup_history` table block, add:
+
+```sql
+-- v3.15.0 #688: WebAuthn/Passkey credentials
+CREATE TABLE IF NOT EXISTS webauthn_credentials (
+  id            SERIAL PRIMARY KEY,
+  user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  credential_id BYTEA   NOT NULL UNIQUE,
+  public_key    TEXT    NOT NULL,
+  sign_count    INTEGER NOT NULL DEFAULT 0,
+  name          VARCHAR(255) NOT NULL DEFAULT 'Passkey',
+  created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at  TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_webauthn_credentials_user ON webauthn_credentials(user_id);
+```
+
+- [ ] **Step 7: Run migration test — expect PASS**
+
+```bash
+vendor/bin/phpunit tests/MigrationTest.php
+```
+
+Expected: all tests pass including the new one.
+
+- [ ] **Step 8: Syntax check, phpstan, phpcs**
+
+```bash
+php -l Simple-PHP-IPAM/migrations.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Simple-PHP-IPAM/migrations.php Simple-PHP-IPAM/schema.sql \
+        Simple-PHP-IPAM/schema.mysql.sql Simple-PHP-IPAM/schema.pgsql.sql \
+        tests/MigrationTest.php
+git commit -m "feat(passkeys): add webauthn_credentials migration and schema for all three engines (#688)"
+```
+
+---
+
+## Task 4: lib.php — settings registry and passkey helpers
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/lib.php`
+
+- [ ] **Step 1: Add `mfa.passkeys_enabled` to the settings registry**
+
+In `Simple-PHP-IPAM/lib.php`, locate the MFA settings block (around line 1543, after `mfa.require`). Add:
+
+```php
+'mfa.passkeys_enabled' => [
+    'label'       => 'Enable Passkeys (WebAuthn)',
+    'type'        => 'bool',
+    'default'     => false,
+    'group'       => 'mfa',
+    'description' => 'Allow users to register hardware security keys or device biometrics (Face ID, Touch ID, Windows Hello) as a second authentication factor.',
+    'sensitive'   => false,
+    'config_key'  => null,
+],
+```
+
+- [ ] **Step 2: Add passkey helper functions to `lib.php`**
+
+After the last `ipam_email_otp_*` function block (around line 8210), add:
+
+```php
+// ── Passkeys (WebAuthn) ───────────────────────────────────────────────────────
+
+function ipam_passkey_webauthn(string $rpName = 'Simple PHP IPAM'): \lbuchs\WebAuthn\WebAuthn
+{
+    // Strip port from HTTP_HOST — rpId must be hostname only, no port.
+    $host = to_str($_SERVER['HTTP_HOST'] ?? 'localhost');
+    $rpId = (string)preg_replace('/:\d+$/', '', $host) ?: 'localhost';
+    return new \lbuchs\WebAuthn\WebAuthn($rpName, $rpId, allowedFormats: ['none', 'packed', 'apple']);
+}
+
+/** @return list<array<string,mixed>> */
+function ipam_passkey_get_credentials(PDO $db, int $userId): array
+{
+    $st = $db->prepare(
+        "SELECT id, credential_id, public_key, sign_count, name, created_at, last_used_at
+           FROM webauthn_credentials
+          WHERE user_id = :uid
+          ORDER BY created_at"
+    );
+    $st->execute([':uid' => $userId]);
+    return $st->fetchAll() ?: [];
+}
+
+function ipam_passkey_has_credentials(PDO $db, int $userId): bool
+{
+    $st = $db->prepare("SELECT COUNT(*) FROM webauthn_credentials WHERE user_id = :uid");
+    $st->execute([':uid' => $userId]);
+    return (int)$st->fetchColumn() > 0;
+}
+
+function ipam_passkey_count(PDO $db, int $userId): int
+{
+    $st = $db->prepare("SELECT COUNT(*) FROM webauthn_credentials WHERE user_id = :uid");
+    $st->execute([':uid' => $userId]);
+    return (int)$st->fetchColumn();
+}
+
+function ipam_passkey_delete(PDO $db, int $credentialDbId, int $userId): bool
+{
+    $st = $db->prepare("DELETE FROM webauthn_credentials WHERE id = :id AND user_id = :uid");
+    $st->execute([':id' => $credentialDbId, ':uid' => $userId]);
+    return $st->rowCount() > 0;
+}
+
+function ipam_passkey_delete_all(PDO $db, int $userId): void
+{
+    $db->prepare("DELETE FROM webauthn_credentials WHERE user_id = :uid")->execute([':uid' => $userId]);
+}
+
+/**
+ * Look up a credential by its binary credential_id; returns DB row or null.
+ * @return array<string,mixed>|null
+ */
+function ipam_passkey_find_by_credential_id(PDO $db, string $credentialIdBin): ?array
+{
+    $st = $db->prepare(
+        "SELECT id, user_id, credential_id, public_key, sign_count, name
+           FROM webauthn_credentials
+          WHERE credential_id = :cid"
+    );
+    $st->bindValue(':cid', $credentialIdBin, PDO::PARAM_LOB);
+    $st->execute();
+    $row = $st->fetch();
+    return $row ?: null;
+}
+
+function ipam_passkey_update_sign_count(PDO $db, int $credentialDbId, int $signCount): void
+{
+    $nowExpr = ipam_db_now_expr($db);
+    $db->prepare("UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = $nowExpr WHERE id = :id")
+       ->execute([':sc' => $signCount, ':id' => $credentialDbId]);
+}
+```
+
+**Note:** `ipam_db_now_expr()` is already in lib.php — verify the function name by searching: `grep -n "function ipam_db_now" Simple-PHP-IPAM/lib.php`. If the function is named differently (e.g. `ipam_now_expr`), use the correct name.
+
+- [ ] **Step 3: Static analysis + lint**
+
+```bash
+php -l Simple-PHP-IPAM/lib.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+```
+
+Expected: no new errors. If PHPStan complains about `\lbuchs\WebAuthn\WebAuthn` not found, verify composer autoloader is loaded in `phpstan.neon` (it should already be via `autoload_files`).
+
+- [ ] **Step 4: Run PHPUnit**
+
+```bash
+vendor/bin/phpunit
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Simple-PHP-IPAM/lib.php
+git commit -m "feat(passkeys): add mfa.passkeys_enabled setting and passkey helper functions to lib.php (#688, #689)"
+```
+
+---
+
+## Task 5: `passkey_register.php` — registration AJAX endpoint (#688)
+
+**Files:**
+- Create: `Simple-PHP-IPAM/passkey_register.php`
+
+This is a POST-only JSON endpoint requiring auth. Two `action` values:
+- `get_challenge` — generates `PublicKeyCredentialCreationOptions` and stores challenge in session
+- `complete` — verifies attestation and stores credential to DB
+
+- [ ] **Step 1: Create `passkey_register.php`**
+
+```php
+<?php
+declare(strict_types=1);
+/**
+ * passkey_register.php — WebAuthn credential registration (POST-only JSON)
+ *
+ * action=get_challenge : returns PublicKeyCredentialCreationOptions JSON
+ * action=complete      : verifies attestation and stores credential
+ *
+ * Requires: session auth (require_login), CSRF on every POST.
+ */
+
+require __DIR__ . '/init.php';
+/** @var \PDO $db */
+/** @var IpamConfig $config */
+require_login();
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'method']);
+    exit;
+}
+
+if (!hash_equals(to_str($_SESSION['csrf'] ?? ''), to_str($_POST['csrf'] ?? ''))) {
+    http_response_code(403);
+    echo json_encode(['error' => 'csrf']);
+    exit;
+}
+
+if (!(bool)to_int(ipam_setting('mfa.passkeys_enabled', false))) {
+    http_response_code(403);
+    echo json_encode(['error' => 'disabled']);
+    exit;
+}
+
+$cur    = current_user();
+$userId = to_int($cur['id']);
+$action = to_str($_POST['action'] ?? '');
+
+// ── action: get_challenge ────────────────────────────────────────────────────
+if ($action === 'get_challenge') {
+    // Load user name/email for display in the authenticator prompt
+    $uRow = $db->prepare("SELECT username, name, email FROM users WHERE id = :id")->execute([':id' => $userId])
+        ? $db->prepare("SELECT username, name, email FROM users WHERE id = :id") : null;
+    $uStmt = $db->prepare("SELECT username, name, email FROM users WHERE id = :id");
+    $uStmt->execute([':id' => $userId]);
+    /** @var array<string,mixed>|false $uData */
+    $uData = $uStmt->fetch();
+
+    $username    = $uData ? to_str($uData['username']) : to_str($cur['username']);
+    $displayName = ($uData && to_str($uData['name']) !== '') ? to_str($uData['name']) : $username;
+
+    $existingCreds = ipam_passkey_get_credentials($db, $userId);
+    $excludeIds    = [];
+    foreach ($existingCreds as $ec) {
+        $excludeIds[] = new \lbuchs\WebAuthn\Binary\ByteBuffer((string)$ec['credential_id']);
+    }
+
+    $webAuthn = ipam_passkey_webauthn();
+    $createArgs = $webAuthn->getCreateArgs(
+        \base64_encode((string)$userId),
+        $username,
+        $displayName,
+        60,
+        requireResidentKey: false,
+        userVerification: 'preferred',
+        crossPlatformAttachment: null,
+        excludeCredentialIds: $excludeIds
+    );
+
+    $_SESSION['passkey_reg_challenge'] = $webAuthn->getChallenge()->getBinaryString();
+
+    echo json_encode(['ok' => true, 'options' => $createArgs]);
+    exit;
+}
+
+// ── action: complete ─────────────────────────────────────────────────────────
+if ($action === 'complete') {
+    if (empty($_SESSION['passkey_reg_challenge'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'no_challenge']);
+        exit;
+    }
+
+    $clientDataJSON    = to_str($_POST['clientDataJSON']    ?? '');
+    $attestationObject = to_str($_POST['attestationObject'] ?? '');
+    $credentialName    = mb_substr(trim(to_str($_POST['name'] ?? '')), 0, 100) ?: 'Passkey';
+
+    if ($clientDataJSON === '' || $attestationObject === '') {
+        http_response_code(400);
+        echo json_encode(['error' => 'missing_fields']);
+        exit;
+    }
+
+    try {
+        $challenge = new \lbuchs\WebAuthn\Binary\ByteBuffer($_SESSION['passkey_reg_challenge']);
+        $webAuthn  = ipam_passkey_webauthn();
+        $credential = $webAuthn->processCreate(
+            $clientDataJSON,
+            $attestationObject,
+            $challenge,
+            verifyUser: false,
+            failIfRpIdHashMismatch: false
+        );
+    } catch (\lbuchs\WebAuthn\WebAuthnException $e) {
+        unset($_SESSION['passkey_reg_challenge']);
+        http_response_code(400);
+        echo json_encode(['error' => 'verification_failed', 'detail' => $e->getMessage()]);
+        audit($db, 'mfa.passkey.register_fail', 'user', $userId, substr($e->getMessage(), 0, 200));
+        exit;
+    }
+
+    unset($_SESSION['passkey_reg_challenge']);
+
+    $credIdBin  = $credential->credentialId->getBinaryString();
+    $publicKey  = $credential->credentialPublicKey;
+    $signCount  = (int)($credential->signCount ?? 0);
+
+    $st = $db->prepare(
+        "INSERT INTO webauthn_credentials (user_id, credential_id, public_key, sign_count, name)
+         VALUES (:uid, :cid, :pk, :sc, :nm)"
+    );
+    $st->bindValue(':uid', $userId, PDO::PARAM_INT);
+    $st->bindValue(':cid', $credIdBin, PDO::PARAM_LOB);
+    $st->bindValue(':pk',  $publicKey, PDO::PARAM_STR);
+    $st->bindValue(':sc',  $signCount, PDO::PARAM_INT);
+    $st->bindValue(':nm',  $credentialName, PDO::PARAM_STR);
+    $st->execute();
+    $newId = (int)$db->lastInsertId();
+
+    audit($db, 'mfa.passkey.register', 'user', $userId, "name={$credentialName}");
+
+    echo json_encode(['ok' => true, 'id' => $newId, 'name' => $credentialName]);
+    exit;
+}
+
+http_response_code(400);
+echo json_encode(['error' => 'unknown_action']);
+```
+
+- [ ] **Step 2: Lint + static analysis**
+
+```bash
+php -l Simple-PHP-IPAM/passkey_register.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/passkey_register.php
+```
+
+Expected: no errors. If PHPStan flags the `ipam_passkey_*` calls as undefined, confirm the functions were committed in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Simple-PHP-IPAM/passkey_register.php
+git commit -m "feat(passkeys): add passkey_register.php AJAX endpoint for WebAuthn registration (#688)"
+```
+
+---
+
+## Task 6: `passkey_verify.php` — mid-login challenge page (#689)
+
+**Files:**
+- Create: `Simple-PHP-IPAM/passkey_verify.php`
+
+Pattern mirrors `email_otp_verify.php`: session-guarded, GET renders the page with inline JS assertion options, POST verifies and completes login.
+
+- [ ] **Step 1: Create `passkey_verify.php`**
+
+```php
+<?php
+declare(strict_types=1);
+require __DIR__ . '/init.php';
+/** @var \PDO $db */
+/** @var IpamConfig $config */
+
+// Guard: must have a pending passkey session set by login.php
+if (empty($_SESSION['passkey_pending_uid']) || empty($_SESSION['passkey_challenge'])) {
+    header('Location: login.php');
+    exit;
+}
+
+if (is_logged_in()) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$uid = to_int($_SESSION['passkey_pending_uid']);
+
+// Reload user — never trust session-stored fields
+$userSt = $db->prepare(
+    "SELECT id, username, role FROM users WHERE id = :id AND is_active = 1"
+);
+$userSt->execute([':id' => $uid]);
+/** @var array<string,mixed>|false $userRow */
+$userRow = $userSt->fetch();
+
+if (!$userRow) {
+    unset($_SESSION['passkey_pending_uid'], $_SESSION['passkey_challenge'], $_SESSION['passkey_assertion_options']);
+    header('Location: login.php');
+    exit;
+}
+
+$username = to_str($userRow['username']);
+$role     = to_str($userRow['role']);
+$error    = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_require();
+
+    $clientDataJSON    = to_str($_POST['clientDataJSON']    ?? '');
+    $authenticatorData = to_str($_POST['authenticatorData'] ?? '');
+    $signature         = to_str($_POST['signature']         ?? '');
+    $credentialId      = to_str($_POST['credentialId']      ?? '');
+
+    if ($clientDataJSON === '' || $authenticatorData === '' || $signature === '' || $credentialId === '') {
+        $error = 'Incomplete passkey response. Please try again.';
+    } else {
+        $credIdBin = base64_decode(strtr($credentialId, '-_', '+/'));
+        $cred = ipam_passkey_find_by_credential_id($db, $credIdBin);
+
+        if (!$cred || to_int($cred['user_id']) !== $uid) {
+            ipam_record_2fa_failure($db, $uid, $config);
+            $error = 'Passkey not recognised. Please try again.';
+        } else {
+            try {
+                $challenge = new \lbuchs\WebAuthn\Binary\ByteBuffer(
+                    (string)$_SESSION['passkey_challenge']
+                );
+                $webAuthn  = ipam_passkey_webauthn();
+                $result    = $webAuthn->processGet(
+                    $clientDataJSON,
+                    $authenticatorData,
+                    $signature,
+                    null,
+                    $cred['public_key'],
+                    $challenge,
+                    (int)$cred['sign_count'],
+                    verifyUser: false
+                );
+
+                unset($_SESSION['passkey_pending_uid'], $_SESSION['passkey_challenge'], $_SESSION['passkey_assertion_options']);
+                ipam_passkey_update_sign_count($db, to_int($cred['id']), (int)$result->signCount);
+                login_user($uid, $username, $role, $db);
+
+                $db->prepare("UPDATE users SET last_login_at = datetime('now') WHERE id = :id")
+                   ->execute([':id' => $uid]);
+                audit($db, 'auth.passkey_login', 'user', $uid, 'passkey authentication ok');
+
+                header('Location: dashboard.php');
+                exit;
+
+            } catch (\lbuchs\WebAuthn\WebAuthnException $e) {
+                ipam_record_2fa_failure($db, $uid, $config);
+                audit($db, 'auth.passkey_fail', 'user', $uid, substr($e->getMessage(), 0, 200));
+                $error = 'Passkey verification failed. Please try again.';
+            }
+        }
+    }
+}
+
+// Read pre-generated assertion options from session
+/** @var object $assertionOpts */
+$assertionOpts = json_decode(to_str($_SESSION['passkey_assertion_options'] ?? '{}'));
+
+page_header('Sign in with Passkey');
+?>
+<div class="card" style="max-width:420px;margin:4rem auto">
+  <h2 style="margin-top:0">Sign in with Passkey</h2>
+  <p class="muted">Use your security key or device biometric to verify your identity, <strong><?= e($username) ?></strong>.</p>
+
+  <?php if ($error !== ''): ?>
+    <p class="danger" role="alert"><?= e($error) ?></p>
+  <?php endif ?>
+
+  <form id="passkey-form" method="post" action="passkey_verify.php" novalidate>
+    <input type="hidden" name="csrf"              value="<?= e(csrf_token()) ?>">
+    <input type="hidden" name="clientDataJSON"    id="f-clientDataJSON">
+    <input type="hidden" name="authenticatorData" id="f-authenticatorData">
+    <input type="hidden" name="signature"         id="f-signature">
+    <input type="hidden" name="credentialId"      id="f-credentialId">
+
+    <button type="button" id="btn-passkey" class="btn" style="width:100%;margin-bottom:.75rem">
+      <?= icon('finger-print') ?> Verify with Passkey
+    </button>
+    <a href="login.php" class="button-secondary" style="display:block;text-align:center">Cancel</a>
+  </form>
+
+  <p class="muted" id="passkey-status" style="font-size:.85rem;margin-top:.75rem"></p>
+</div>
+
+<script>
+(function () {
+  var opts = <?= json_encode($assertionOpts) ?>;
+  var btn  = document.getElementById('btn-passkey');
+  var status = document.getElementById('passkey-status');
+
+  function b64url(buf) {
+    return btoa(String.fromCharCode(...new Uint8Array(buf)))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  async function verify() {
+    btn.disabled = true;
+    status.textContent = 'Waiting for authenticator…';
+    try {
+      opts.challenge = Uint8Array.from(atob(opts.challenge.replace(/-/g,'+').replace(/_/g,'/')), c => c.charCodeAt(0));
+      if (opts.allowCredentials) {
+        opts.allowCredentials = opts.allowCredentials.map(function(c) {
+          return Object.assign({}, c, {id: Uint8Array.from(atob(c.id.replace(/-/g,'+').replace(/_/g,'/')), x => x.charCodeAt(0))});
+        });
+      }
+      var cred = await navigator.credentials.get({publicKey: opts});
+      document.getElementById('f-clientDataJSON').value    = b64url(cred.response.clientDataJSON);
+      document.getElementById('f-authenticatorData').value = b64url(cred.response.authenticatorData);
+      document.getElementById('f-signature').value         = b64url(cred.response.signature);
+      document.getElementById('f-credentialId').value      = b64url(cred.rawId);
+      document.getElementById('passkey-form').submit();
+    } catch (err) {
+      status.textContent = 'Passkey prompt cancelled or failed. Try again.';
+      btn.disabled = false;
+    }
+  }
+
+  btn.addEventListener('click', verify);
+
+  // Auto-trigger on page load for a smoother UX
+  window.addEventListener('load', function() { setTimeout(verify, 300); });
+}());
+</script>
+<?php page_footer(); ?>
+```
+
+- [ ] **Step 2: Lint + static analysis + semgrep**
+
+```bash
+php -l Simple-PHP-IPAM/passkey_verify.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/passkey_verify.php
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Simple-PHP-IPAM/passkey_verify.php
+git commit -m "feat(passkeys): add passkey_verify.php mid-login challenge page (#689)"
+```
+
+---
+
+## Task 7: Update `login.php` — passkey dispatch (#689)
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/login.php`
+
+Two changes:
+1. After the Email OTP check (~line 155), add a passkey check that generates an assertion challenge, stores it in session, and redirects to `passkey_verify.php`.
+2. Update the `mfa.require` guard to also skip enrollment if the user has passkeys enrolled and passkeys are enabled.
+
+- [ ] **Step 1: Add passkey SELECT to the users query**
+
+Find the line in `login.php`:
+```php
+$st = $db->prepare("SELECT id, username, password_hash, role, is_active, totp_enabled, email_otp_enabled FROM users WHERE username = :u");
+```
+
+Change to:
+```php
+$st = $db->prepare("SELECT id, username, password_hash, role, is_active, totp_enabled, email_otp_enabled FROM users WHERE username = :u");
+```
+
+(No change needed here — passkey count is looked up separately below to avoid a JOIN on every login attempt.)
+
+- [ ] **Step 2: Add passkey challenge dispatch after the Email OTP block**
+
+Locate this block in `login.php` (around line 155):
+```php
+                $_SESSION['email_otp_pending_uid'] = to_int($user['id']);
+                header('Location: email_otp_verify.php');
+                exit;
+```
+
+Immediately **after** the `exit;` of that block (still inside the `if (password_verify(...))` scope), add:
+
+```php
+                $passkeysEnabled = (bool)to_int(ipam_setting('mfa.passkeys_enabled', false));
+                if ($passkeysEnabled && ipam_passkey_has_credentials($db, to_int($user['id']))) {
+                    // Build assertion options and store in session
+                    $creds         = ipam_passkey_get_credentials($db, to_int($user['id']));
+                    $credentialIds = array_map(
+                        static fn(array $c): \lbuchs\WebAuthn\Binary\ByteBuffer =>
+                            new \lbuchs\WebAuthn\Binary\ByteBuffer((string)$c['credential_id']),
+                        $creds
+                    );
+                    $webAuthn    = ipam_passkey_webauthn();
+                    $assertArgs  = $webAuthn->getGetArgs($credentialIds, 60, 'preferred');
+                    $_SESSION['passkey_pending_uid']        = to_int($user['id']);
+                    $_SESSION['passkey_challenge']          = $webAuthn->getChallenge()->getBinaryString();
+                    $_SESSION['passkey_assertion_options']  = json_encode($assertArgs);
+                    audit($db, 'auth.passkey_challenge', 'user', to_int($user['id']), 'passkey challenge issued');
+                    header('Location: passkey_verify.php');
+                    exit;
+                }
+```
+
+- [ ] **Step 3: Update the `mfa.require` guard**
+
+Locate the `mfa.require` guard block (around line 159):
+```php
+                if ((bool)to_int(ipam_setting('mfa.require', false)) &&
+                    to_int($user['totp_enabled']      ?? 0) === 0 &&
+                    to_int($user['email_otp_enabled'] ?? 0) === 0) {
+```
+
+Replace the condition to also exempt users who have passkeys enrolled (when passkeys are enabled):
+```php
+                $passkeysSatisfy = isset($passkeysEnabled)
+                    ? ($passkeysEnabled && ipam_passkey_has_credentials($db, to_int($user['id'])))
+                    : false;
+                if ((bool)to_int(ipam_setting('mfa.require', false)) &&
+                    to_int($user['totp_enabled']      ?? 0) === 0 &&
+                    to_int($user['email_otp_enabled'] ?? 0) === 0 &&
+                    !$passkeysSatisfy) {
+```
+
+**Note:** `$passkeysEnabled` was set in the passkey block above. If the user had passkeys, we'd have redirected already and never reach this point. But if passkeys are disabled (`$passkeysEnabled = false`), we define `$passkeysSatisfy = false` correctly via the ternary. Use `isset($passkeysEnabled)` to handle the case where the passkey block was skipped entirely (should not happen with correct code, but guards against future refactors).
+
+- [ ] **Step 4: Lint + static analysis**
+
+```bash
+php -l Simple-PHP-IPAM/login.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/login.php
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Simple-PHP-IPAM/login.php
+git commit -m "feat(passkeys): dispatch passkey challenge in login.php after Email OTP check (#689)"
+```
+
+---
+
+## Task 8: `change_password.php` — passkey management UI (#688, #689)
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/change_password.php`
+- Modify: `Simple-PHP-IPAM/assets/app.css` (minor: no new classes needed, uses `.card`, `.action-pill`)
+
+This task uses the **ui-ux-pro-max skill** for design. Invoke it before implementing the UI with the prompt:
+> "Design a passkey management card for the Account page (change_password.php). The card should list enrolled passkeys by name + creation date, provide an 'Add Passkey' button (only shown when mfa.passkeys_enabled=true), and a delete button per credential. Follow the existing TOTP and Email OTP card patterns in the same page. Use the `.card`, `.badge`, `.action-pill`, and existing CSS variables. Accessible: keyboard-navigable, ARIA labels on icon-only buttons, focus-visible rings."
+
+- [ ] **Step 1: Read existing TOTP and Email OTP card HTML for reference**
+
+Run: `grep -n "id=\"totp\"\|id=\"email-otp\"\|card.*totp\|card.*email" Simple-PHP-IPAM/change_password.php | head -10`
+
+Identify the start/end of both MFA card sections to match the same pattern.
+
+- [ ] **Step 2: Add POST handler for passkey delete action**
+
+In `change_password.php`, after the `email_otp_disable` handler block, add:
+
+```php
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && to_str($_POST['action'] ?? '') === 'passkey_delete') {
+    csrf_require();
+    $credId = to_int($_POST['credential_id'] ?? 0);
+    if ($credId > 0 && ipam_passkey_delete($db, $credId, to_int($cur['id']))) {
+        audit($db, 'user.passkey_delete', 'user', to_int($cur['id']), "credential_id={$credId}");
+    }
+    header('Location: change_password.php#passkeys');
+    exit;
+}
+```
+
+- [ ] **Step 3: Load passkey data for display**
+
+After the existing `$emailOtpEnabled` / `$emailOtpRow` load block, add:
+
+```php
+$passkeysEnabled  = (bool)to_int(ipam_setting('mfa.passkeys_enabled', false));
+$passkeyCreds     = ipam_passkey_get_credentials($db, to_int($cur['id']));
+```
+
+- [ ] **Step 4: Add the passkeys card to the HTML**
+
+After the Email OTP card section (`id="email-otp"`), add:
+
+```php
+<section id="passkeys" class="card">
+  <h3 style="margin-top:0"><?= icon('finger-print') ?> Passkeys</h3>
+
+  <?php if (!$passkeysEnabled): ?>
+    <p class="muted">Passkeys are not enabled on this server. Contact your administrator.</p>
+  <?php else: ?>
+
+    <?php if ($passkeyCreds !== []): ?>
+      <p>Your registered passkeys:</p>
+      <ul style="list-style:none;padding:0;margin:0 0 1rem">
+        <?php foreach ($passkeyCreds as $pk): ?>
+          <li style="display:flex;align-items:center;gap:.5rem;padding:.4rem 0;border-bottom:1px solid var(--border)">
+            <?= icon('key') ?>
+            <span style="flex:1"><strong><?= e(to_str($pk['name'])) ?></strong>
+              <span class="muted" style="font-size:.8rem">
+                — added <?= e(substr(to_str($pk['created_at']), 0, 10)) ?>
+                <?php if (to_str($pk['last_used_at']) !== ''): ?>
+                  · last used <?= e(substr(to_str($pk['last_used_at']), 0, 10)) ?>
+                <?php endif ?>
+              </span>
+            </span>
+            <form method="post" action="change_password.php#passkeys"
+                  onsubmit="return confirm('Remove this passkey?')">
+              <input type="hidden" name="csrf"          value="<?= e(csrf_token()) ?>">
+              <input type="hidden" name="action"        value="passkey_delete">
+              <input type="hidden" name="credential_id" value="<?= e((string)to_int($pk['id'])) ?>">
+              <button type="submit" class="action-pill button-danger"
+                      aria-label="Remove passkey <?= e(to_str($pk['name'])) ?>">
+                <?= icon('trash') ?> Remove
+              </button>
+            </form>
+          </li>
+        <?php endforeach ?>
+      </ul>
+    <?php else: ?>
+      <p class="muted">No passkeys registered yet.</p>
+    <?php endif ?>
+
+    <button type="button" id="btn-add-passkey" class="action-pill">
+      <?= icon('plus-circle') ?> Add Passkey
+    </button>
+    <span id="passkey-add-status" class="muted" style="font-size:.85rem;display:none;margin-left:.5rem"></span>
+
+  <?php endif ?>
+</section>
+
+<script>
+(function () {
+  var btn = document.getElementById('btn-add-passkey');
+  if (!btn) return;
+
+  var statusEl = document.getElementById('passkey-add-status');
+
+  function b64url(buf) {
+    return btoa(String.fromCharCode(...new Uint8Array(buf)))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  async function register() {
+    btn.disabled = true;
+    statusEl.style.display = 'inline';
+    statusEl.textContent = 'Generating challenge…';
+
+    var csrf = document.querySelector('[name=csrf]').value;
+
+    try {
+      var challengeRes = await fetch('passkey_register.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({action: 'get_challenge', csrf: csrf})
+      });
+      var challengeData = await challengeRes.json();
+      if (!challengeData.ok) throw new Error(challengeData.error || 'Challenge failed');
+
+      var opts = challengeData.options;
+      opts.challenge = Uint8Array.from(atob(opts.challenge.replace(/-/g,'+').replace(/_/g,'/')), c => c.charCodeAt(0));
+      opts.user.id   = Uint8Array.from(atob(opts.user.id.replace(/-/g,'+').replace(/_/g,'/')), c => c.charCodeAt(0));
+      if (opts.excludeCredentials) {
+        opts.excludeCredentials = opts.excludeCredentials.map(function(c) {
+          return Object.assign({}, c, {id: Uint8Array.from(atob(c.id.replace(/-/g,'+').replace(/_/g,'/')), x => x.charCodeAt(0))});
+        });
+      }
+
+      statusEl.textContent = 'Waiting for authenticator…';
+      var cred = await navigator.credentials.create({publicKey: opts});
+
+      var credName = prompt('Name this passkey (optional):', 'Passkey') || 'Passkey';
+
+      var completeRes = await fetch('passkey_register.php', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({
+          action:            'complete',
+          csrf:              csrf,
+          clientDataJSON:    b64url(cred.response.clientDataJSON),
+          attestationObject: b64url(cred.response.attestationObject),
+          name:              credName
+        })
+      });
+      var result = await completeRes.json();
+      if (!result.ok) throw new Error(result.error || 'Registration failed');
+
+      statusEl.textContent = 'Passkey registered!';
+      setTimeout(function() { window.location.href = 'change_password.php#passkeys'; }, 800);
+
+    } catch (err) {
+      statusEl.textContent = 'Registration failed: ' + err.message;
+      btn.disabled = false;
+    }
+  }
+
+  btn.addEventListener('click', register);
+}());
+</script>
+```
+
+- [ ] **Step 5: Lint + static analysis + semgrep**
+
+```bash
+php -l Simple-PHP-IPAM/change_password.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/change_password.php
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Simple-PHP-IPAM/change_password.php
+git commit -m "feat(passkeys): add passkey management card to change_password.php (#688, #689)"
+```
+
+---
+
+## Task 9: `users.php` — admin passkey management (#689)
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/users.php`
+
+Admin can see passkey count per user and reset (delete all) a user's passkeys.
+
+- [ ] **Step 1: Add passkey count to users SELECT query**
+
+Find the query that selects users (around line 277 in users.php):
+```php
+totp_enabled, email_otp_enabled, locked_until, lock_reason, failed_auth_count
+```
+
+The passkey count requires a subquery. Change the main user fetch to a LEFT JOIN subquery or add passkey count to the display loop:
+
+```php
+// After the user list is fetched, add passkey counts in a second query to avoid a GROUP BY on the main query
+$userIds    = array_column($users, 'id');
+$pkCounts   = [];
+if ($userIds !== []) {
+    $in       = implode(',', array_fill(0, count($userIds), '?'));
+    $pkStmt   = $db->prepare("SELECT user_id, COUNT(*) AS cnt FROM webauthn_credentials WHERE user_id IN ($in) GROUP BY user_id");
+    $pkStmt->execute($userIds);
+    foreach ($pkStmt->fetchAll() as $row) {
+        $pkCounts[to_int($row['user_id'])] = to_int($row['cnt']);
+    }
+}
+```
+
+**Note:** Add this block right after the main user list fetch.
+
+- [ ] **Step 2: Add passkey reset POST handler**
+
+After the `email_otp_reset` handler block, add:
+
+```php
+} elseif ($action === 'passkey_reset') {
+    csrf_require();
+    $target = $db->prepare("SELECT id, username FROM users WHERE id = :id")->execute([':id' => $id])
+        ? $db->prepare("SELECT id, username FROM users WHERE id = :id") : null;
+    $targetStmt = $db->prepare("SELECT id, username FROM users WHERE id = :id");
+    $targetStmt->execute([':id' => $id]);
+    /** @var array<string,mixed>|false $targetRow */
+    $targetRow = $targetStmt->fetch();
+    if ($targetRow) {
+        ipam_passkey_delete_all($db, $id);
+        audit($db, 'user.passkey_reset', 'user', $id, 'admin_reset by ' . e($cur['username']));
+        $flash = 'Passkeys cleared for ' . to_str($targetRow['username']);
+    }
+```
+
+- [ ] **Step 3: Add passkey column to users table and reset button**
+
+In the users table HTML, add a "Passkeys" column header after the "Email OTP" column header.
+
+In the per-user row, add:
+```php
+<td><?php $pk = $pkCounts[to_int($u['id'])] ?? 0; echo $pk > 0 ? "<span class=\"badge badge--success\">{$pk}</span>" : '<span class="muted">—</span>'; ?></td>
+```
+
+After the email_otp reset button block, add:
+```php
+<?php if (($pkCounts[to_int($u['id'])] ?? 0) > 0 && to_int($u['id']) !== $self['id']): ?>
+  <form method="post" onsubmit="return confirm('Delete ALL passkeys for this user?')">
+    <input type="hidden" name="csrf"   value="<?= e(csrf_token()) ?>">
+    <input type="hidden" name="action" value="passkey_reset">
+    <input type="hidden" name="id"     value="<?= e((string)to_int($u['id'])) ?>">
+    <button type="submit" class="action-pill button-danger">
+      <?= icon('key') ?> Reset Passkeys
+    </button>
+  </form>
+<?php endif ?>
+```
+
+- [ ] **Step 4: Lint + static analysis**
+
+```bash
+php -l Simple-PHP-IPAM/users.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Simple-PHP-IPAM/users.php
+git commit -m "feat(passkeys): add passkey count and admin reset to users.php (#689)"
+```
+
+---
+
+## Task 10: `pages.spec.ts` and `demo_seed.php` updates (#718)
+
+**Files:**
+- Modify: `testing/playwright/tests/pages.spec.ts`
+- Modify: `Simple-PHP-IPAM/demo_seed.php`
+- Modify: `testing/playwright/bootstrap-app.sh`
+
+- [ ] **Step 1: Add new pages to pages.spec.ts**
+
+In `testing/playwright/tests/pages.spec.ts`, find the page guard list (a `for...of` loop or array of page paths). Add `passkey_verify.php` and `passkey_register.php`.
+
+`passkey_verify.php` should be tested as a redirect-to-login case (no session):
+```typescript
+test('passkey_verify.php redirects to login without pending session', async ({ page }) => {
+    await page.goto('passkey_verify.php');
+    await expect(page).toHaveURL(/login\.php/);
+});
+```
+
+`passkey_register.php` should be tested as a JSON error when accessed as GET:
+```typescript
+test('passkey_register.php returns 405 on GET', async ({ page }) => {
+    const resp = await page.request.get(appUrl('passkey_register.php'));
+    expect(resp.status()).toBe(405);
+});
+```
+
+- [ ] **Step 2: Add passkey test user to `demo_seed.php`**
+
+After the `SEED_EMAIL_OTP_TEST_USER` block (around line 115), add:
+
+```php
+// Passkey test user — seeded only when SEED_PASSKEY_TEST_USER=1
+// The user exists WITHOUT a pre-seeded credential (WebAuthn credentials require
+// a real browser ceremony). The test spec uses a virtual authenticator to register
+// credentials dynamically at test time.
+if (getenv('SEED_PASSKEY_TEST_USER') === '1') {
+    $pwHash = password_hash('Password1!', PASSWORD_DEFAULT);
+    $exists = $db->prepare("SELECT id FROM users WHERE username = 'passkey_test_user'");
+    $exists->execute();
+    if (!$exists->fetch()) {
+        $db->prepare(
+            "INSERT INTO users (username, password_hash, role, is_active, email) VALUES (?,?,?,1,?)"
+        )->execute(['passkey_test_user', $pwHash, 'readonly', 'passkey-test@example.com']);
+    }
+}
+```
+
+- [ ] **Step 3: Update `bootstrap-app.sh`**
+
+Find the line:
+```bash
+docker run --rm "${seed_docker_args[@]}" -e SEED_2FA_TEST_USER=1 -e SEED_EMAIL_OTP_TEST_USER=1 ...
+```
+
+Add `-e SEED_PASSKEY_TEST_USER=1` to the same line.
+
+Find the block that writes `SEED_EMAIL_OTP_TEST_USER=1` to the `.env` file and add a similar block:
+```bash
+if grep -q "^SEED_PASSKEY_TEST_USER=" "${script_dir}/.env" 2>/dev/null; then
+    perl -i -pe 's/^SEED_PASSKEY_TEST_USER=.*/SEED_PASSKEY_TEST_USER=1/' "${script_dir}/.env"
+else
+    echo "SEED_PASSKEY_TEST_USER=1" >> "${script_dir}/.env"
+fi
+```
+
+- [ ] **Step 4: Lint + phpstan (for demo_seed.php)**
+
+```bash
+php -l Simple-PHP-IPAM/demo_seed.php
+vendor/bin/phpstan analyse --memory-limit=1G
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add testing/playwright/tests/pages.spec.ts Simple-PHP-IPAM/demo_seed.php \
+        testing/playwright/bootstrap-app.sh
+git commit -m "test(passkeys): seed passkey_test_user, add page guard tests for new pages (#718)"
+```
+
+---
+
+## Task 11: Playwright passkeys.spec.ts (#718)
+
+**Files:**
+- Create: `testing/playwright/tests/passkeys.spec.ts`
+
+Uses Playwright `context.addVirtualAuthenticator()` for deterministic WebAuthn testing without real hardware.
+
+- [ ] **Step 1: Create `passkeys.spec.ts`**
+
+```typescript
+/**
+ * passkeys.spec.ts — WebAuthn/Passkey 2FA tests
+ *
+ * Uses Playwright's built-in virtual authenticator (Chromium only) to simulate
+ * hardware security key interactions without real hardware.
+ *
+ * Prerequisites:
+ *   - SEED_PASSKEY_TEST_USER=1 set by bootstrap-app.sh
+ *   - mfa.passkeys_enabled=true set via settings API at start of suite
+ *   - Chromium only — Firefox/WebKit do not expose the addVirtualAuthenticator API
+ */
+
+import { test, expect, BrowserContext } from '@playwright/test';
+import { login, logout, ADMIN_USER, ADMIN_PASS, appUrl, fetchPost } from '../fixtures/ipam';
+
+// ── Self-skip guard ──────────────────────────────────────────────────────────
+
+function isPasskeySeeded(): boolean {
+    return process.env.SEED_PASSKEY_TEST_USER === '1';
+}
+
+const PASSKEY_USER = 'passkey_test_user';
+const PASSKEY_PASS = 'Password1!';
+
+// ── Virtual authenticator setup ──────────────────────────────────────────────
+
+async function addVirtualAuth(context: BrowserContext) {
+    return context.addVirtualAuthenticator({
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: false,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+    });
+}
+
+// ── Helper: enable/disable passkeys via admin settings ──────────────────────
+
+async function setPasskeysEnabled(page: import('@playwright/test').Page, enabled: boolean) {
+    await login(page, ADMIN_USER, ADMIN_PASS);
+    const csrf = await page.evaluate(() =>
+        (document.querySelector('[name=csrf]') as HTMLInputElement | null)?.value ?? ''
+    );
+    // Navigate to settings page and toggle mfa.passkeys_enabled
+    await page.goto(appUrl('settings.php'));
+    // The settings page uses a POST form with key-prefixed field names.
+    // mfa.passkeys_enabled maps to k_mfa__passkeys_enabled (dots → __, dashes preserved).
+    const fieldName = 'k_mfa__passkeys_enabled';
+    if (enabled) {
+        await page.locator(`[name="${fieldName}"]`).check();
+    } else {
+        await page.locator(`[name="${fieldName}"]`).uncheck().catch(() => {});
+    }
+    await page.locator('button[type=submit]').first().click();
+    await logout(page);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Passkeys', () => {
+    test.skip(!isPasskeySeeded(), 'SEED_PASSKEY_TEST_USER not set — skipping passkeys suite');
+
+    test.beforeAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        await setPasskeysEnabled(page, true);
+        await page.close();
+    });
+
+    test.afterAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        await setPasskeysEnabled(page, false);
+        await page.close();
+    });
+
+    test('passkeys disabled: Account page shows disabled notice', async ({ page }) => {
+        // Temporarily disable for this check
+        const adminPage = await page.context().newPage();
+        await setPasskeysEnabled(adminPage, false);
+        await adminPage.close();
+
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php'));
+        await expect(page.locator('#passkeys')).toContainText('not enabled on this server');
+
+        // Re-enable for subsequent tests
+        const re = await page.context().newPage();
+        await setPasskeysEnabled(re, true);
+        await re.close();
+    });
+
+    test('Account page shows Add Passkey button when passkeys enabled', async ({ page }) => {
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php'));
+        await expect(page.locator('#btn-add-passkey')).toBeVisible();
+    });
+
+    test('register a passkey via virtual authenticator', async ({ page, context }) => {
+        const auth = await addVirtualAuth(context);
+
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php#passkeys'));
+        await expect(page.locator('#btn-add-passkey')).toBeVisible();
+
+        page.on('dialog', dialog => dialog.accept('My Test Passkey'));
+        await page.locator('#btn-add-passkey').click();
+
+        // Wait for success message and page reload
+        await page.waitForURL(/change_password\.php/, { timeout: 30_000 });
+        await expect(page.locator('#passkeys')).toContainText('My Test Passkey');
+
+        await auth.dispose();
+    });
+
+    test('login with passkey after registration', async ({ page, context }) => {
+        const auth = await addVirtualAuth(context);
+
+        // First: register a passkey
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php#passkeys'));
+        page.on('dialog', dialog => dialog.accept('Login Test Passkey'));
+        await page.locator('#btn-add-passkey').click();
+        await page.waitForURL(/change_password\.php/, { timeout: 30_000 });
+        await logout(page);
+
+        // Now: log in — should redirect to passkey_verify.php
+        await page.goto(appUrl('login.php'));
+        await page.locator('[name=username]').fill(PASSKEY_USER);
+        await page.locator('[name=password]').fill(PASSKEY_PASS);
+        await page.locator('button[type=submit]').click();
+
+        // passkey_verify.php auto-triggers; virtual authenticator responds automatically
+        await page.waitForURL(/dashboard\.php/, { timeout: 30_000 });
+        await expect(page).toHaveURL(/dashboard\.php/);
+
+        await auth.dispose();
+    });
+
+    test('invalid passkey assertion is rejected', async ({ page, context }) => {
+        // Register a passkey first
+        const auth = await addVirtualAuth(context);
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php#passkeys'));
+        page.on('dialog', dialog => dialog.accept('Reject Test Passkey'));
+        await page.locator('#btn-add-passkey').click();
+        await page.waitForURL(/change_password\.php/, { timeout: 30_000 });
+        await logout(page);
+        await auth.dispose();
+
+        // Without virtual authenticator — browser will show no matching credential
+        // Go to passkey_verify.php directly (set session manually via login.php flow)
+        await page.goto(appUrl('login.php'));
+        await page.locator('[name=username]').fill(PASSKEY_USER);
+        await page.locator('[name=password]').fill(PASSKEY_PASS);
+        await page.locator('button[type=submit]').click();
+        await page.waitForURL(/passkey_verify\.php/, { timeout: 15_000 });
+
+        // Page should be on passkey challenge — without virtual auth the auto-trigger will fail
+        // Inject a tampered POST with garbage credential data
+        const csrf = await page.locator('[name=csrf]').inputValue();
+        await page.evaluate(
+            async ({ csrf }: { csrf: string }) => {
+                const formData = new URLSearchParams({
+                    csrf,
+                    clientDataJSON:    btoa('garbage'),
+                    authenticatorData: btoa('garbage'),
+                    signature:         btoa('garbage'),
+                    credentialId:      btoa('garbage'),
+                });
+                const resp = await fetch('passkey_verify.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: formData.toString(),
+                });
+                return resp.url;
+            },
+            { csrf }
+        );
+
+        // After tampered POST the page should still be on passkey_verify.php (not dashboard)
+        await page.reload();
+        await expect(page).toHaveURL(/login\.php|passkey_verify\.php/);
+    });
+
+    test('admin can view passkey count on users.php', async ({ page }) => {
+        await login(page, ADMIN_USER, ADMIN_PASS);
+        await page.goto(appUrl('users.php'));
+        // passkey_test_user row should show passkey badge count or "—"
+        const userRow = page.locator('tr', { hasText: PASSKEY_USER });
+        await expect(userRow).toBeVisible();
+    });
+
+    test('user can delete a passkey from Account page', async ({ page, context }) => {
+        const auth = await addVirtualAuth(context);
+
+        await login(page, PASSKEY_USER, PASSKEY_PASS);
+        await page.goto(appUrl('change_password.php#passkeys'));
+        page.on('dialog', dialog => dialog.accept('Deletable Passkey'));
+        await page.locator('#btn-add-passkey').click();
+        await page.waitForURL(/change_password\.php/, { timeout: 30_000 });
+        await expect(page.locator('#passkeys')).toContainText('Deletable Passkey');
+
+        // Delete it
+        page.once('dialog', d => d.accept());
+        await page.locator('#passkeys button[type=submit]').last().click();
+        await page.waitForURL(/change_password\.php/, { timeout: 15_000 });
+        await expect(page.locator('#passkeys')).not.toContainText('Deletable Passkey');
+
+        await auth.dispose();
+    });
+
+    test('admin can reset all passkeys for a user', async ({ page, context }) => {
+        const auth = await addVirtualAuth(context);
+
+        // Register a passkey as passkey_test_user
+        const userPage = await context.newPage();
+        await login(userPage, PASSKEY_USER, PASSKEY_PASS);
+        await userPage.goto(appUrl('change_password.php#passkeys'));
+        userPage.on('dialog', dialog => dialog.accept('Admin Reset Passkey'));
+        await userPage.locator('#btn-add-passkey').click();
+        await userPage.waitForURL(/change_password\.php/, { timeout: 30_000 });
+        await logout(userPage);
+        await userPage.close();
+
+        // Now admin resets
+        await login(page, ADMIN_USER, ADMIN_PASS);
+        await page.goto(appUrl('users.php'));
+        const userRow = page.locator('tr', { hasText: PASSKEY_USER });
+        const resetBtn = userRow.locator('button', { hasText: 'Reset Passkeys' });
+        await expect(resetBtn).toBeVisible();
+        page.once('dialog', d => d.accept());
+        await resetBtn.click();
+        await page.waitForURL(/users\.php/, { timeout: 15_000 });
+
+        // Verify passkey count is gone
+        const updatedRow = page.locator('tr', { hasText: PASSKEY_USER });
+        await expect(updatedRow.locator('.badge--success')).not.toBeVisible();
+
+        await auth.dispose();
+    });
+});
+```
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+(cd testing/playwright && npx tsc --noEmit)
+```
+
+Expected: no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add testing/playwright/tests/passkeys.spec.ts
+git commit -m "test(passkeys): add passkeys.spec.ts with virtual authenticator suite (#718)"
+```
+
+---
+
+## Task 12: Documentation (#687, #689)
+
+This task uses the **documentation skill**. Invoke it with:
+> "Update Simple PHP IPAM docs for v3.15.0 Passkeys release. Files to update: docs/security.md (add passkeys section), docs/configuration.md (mfa.passkeys_enabled setting), docs/upgrading.md (v3.15.0 upgrade notes). The feature adds WebAuthn/Passkey support as a 3rd 2FA method (after TOTP and Email OTP), controlled by a new mfa.passkeys_enabled setting. Priority order: TOTP > Email OTP > Passkey. Admin can delete user passkeys from users.php."
+
+**Files:**
+- Modify: `docs/security.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/upgrading.md`
+
+- [ ] **Step 1: Update `docs/security.md`**
+
+Find the MFA/2FA section. After the Email OTP subsection, add:
+
+```markdown
+### Passkeys (WebAuthn)
+
+Passkeys (WebAuthn, FIDO2) are phishing-resistant credentials tied to a device authenticator (Face ID, Touch ID, Windows Hello, or a hardware security key). They are the strongest 2FA method supported by Simple PHP IPAM because the credential is scoped to the RP ID (your server's hostname) and cannot be phished.
+
+**Enabling passkeys:** Set `mfa.passkeys_enabled = true` in Settings → Multi-Factor Authentication.
+
+**Enrolling:** Users enroll from the Account page (⚙ → Account). Each passkey is named by the user and listed with its registration date.
+
+**Login flow:** After entering their password, users with a passkey enrolled are redirected to `passkey_verify.php` where the browser authenticator handles the challenge. The session is not created until the passkey challenge succeeds.
+
+**Priority order:** When a user has multiple 2FA methods enrolled, the challenge priority is TOTP → Email OTP → Passkey. Future releases may add a method-selection step.
+
+**Admin management:** Admins can delete all passkeys for a user from Users → Edit (useful when a user loses their device). Users can self-manage from the Account page.
+```
+
+- [ ] **Step 2: Update `docs/configuration.md`**
+
+In the MFA settings table, add a row:
+
+```markdown
+| `mfa.passkeys_enabled` | bool | `false` | Allow users to register WebAuthn/Passkey credentials as a 2FA method. |
+```
+
+- [ ] **Step 3: Update `docs/upgrading.md`**
+
+At the top of "Version-specific upgrade notes", add:
+
+```markdown
+### v3.15.0
+
+- **New:** Passkeys (WebAuthn) 2FA method — opt-in via Settings → Multi-Factor Authentication → Enable Passkeys.
+- No breaking changes. Existing TOTP and Email OTP enrollments are unaffected.
+- New database table: `webauthn_credentials` (migration runs automatically on first request).
+- New pages: `passkey_verify.php` (mid-login challenge), `passkey_register.php` (registration AJAX endpoint).
+```
+
+- [ ] **Step 4: Verify no stale version strings in docs**
+
+```bash
+grep -r "3\.14\." docs/ | grep -v "CHANGELOG\|upgrading"
+```
+
+If any hits refer to the old version where the context has changed, update them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/security.md docs/configuration.md docs/upgrading.md
+git commit -m "docs: update security.md, configuration.md, upgrading.md for v3.15.0 passkeys (#687, #689)"
+```
+
+---
+
+## Task 13: Version bump and CLAUDE.md update
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/version.php`
+- Modify: `Simple-PHP-IPAM/lib.php` (asset cache-buster `?v=3.15.0`)
+- Modify: `Simple-PHP-IPAM/demo_gate.php` (asset cache-buster, lines 74-75)
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Bump version.php**
+
+Change `'3.14.0'` → `'3.15.0'` in `Simple-PHP-IPAM/version.php`.
+
+- [ ] **Step 2: Update asset cache-buster in `lib.php`**
+
+Search for `?v=3.14.0` in `lib.php` and change to `?v=3.15.0`.
+
+```bash
+grep -n "?v=3.14.0" Simple-PHP-IPAM/lib.php
+```
+
+- [ ] **Step 3: Update asset cache-buster in `demo_gate.php`**
+
+```bash
+grep -n "?v=3.14.0" Simple-PHP-IPAM/demo_gate.php
+```
+
+Change both occurrences to `?v=3.15.0`.
+
+- [ ] **Step 4: Add CHANGELOG entry**
+
+At the top of `CHANGELOG.md`, after the `[Unreleased]` heading (or create it), add:
+
+```markdown
+## [3.15.0] - 2026-04-XX
+
+### Added
+- Passkeys (WebAuthn/FIDO2) as a third 2FA method alongside TOTP and Email OTP (#688, #689)
+- New `mfa.passkeys_enabled` admin setting under Multi-Factor Authentication (#689)
+- New `webauthn_credentials` database table; migration runs automatically (#688)
+- New `passkey_verify.php` mid-login challenge page (#689)
+- New `passkey_register.php` AJAX registration endpoint (#688)
+- Admin passkey reset on users.php (#689)
+- Passkey management (register, name, delete) on the Account page (#688)
+- `lbuchs/webauthn ^2.1` Composer runtime dependency (#687)
+- Playwright tests for passkey registration, authentication, and admin reset (#718)
+```
+
+Add the comparison link at the bottom of the file:
+```markdown
+[3.15.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.14.0...v3.15.0
+```
+
+- [ ] **Step 5: Update README.md "What's new" section**
+
+Replace the existing `## What's new in v3.14.0` block **in-place** (do not append) with:
+
+```markdown
+## What's new in v3.15.0
+
+**Passkeys (WebAuthn)** — Register hardware security keys or device biometrics (Face ID, Touch ID, Windows Hello) as a phishing-resistant second factor. Enabled by the new `mfa.passkeys_enabled` admin setting. Existing TOTP and Email OTP enrollments are unaffected. See [docs/security.md](docs/security.md) for setup.
+```
+
+- [ ] **Step 6: Update CLAUDE.md**
+
+Two changes:
+1. In the "Current shipped version" callout near the top of **Project overview**, change `v3.14.0` → `v3.15.0`.
+2. In the **Page inventory** table, add two rows:
+
+```markdown
+| `passkey_verify.php` | partial | any | Mid-login WebAuthn challenge; reached only via `$_SESSION['passkey_pending_uid']` set by `login.php`; redirects to login if session key absent (v3.15.0) |
+| `passkey_register.php` | yes | any | POST-only AJAX endpoint: generates WebAuthn registration challenge and verifies attestation; returns JSON (v3.15.0) |
+```
+
+- [ ] **Step 7: Full static analysis**
+
+```bash
+php -l Simple-PHP-IPAM/version.php
+php -l Simple-PHP-IPAM/demo_gate.php
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+vendor/bin/phpunit
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/
+```
+
+Expected: all pass. If any PHPStan baseline changes are needed (new WebAuthn types), update `phpstan-baseline.neon` minimally — do not suppress real errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Simple-PHP-IPAM/version.php Simple-PHP-IPAM/lib.php Simple-PHP-IPAM/demo_gate.php \
+        CHANGELOG.md README.md CLAUDE.md
+git commit -m "chore(release): bump to v3.15.0, update CHANGELOG, README, CLAUDE.md"
+```
+
+---
+
+## Task 14: Local release gate
+
+- [ ] **Step 1: Static analysis gate**
+
+```bash
+for f in Simple-PHP-IPAM/passkey_verify.php Simple-PHP-IPAM/passkey_register.php \
+          Simple-PHP-IPAM/login.php Simple-PHP-IPAM/change_password.php \
+          Simple-PHP-IPAM/users.php Simple-PHP-IPAM/migrations.php \
+          Simple-PHP-IPAM/lib.php Simple-PHP-IPAM/version.php; do
+    php -l "$f"
+done
+vendor/bin/phpstan analyse --memory-limit=1G
+vendor/bin/phpcs
+vendor/bin/phpunit
+semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/
+```
+
+Expected: zero errors, zero new baseline suppressions. Fix all failures before proceeding.
+
+- [ ] **Step 2: SQLite containerized Playwright gate**
+
+```bash
+bash testing/playwright/bootstrap-app.sh sqlite
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test --project=chromium)
+bash testing/playwright/teardown-app.sh
+```
+
+Expected: 0 failures. Fix any failures before proceeding to MySQL gate.
+
+- [ ] **Step 3: MySQL containerized Playwright gate**
+
+```bash
+bash testing/playwright/bootstrap-app.sh mysql
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test --project=chromium)
+bash testing/playwright/teardown-app.sh
+```
+
+Expected: 0 failures.
+
+- [ ] **Step 4: PostgreSQL containerized Playwright gate**
+
+```bash
+bash testing/playwright/bootstrap-app.sh pgsql
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test --project=chromium)
+bash testing/playwright/teardown-app.sh
+```
+
+Expected: 0 failures.
+
+**All three gates must be green before the next task. No exceptions.**
+
+---
+
+## Task 15: Clean data dir and build release bundle
+
+- [ ] **Step 1: Clean data directory debris**
+
+```bash
+rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt
+ls Simple-PHP-IPAM/data/
+```
+
+Expected: only `ipam.sqlite`, `tmp/`, possibly `.htaccess`. No `.bak` or `demo_last_reset.txt`.
+
+- [ ] **Step 2: Build the release bundle**
+
+```bash
+./releases/make_releases.sh Simple-PHP-IPAM 3.15.0
+```
+
+Expected: creates `ipam-3.15.0/` in the repo root with `ipam-3.15.0.tar.gz` and `SHA256SUMS`.
+
+- [ ] **Step 3: Verify bundle contents**
+
+```bash
+tar tvf ipam-3.15.0/ipam-3.15.0.tar.gz | grep -E "upgrade\.sh|passkey_register|passkey_verify|vendor/" | head -20
+```
+
+Expected:
+- `upgrade.sh` present with execute permission (`-rwxr-xr-x`)
+- `passkey_register.php` and `passkey_verify.php` present
+- `vendor/lbuchs/webauthn/` present (Composer deps bundled)
+
+- [ ] **Step 4: Stage bundle**
+
+```bash
+mkdir -p releases/ipam-3.15.0
+mv ipam-3.15.0/ipam-3.15.0.tar.gz ipam-3.15.0/SHA256SUMS releases/ipam-3.15.0/
+rmdir ipam-3.15.0 2>/dev/null || true
+git add releases/ipam-3.15.0/
+git commit -m "chore(release): add v3.15.0 release bundle and SHA256SUMS"
+```
+
+---
+
+## Task 16: Push, PR, and await review
+
+> **STOP: Explicit user permission required before pushing or creating a PR.**
+
+- [ ] **Step 1: Push feature branch**
+
+*(Do not run until user says to push.)*
+
+```bash
+git push -u origin feat/v3.15.0
+```
+
+- [ ] **Step 2: Open PR**
+
+*(Do not run until user says to open PR.)*
+
+```bash
+gh pr create \
+  --base dev \
+  --title "feat: v3.15.0 — Passkeys (WebAuthn) 2FA" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds WebAuthn/Passkey authentication as a third 2FA option (TOTP → Email OTP → Passkey priority)
+- New `mfa.passkeys_enabled` admin setting under MFA settings group
+- New `webauthn_credentials` table migration (SQLite, MySQL, PostgreSQL)
+- `passkey_register.php` AJAX endpoint for two-round registration ceremony
+- `passkey_verify.php` mid-login challenge page (mirrors email_otp_verify.php pattern)
+- Passkey management card on Account page (list, add, delete)
+- Admin passkey reset on users.php
+- `lbuchs/webauthn ^2.1` runtime Composer dep (MIT, zero transitive deps)
+- Playwright tests with virtual authenticator for registration, login, admin reset
+
+Closes #687, #688, #689, #718.
+
+## Test plan
+
+- [ ] All three engine gates green locally (SQLite, MySQL, PostgreSQL)
+- [ ] `vendor/bin/phpstan`, `vendor/bin/phpcs`, `vendor/bin/phpunit`, `semgrep` all clean
+- [ ] passkeys.spec.ts passes on chromium with virtual authenticator
+- [ ] Bundle verified: passkey_verify.php, passkey_register.php, vendor/lbuchs/ present
+
+🤖 Generated with [Claude Code](https://claude.ai/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Monitor CI and address CodeRabbit comments**
+
+If CodeRabbit or CI raises issues:
+1. Fix on the same branch
+2. Rebuild the bundle: `rm -rf releases/ipam-3.15.0 ipam-3.15.0; ./releases/make_releases.sh Simple-PHP-IPAM 3.15.0; mkdir -p releases/ipam-3.15.0; mv ipam-3.15.0/ipam-3.15.0.tar.gz ipam-3.15.0/SHA256SUMS releases/ipam-3.15.0/; rmdir ipam-3.15.0 2>/dev/null; git add releases/ipam-3.15.0/; git commit -m "chore(release): rebuild v3.15.0 bundle after review fixes"`
+3. Push and wait for CI to go green again
+
+---
+
+## Task 17: Merge and release
+
+> **STOP: Explicit user permission required before merging.**
+
+- [ ] **Step 1: Merge PR** *(user permission required)*
+
+```bash
+gh pr merge --squash  # or --merge, per project convention
+```
+
+- [ ] **Step 2: Tag and release** *(after PR merges to dev, then promote dev→main per workflow)*
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v3.15.0 -m "v3.15.0 — Passkeys (WebAuthn) 2FA"
+git push origin v3.15.0
+```
+
+- [ ] **Step 3: Create GitHub release**
+
+```bash
+gh release create v3.15.0 \
+  releases/ipam-3.15.0/ipam-3.15.0.tar.gz \
+  releases/ipam-3.15.0/SHA256SUMS \
+  --title "v3.15.0 — Passkeys (WebAuthn) 2FA" \
+  --notes "Adds WebAuthn/Passkey authentication as a third 2FA option. See CHANGELOG.md for full details."
+```
+
+- [ ] **Step 4: Deploy to all instances per CLAUDE.md release workflow**
+
+Follow the deployment procedure in CLAUDE.md Phase 4 (demo, prod, 4 testing instances, website).
+
+- [ ] **Step 5: Close GitHub issues and milestone**
+
+```bash
+for issue in 687 688 689 718; do
+  gh issue close $issue --comment "Released in v3.15.0. See https://github.com/seanmousseau/Simple-PHP-IPAM/releases/tag/v3.15.0"
+done
+gh api -X PATCH repos/seanmousseau/Simple-PHP-IPAM/milestones/41 -f state=closed
+```
+
+- [ ] **Step 6: Update Memory MCP**
+
+Add a final observation to `project:simple-php-ipam` entity:
+- Shipped version: v3.15.0
+- Merge commit (fill in after merge)
+- Bundle SHA256 from `releases/ipam-3.15.0/SHA256SUMS`
+- Issues closed: #687, #688, #689, #718
+- Milestone #41 closed
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- ✅ #687: lbuchs/webauthn dependency added in Task 2
+- ✅ #688: migration + schema (Task 3), registration backend (Task 5), change_password.php UI (Task 8)
+- ✅ #689: mfa.passkeys_enabled setting (Task 4), passkey_verify.php (Task 6), login.php dispatch (Task 7), users.php admin (Task 9)
+- ✅ #718: passkeys.spec.ts with virtual authenticator (Task 11), demo_seed.php seeding (Task 10)
+- ✅ docs: security.md, configuration.md, upgrading.md (Task 12)
+- ✅ version bump, CHANGELOG, README, CLAUDE.md (Task 13)
+- ✅ Full local gate (Task 14), bundle (Task 15), PR (Task 16), merge + deploy (Task 17)
+
+**Type/name consistency check:**
+- `ipam_passkey_webauthn()` — defined Task 4, used in Tasks 5, 6, 7 ✅
+- `ipam_passkey_get_credentials()` — defined Task 4, used in Tasks 5, 7, 8 ✅
+- `ipam_passkey_has_credentials()` — defined Task 4, used in Tasks 4 (settings note), 7 ✅
+- `ipam_passkey_find_by_credential_id()` — defined Task 4, used in Task 6 ✅
+- `ipam_passkey_update_sign_count()` — defined Task 4, used in Task 6 ✅
+- `ipam_passkey_delete()` — defined Task 4, used in Task 8 ✅
+- `ipam_passkey_delete_all()` — defined Task 4, used in Tasks 8 (no, actually Task 9) ✅
+- `ipam_passkey_count()` — defined Task 4, used in Task 9 ✅
+- Session keys: `passkey_pending_uid`, `passkey_challenge`, `passkey_assertion_options`, `passkey_reg_challenge` — consistent across Tasks 5, 6, 7 ✅
+
+**No-placeholder check:** All code blocks are complete. No "TBD" or "TODO" in implementation steps. ✅

--- a/docs/superpowers/plans/2026-04-27-v3.16.0.md
+++ b/docs/superpowers/plans/2026-04-27-v3.16.0.md
@@ -1,0 +1,587 @@
+# v3.16.0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task with a fresh subagent per task and two-stage review. Steps use checkbox (`- [ ]`) syntax. When a task touches UI/UX, invoke `ui-ux-pro-max` first. When a task touches docs, invoke `documentation`. When running the release gate, invoke the project's `release-gate` skill (`.claude/skills/release-gate/SKILL.md`). Use `gh` / `git` CLI over MCP GitHub tools. Use Memory MCP throughout — read at start, write observations after every meaningful change, write a "RELEASED" observation at close-out.
+
+**Goal:** Ship v3.16.0 — a focused MFA / Settings / Search UX polish release. Five issues, single track, low risk. Backup infrastructure has been re-scoped to v3.17.0 (combined with restore) and is out of scope here.
+
+**Architecture:** Single feature branch off `dev`. The five tasks are mostly independent and can be tackled in order with a fresh subagent each. Schema change is small (one nullable column on `users`). All search engines normalised through `LOWER()` for portable case-insensitivity. Settings page reorganised under the existing `ipam_render($view, $props)` views helper (no new templating).
+
+**Tech Stack:** PHP 8.2+, SQLite 3 / MySQL 8.0.29+ / PostgreSQL 14+, vanilla CSS/JS, Heroicons sprite (`assets/icons.svg`), Open Props tokens (already vendored). No new runtime deps.
+
+---
+
+## GitHub Issues (5)
+
+| # | Title | Sub-skill |
+|---|---|---|
+| #745 | Group MFA methods (TOTP/Email OTP/Passkeys) into a single Account card | ui-ux-pro-max |
+| #746 | Let users select their preferred 2FA method at login | ui-ux-pro-max |
+| #747 | Admin toggle for TOTP on Settings page | ui-ux-pro-max |
+| #749 | Reorganize Settings page with vertical tab navigation | ui-ux-pro-max |
+| #750 | Make global search case-insensitive across all engines | — |
+
+### Out of scope (now in v3.17.0)
+
+Backup epic (12 issues): #690, #691, #692, #693, #694, #695, #696, #697, #719, #720, #721, #722. v3.17.0 also retains the original restore work (#698, #699, #700, #701, #723) and ships backup + restore as a single coherent feature.
+
+---
+
+## Pre-Work Checklist
+
+Already executed during this planning session — recorded for the audit trail:
+
+- [x] Memory MCP `project:simple-php-ipam:roadmap:v3.16.0` updated with split rationale.
+- [x] Closed v3.15.0 milestone (#41); all four issues delivered.
+- [x] Re-milestoned 12 backup issues v3.16.0 → v3.17.0 (#43); renamed `test(v3.16.0):` → `test(v3.17.0):` on #719/#720/#721/#722.
+- [x] Updated v3.16.0 (#44) and v3.17.0 (#43) descriptions on GitHub.
+- [x] No open issues with no milestone.
+- [x] Deleted stale branches `feat/v3.15.0`, `fix/v3.15.1`, `fix/v3.15.2` (local + remote) and the orphaned worktree.
+- [x] Confirmed `dev` is in sync with `main` at `e63c86c` (v3.15.2 release).
+
+---
+
+## File Map
+
+### New files
+
+- `Simple-PHP-IPAM/views/settings/tab_general.php`
+- `Simple-PHP-IPAM/views/settings/tab_authentication.php`
+- `Simple-PHP-IPAM/views/settings/tab_notifications.php`
+- `Simple-PHP-IPAM/views/settings/tab_data.php`
+- `Simple-PHP-IPAM/views/settings/tab_integrations.php`
+- `testing/playwright/tests/search.spec.ts` (only if no existing search spec covers the case-insensitive scenarios)
+
+### Modified files
+
+- `Simple-PHP-IPAM/migrations.php` — closure `3.16.0-preferred-mfa-method` adding nullable `users.preferred_mfa_method`
+- `Simple-PHP-IPAM/schema.sql` / `schema.mysql.sql` / `schema.pgsql.sql` — same column on the fresh-install schemas
+- `Simple-PHP-IPAM/lib.php` — register `mfa.totp_enabled`; helpers `ipam_user_mfa_methods()`, `ipam_user_preferred_mfa()`
+- `Simple-PHP-IPAM/login.php` — replace fixed TOTP→Email→Passkey chain with dispatch table keyed on `users.preferred_mfa_method`
+- `Simple-PHP-IPAM/totp_verify.php` — guard against `mfa.totp_enabled = false`; method-switch buttons unchanged from v3.15.2
+- `Simple-PHP-IPAM/email_otp_verify.php` — add method-switch buttons (mirror v3.15.2 totp_verify pattern)
+- `Simple-PHP-IPAM/passkey_verify.php` — add method-switch buttons
+- `Simple-PHP-IPAM/totp_enroll.php` — 403/redirect when `mfa.totp_enabled = false`
+- `Simple-PHP-IPAM/change_password.php` — single "Two-Factor Authentication" card with three rows + preferred-method dropdown
+- `Simple-PHP-IPAM/settings.php` — vertical tab nav, 5 tabs, `?tab=X` URL state, `mfa.totp_enabled` toggle in Authentication tab
+- `Simple-PHP-IPAM/search.php` — `LOWER(col) LIKE LOWER(:q)` rewrite on addresses, devices, subnets blocks
+- `Simple-PHP-IPAM/api.php` — same change in `api_search()`
+- `Simple-PHP-IPAM/export_search.php` — mirror the WHERE rewrite if it builds its own
+- `Simple-PHP-IPAM/assets/app.css` — vertical tab nav styles, MFA card row styles
+- `Simple-PHP-IPAM/assets/app.js` — settings tab keyboard nav (arrow keys), method-switch button handlers
+- `tests/MigrationTest.php` — assert `users.preferred_mfa_method` column added
+- `testing/playwright/tests/mfa.spec.ts` (or equivalent) — admin disables TOTP; preferred-method dispatch; switch graph between all three verify pages
+
+### Release-wide
+
+- `Simple-PHP-IPAM/version.php` → `3.16.0`
+- `Simple-PHP-IPAM/lib.php` page_header asset cache-buster `?v=3.16.0`
+- `Simple-PHP-IPAM/demo_gate.php:74-75` cache-buster
+- `CHANGELOG.md` — `## [3.16.0] - YYYY-MM-DD` entry + comparison link
+- `README.md` — replace "What's new" section in place
+- `CLAUDE.md` — bump current shipped version
+- `docs/configuration.md` — `mfa.totp_enabled`, `users.preferred_mfa_method` field
+- `docs/upgrading.md` — `### v3.16.0` notes
+- `docs/security.md` — note that admins can disable TOTP globally
+- `website/front-page.php`, `website/header.php`, `website/page.php`, `website/page-docs.php` — version bump only (no new doc page)
+
+---
+
+## Phase 0 — Branch Setup
+
+### Task 0.1: Create the feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Sync `dev` with `main`**
+
+```bash
+git checkout dev
+git pull origin dev
+git merge --ff-only origin/main
+git push origin dev
+```
+
+Expected: `dev` at `e63c86c` (or later if `main` has moved).
+
+- [ ] **Step 2: Create release branch from `dev`**
+
+```bash
+git checkout -b feat/v3.16.0
+git commit --allow-empty -m "chore: begin v3.16.0 — MFA / Settings / Search UX polish"
+git push -u origin feat/v3.16.0
+```
+
+- [ ] **Step 3: Memory MCP**
+
+```text
+mcp__MCP_DOCKER__add_observations on project:simple-php-ipam:roadmap:v3.16.0:
+"Branch setup complete: feat/v3.16.0 created from dev at <SHA>."
+```
+
+---
+
+## Phase 1 — Implementation
+
+> Use `superpowers:subagent-driven-development`: fresh subagent per task, two-stage review. **Invoke `ui-ux-pro-max` at the start of every task except Task 1.1 (#750).**
+
+### Task 1.1: #750 — Case-insensitive global search
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/search.php` (lines ~32–41 addresses, ~140–148 devices, ~176–180 subnets)
+- Modify: `Simple-PHP-IPAM/api.php` (`api_search()` mirror)
+- Modify: `Simple-PHP-IPAM/export_search.php` (only if it builds its own WHERE)
+- Test: `testing/playwright/tests/search.spec.ts` (extend existing or create)
+
+- [ ] **Step 1: Failing Playwright test**
+
+In the search spec, add:
+
+```typescript
+test('search is case-insensitive across hostname mixed-case input', async ({ page }) => {
+  await login(page);
+  await page.goto('/search.php?q=SEED-WEB-01');
+  await expect(page.getByRole('row', { name: /seed-web-01/i })).toBeVisible();
+  await page.goto('/search.php?q=Seed-Web-01');
+  await expect(page.getByRole('row', { name: /seed-web-01/i })).toBeVisible();
+});
+```
+
+Run against pgsql first — that's where the bug is loudest:
+
+```bash
+bash testing/playwright/bootstrap-app.sh pgsql
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test search.spec.ts --project=chromium)
+```
+
+Expected: FAIL on Postgres (case-sensitive `LIKE`).
+
+- [ ] **Step 2: Implement on the addresses block**
+
+`search.php` ~line 32:
+
+```php
+$where[] = "(LOWER(a.ip) LIKE :q1 ESCAPE '!' OR LOWER(a.hostname) LIKE :q2 ESCAPE '!'"
+         . " OR LOWER(a.owner) LIKE :q3 ESCAPE '!' OR LOWER(a.note) LIKE :q4 ESCAPE '!'"
+         . " OR LOWER(a.grp) LIKE :q5 ESCAPE '!' OR LOWER(a.mac) LIKE :q6 ESCAPE '!')";
+$qLike = '%' . like_escape(mb_strtolower($q)) . '%';
+```
+
+- [ ] **Step 3: Same change on devices block (~line 140) and subnets block (~line 176)**
+
+- [ ] **Step 4: Same change in `api.php::api_search()` and `export_search.php`**
+
+- [ ] **Step 5: Run gate locally on all three drivers**
+
+For each engine — sqlite, mysql, pgsql — run:
+
+```bash
+bash testing/playwright/bootstrap-app.sh <engine>
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+(cd testing/playwright && IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo npx playwright test --project=chromium)
+bash testing/playwright/teardown-app.sh
+```
+
+Expected: PASS on all three engines.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Simple-PHP-IPAM/search.php Simple-PHP-IPAM/api.php Simple-PHP-IPAM/export_search.php testing/playwright/tests/search.spec.ts
+git commit -m "feat(search): case-insensitive search across all engines via LOWER() (#750)"
+```
+
+- [ ] **Step 7: Memory MCP** — `"#750 fixed in <commit>: search now portable across SQLite/MySQL/PostgreSQL with LOWER() on both sides."`
+
+---
+
+### Task 1.2: #747 — Admin toggle for TOTP
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/lib.php` — register `mfa.totp_enabled` (default `true`)
+- Modify: `Simple-PHP-IPAM/totp_enroll.php` — 403 / redirect when off
+- Modify: `Simple-PHP-IPAM/login.php` — skip TOTP path when off
+- Modify: `Simple-PHP-IPAM/totp_verify.php` — bail if user lands here with the setting off
+- Modify: `Simple-PHP-IPAM/change_password.php` — hide TOTP enroll button when off
+- Modify: `Simple-PHP-IPAM/settings.php` — toggle alongside Email OTP and Passkeys
+- Test: `testing/playwright/tests/mfa.spec.ts` (extend)
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max`** — confirm the Settings toggle row pattern matches the existing `mfa.email_otp_enabled` and `mfa.passkeys_enabled` toggles (same row layout, same status pill, same hint text style).
+- [ ] **Step 2: Failing Playwright test** — admin disables TOTP, user with TOTP enrolled is dispatched to Email OTP / Passkey instead.
+- [ ] **Step 3: Register setting in `lib.php` settings registry** with `default_value => 1`, `type => 'bool'`, `category => 'mfa'`, `config_key => 'mfa.totp_enabled'`.
+- [ ] **Step 4: Add the toggle to `settings.php` MFA group** mirroring the existing Email OTP / Passkeys toggles.
+- [ ] **Step 5: Guard `totp_enroll.php`** at the top (after `require_login()`):
+
+```php
+if (!ipam_setting('mfa.totp_enabled', true)) {
+    header('Location: change_password.php');
+    exit;
+}
+```
+
+- [ ] **Step 6: Guard `login.php` dispatch** — wrap the `totp_pending_uid` set-and-redirect in `if (ipam_setting('mfa.totp_enabled', true))`.
+- [ ] **Step 7: `totp_verify.php`** — at top, if setting is off, clear `$_SESSION['totp_pending_uid']` and redirect to `login.php`.
+- [ ] **Step 8: `change_password.php`** — hide the TOTP enroll affordance, show "TOTP is not enabled on this server. Contact your administrator." in its slot.
+- [ ] **Step 9: Surface the `app_secret`-missing warning on Settings** when `mfa.totp_enabled = true` and `app_secret` is unset (per #747 edge case).
+- [ ] **Step 10: Run sqlite + mysql + pgsql gate locally; commit**
+
+```bash
+git commit -m "feat(mfa): admin toggle for TOTP enrolment + login dispatch (#747)"
+```
+
+---
+
+### Task 1.3: #745 — Group MFA methods on Account page
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/change_password.php`
+- Modify: `Simple-PHP-IPAM/assets/app.css`
+- Test: extend the relevant Playwright spec (likely `account.spec.ts` or `mfa.spec.ts`)
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max`** with query: "consolidate three separate MFA cards (TOTP, Email OTP, Passkeys) into a single 'Two-Factor Authentication' card with consistent row layout. Each row shows method name, enabled/disabled status pill, and primary action affordance. Match patterns used by Stripe and GitHub for security settings." Capture the recommended layout structure as the implementation reference.
+- [ ] **Step 2: Failing Playwright assertion** — single card, three rows, consistent status pill class.
+- [ ] **Step 3: Restructure markup** in `change_password.php`. Use existing icon sprite (`<svg><use href="assets/icons.svg#shield-check"/></svg>`).
+- [ ] **Step 4: Update `assets/app.css`** with a new `.mfa-method-row` rule that uses Open Props tokens for spacing and respects light/dark theme.
+- [ ] **Step 5: Verify keyboard navigation** — Tab order goes through all three rows in document order; each action button has visible `:focus-visible`.
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(account): unify MFA methods into a single Two-Factor Authentication card (#745)"
+```
+
+---
+
+### Task 1.4: #746 — Preferred MFA method picker
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/migrations.php` — closure `3.16.0-preferred-mfa-method`
+- Modify: `Simple-PHP-IPAM/schema.sql`, `schema.mysql.sql`, `schema.pgsql.sql`
+- Modify: `Simple-PHP-IPAM/login.php` — dispatch table
+- Modify: `Simple-PHP-IPAM/change_password.php` — dropdown inside the unified MFA card
+- Modify: `Simple-PHP-IPAM/totp_verify.php`, `email_otp_verify.php`, `passkey_verify.php` — full switch graph
+- Modify: `Simple-PHP-IPAM/lib.php` — `ipam_user_preferred_mfa(int $uid): ?string`
+- Test: `tests/MigrationTest.php`, `testing/playwright/tests/mfa.spec.ts`
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max`** with query: "preferred method dropdown inside a security card listing only enrolled methods, with sensible fallback if the preferred method is later disabled". Confirm the affordance pattern.
+- [ ] **Step 2: Write a migration test** in `tests/MigrationTest.php` asserting the `users.preferred_mfa_method` column is added and NULL by default:
+
+```php
+public function testV316PreferredMfaColumn(): void
+{
+    apply_migrations($this->db);
+    $cols = $this->db->query("PRAGMA table_info(users)")->fetchAll();
+    $col = array_values(array_filter($cols, fn($c) => $c['name'] === 'preferred_mfa_method'));
+    $this->assertNotEmpty($col);
+    $this->assertSame(0, (int)$col[0]['notnull']);
+}
+```
+
+- [ ] **Step 3: Failing Playwright assertion** — set `preferred_mfa_method = 'email_otp'` on a TOTP+Email user, log in, assert landing on `email_otp_verify.php`.
+- [ ] **Step 4: Add migration closure** guarded with `PRAGMA table_info` (SQLite) / `INFORMATION_SCHEMA.COLUMNS` (MySQL) / `pg_attribute` (Postgres). Use the `Dialect` helper for portable column-add.
+- [ ] **Step 5: Update all three schema files** (CLAUDE.md SchemaParityTest gate).
+- [ ] **Step 6: Replace `login.php` dispatch** with a function that picks: `users.preferred_mfa_method` if enrolled & globally enabled → most-recently-enrolled enrolled method → existing fallback chain.
+- [ ] **Step 7: Add switch buttons to `email_otp_verify.php` and `passkey_verify.php`** mirroring the v3.15.2 `totp_verify.php` pattern. Re-use `ipam_passkey_dispatch_challenge()` for the passkey path.
+- [ ] **Step 8: Add the dropdown to `change_password.php`** inside the unified MFA card from Task 1.3. List only enrolled methods.
+- [ ] **Step 9: Run gate sqlite + mysql + pgsql; commit**
+
+```bash
+git commit -m "feat(mfa): preferred MFA method picker + full switch graph (#746)"
+```
+
+---
+
+### Task 1.5: #749 — Settings page tab nav
+
+**Files:**
+- Modify: `Simple-PHP-IPAM/settings.php`
+- New: `Simple-PHP-IPAM/views/settings/tab_*.php` (5 files)
+- Modify: `Simple-PHP-IPAM/assets/app.css`
+- Modify: `Simple-PHP-IPAM/assets/app.js`
+- Test: `testing/playwright/tests/settings.spec.ts` (extend)
+
+- [ ] **Step 1: Invoke `ui-ux-pro-max`** with query: "vertical left-rail tab navigation for an admin settings page with 5 top-level tabs (General, Authentication, Notifications, Data & Maintenance, Integrations). Each tab renders subsections as `<h3>` headers, not nested tabs. Active tab uses `border-left: 3px solid var(--link)` and `aria-current='page'`. Mobile <768px collapses to a `<select>`. Skip-link at top." Capture token map and concrete CSS patterns.
+- [ ] **Step 2: Failing Playwright assertion** — `settings.php?tab=auth` renders the Authentication subsections only and the rail shows `aria-current="page"` on the matching link.
+- [ ] **Step 3: Extract each of the 16 current groups into one of 5 tab view files** under `Simple-PHP-IPAM/views/settings/` per #749's mapping table.
+- [ ] **Step 4: Rewrite `settings.php`** to read `?tab=` (validate against allowlist; default to `general`), render the rail, and `ipam_render('settings/tab_' . $tab, $props)`.
+- [ ] **Step 5: CSS** — `.settings-rail`, `.settings-rail a`, `.settings-rail a[aria-current=page]`, mobile `<select>` fallback under `@media (max-width: 768px)`.
+- [ ] **Step 6: JS** — arrow-key navigation between rail items (Up/Down moves focus, Enter activates, Home/End jump to first/last).
+- [ ] **Step 7: Verify POST flow unchanged** — every existing per-group form still posts to `settings.php` with `group=` hidden, server validates and redirects to `settings.php?tab=<owning-tab>#group-<group>`.
+- [ ] **Step 8: Run a11y check** — `axe-playwright` (or manual: every rail item reachable by Tab, focus ring visible, skip link reaches the first form, screen reader announces tab labels).
+- [ ] **Step 9: Commit**
+
+```bash
+git commit -m "feat(settings): vertical tab navigation with 5 grouped tabs (#749)"
+```
+
+---
+
+## Phase 2 — Documentation
+
+> **Invoke the `documentation` skill at the start of this phase.**
+
+### Task 2.1: Audit and update docs
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `docs/upgrading.md`
+- Modify: `docs/security.md`
+- Modify: `docs/index.md`
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Invoke `documentation`** with query: "release-cycle documentation update for a small UX-focused PHP web-app release. Five user-visible changes: case-insensitive search, admin TOTP toggle, unified Two-Factor Authentication card, preferred-MFA-method picker, settings page tab nav. Audience: self-hosting sysadmins. Distinguish between configuration reference (every key, type, default), upgrade notes (one-time changes operators need to know about), and security model updates."
+- [ ] **Step 2: Update `docs/configuration.md`** — new keys: `mfa.totp_enabled`. New nullable user field `users.preferred_mfa_method` (mention as DB schema change, not a config key).
+- [ ] **Step 3: Update `docs/upgrading.md`** — add `### v3.16.0` at top of version-specific notes. Cover: TOTP can now be globally disabled by admins; existing TOTP enrolments are preserved when toggled off (won't lose backup codes); preferred MFA method column added (NULL by default, falls back to enrolment-order); Settings page reorganised into 5 tabs (URL `?tab=` parameter).
+- [ ] **Step 4: Update `docs/security.md`** — note in the MFA section that admins can disable TOTP globally without revoking individual user enrolments.
+- [ ] **Step 5: Update `docs/index.md`** — feature list bullets reflect the unified MFA UX.
+- [ ] **Step 6: Audit other docs** — `grep -r 'v3\.\(14\|15\)' docs/` and update remaining stale references where reasonable.
+- [ ] **Step 7: Update `CLAUDE.md`** — bump current shipped version to v3.16.0 (bottom of project overview / wherever the version marker lives). No page-inventory additions needed (no new pages). No new runtime deps.
+- [ ] **Step 8: Update `README.md`** — replace `## What's new in vX.Y.Z` block in place with v3.16.0 highlights.
+- [ ] **Step 9: Update `CHANGELOG.md`** — `## [3.16.0] - YYYY-MM-DD` with Added / Changed / Fixed sections + comparison link at bottom.
+- [ ] **Step 10: Commit**
+
+```bash
+git commit -m "docs(v3.16.0): MFA / Settings / Search UX documentation update"
+```
+
+---
+
+## Phase 3 — Release Gate
+
+> **Invoke the project's `release-gate` skill (`.claude/skills/release-gate/SKILL.md`).** The skill orchestrates all of the steps below; the per-step detail is included for traceability.
+
+### Task 3.1: Static analysis on every changed file
+
+- [ ] **Step 1:** `for f in $(git diff --name-only origin/main..HEAD | grep '\.php$'); do php -l "$f" || exit 1; done`
+- [ ] **Step 2:** `vendor/bin/phpstan analyse --memory-limit=1G`
+- [ ] **Step 3:** `vendor/bin/phpcs`
+- [ ] **Step 4:** `vendor/bin/phpunit`
+- [ ] **Step 5:** `semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/`
+
+All five must be green. **No bypass. No "investigate later". No suppressions added without justification.** If anything fails, stop, debug, fix the underlying issue.
+
+### Task 3.2: Containerized full Playwright suite — sqlite
+
+```bash
+bash testing/playwright/bootstrap-app.sh sqlite
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test)
+bash testing/playwright/teardown-app.sh
+```
+
+- [ ] **Step 1: Run.** All tests must pass. **No flaky retries. If a test fails, debug. If a test is intermittent, the test or the app has a race condition — find it and fix it. Do not justify why a test is failing.**
+
+### Task 3.3: Containerized full Playwright suite — mysql
+
+Same as 3.2 with `bootstrap-app.sh mysql`. Required because v3.16.0 includes a migration that runs on MySQL (`users.preferred_mfa_method`).
+
+### Task 3.4: Containerized full Playwright suite — pgsql
+
+Same as 3.2 with `bootstrap-app.sh pgsql`. Required because v3.16.0 includes a migration that runs on Postgres and because the search rewrite to `LOWER()` is the headline portability fix on this engine.
+
+### Task 3.5: Build the bundle
+
+- [ ] **Step 1: Bump `Simple-PHP-IPAM/version.php`** to `3.16.0` and asset cache-buster `?v=3.16.0` in `lib.php` `page_header()` and `demo_gate.php:74-75`.
+- [ ] **Step 2: Clean data debris** — `rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt`.
+- [ ] **Step 3: Build** — `./releases/make_releases.sh Simple-PHP-IPAM 3.16.0`.
+- [ ] **Step 4: Verify tarball** — `tar tvf ipam-3.16.0/ipam-3.16.0.tar.gz | grep -E 'upgrade.sh|\.htaccess|views/settings/'` returns matches; no `data/ipam.sqlite`, no `data/.db_initialized`, no `data/*.bak`.
+- [ ] **Step 5: Stage**
+
+```bash
+mkdir -p releases/ipam-3.16.0
+mv ipam-3.16.0/ipam-3.16.0.tar.gz ipam-3.16.0/SHA256SUMS releases/ipam-3.16.0/
+rmdir ipam-3.16.0 2>/dev/null || true
+git add Simple-PHP-IPAM/version.php Simple-PHP-IPAM/lib.php Simple-PHP-IPAM/demo_gate.php releases/ipam-3.16.0/
+git commit -m "chore(release): add v3.16.0 release bundle and SHA256SUMS"
+```
+
+- [ ] **Step 6: Memory MCP** — `"v3.16.0 bundle built: SHA256 <hash>, size <bytes>."`
+
+---
+
+## Phase 4 — Release & Closeout
+
+### Task 4.1: Open the release PR (REQUIRES USER PERMISSION TO PUSH AND OPEN PR)
+
+**STOP. Wait for explicit user approval before pushing or opening the PR.**
+
+- [ ] **Step 1: User approval check.** Proceed only if approved.
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push origin feat/v3.16.0
+```
+
+- [ ] **Step 3: Open PR `feat/v3.16.0 → main`**
+
+```bash
+gh pr create --base main --head feat/v3.16.0 \
+  --title "v3.16.0 — MFA / Settings / Search UX polish" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Unified Two-Factor Authentication card on the Account page (TOTP + Email OTP + Passkeys in a single, consistent layout)
+- Users can now select a preferred 2FA method; login dispatches there first with full switch graph between the three verify pages
+- Admins can globally disable TOTP from the Settings page (parity with Email OTP and Passkeys); existing per-user enrolments are preserved
+- Settings page reorganised into 5 vertical tabs (General, Authentication, Notifications, Data & Maintenance, Integrations) — 16 groups consolidated, no scroll-hunting
+- Global search is now case-insensitive across SQLite, MySQL, and PostgreSQL via portable `LOWER()` rewrite
+
+## Closes
+
+#745 #746 #747 #749 #750
+
+## Test plan
+
+- [x] PHPStan, PHPCS, PHPUnit, Semgrep — all green
+- [x] Containerized Playwright full suite — sqlite, mysql, pgsql — all green
+- [x] Manual UI walkthrough on all three engines: settings tabs, MFA card, preferred-method picker, admin TOTP toggle, case-insensitive search
+- [x] Bundle built and SHA matches in-tree SHA256SUMS
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Post link to user.**
+
+### Task 4.2: Respond to CodeRabbit / human review
+
+For every review round:
+
+1. Make the fix on `feat/v3.16.0` and re-run static analysis.
+2. **Rebuild the bundle** (CLAUDE.md release invariant — bundle must match final code commit):
+
+```bash
+rm -rf releases/ipam-3.16.0 ipam-3.16.0
+rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt
+./releases/make_releases.sh Simple-PHP-IPAM 3.16.0
+mkdir -p releases/ipam-3.16.0
+mv ipam-3.16.0/ipam-3.16.0.tar.gz ipam-3.16.0/SHA256SUMS releases/ipam-3.16.0/
+rmdir ipam-3.16.0 2>/dev/null || true
+git add releases/ipam-3.16.0/
+git commit -m "chore(release): rebuild v3.16.0 bundle after review fixes"
+git push origin feat/v3.16.0
+```
+
+3. Repeat until all rounds resolved.
+
+### Task 4.3: Merge (REQUIRES USER PERMISSION)
+
+**STOP. Wait for explicit user instruction to merge. Do not infer.**
+
+- [ ] **Step 1: User approval check.**
+- [ ] **Step 2: Merge** via `gh pr merge <N> --merge` (preserve merge commit per project convention).
+
+### Task 4.4: Tag and create GitHub release
+
+```bash
+git checkout main
+git pull origin main
+git tag -a v3.16.0 -m "v3.16.0 — MFA / Settings / Search UX polish"
+git push origin v3.16.0
+gh release create v3.16.0 \
+  releases/ipam-3.16.0/ipam-3.16.0.tar.gz \
+  releases/ipam-3.16.0/SHA256SUMS \
+  --title "v3.16.0 — MFA / Settings / Search UX polish" \
+  --notes-file <(awk '/^## \[3\.16\.0\]/,/^## \[3\.15\.2\]/' CHANGELOG.md | head -n -2)
+gh release view v3.16.0 --json url,assets
+```
+
+### Task 4.5: Deploy
+
+Per CLAUDE.md release workflow. All deploys use the release tarball + `upgrade.sh` — never raw rsync.
+
+- [ ] **Step 1: Demo (`demo.simplephpipam.com`, root@192.168.80.23, OLS)** — copy tarball, extract under `/tmp`, run `upgrade.sh --yes /usr/local/lsws/vhosts/demo.simplephpipam.com/html`, `chown -R nobody:nogroup`. Verify version in footer.
+- [ ] **Step 2: Prod (`ipam.seanmousseau.com`, same host, MySQL at 192.168.80.13)** — same pattern, different vhost root. Verify version in footer.
+- [ ] **Step 3: 4 testing instances on root@192.168.80.15** — `docker cp` tarball into `dev_seanmousseau_com-apache-php-1`, run `upgrade.sh --yes` for each of `ipam`, `ipam-maria`, `ipam-mysql`, `ipam-postgres`. Verify versions.
+
+### Task 4.6: Marketing website (version bump only — no new docs page)
+
+```bash
+cd website/
+# Update front-page.php: hero badge, Download button (TWO places: hero + quickstart), tar command in quickstart
+# Update header.php: version reference if any
+# Update page.php / page-docs.php: version reference if any (no new doc to add)
+git add -A && git commit -m "chore(release): bump to v3.16.0"
+git push origin main
+cd ..
+rsync -az --delete website/ root@192.168.80.23:/usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/
+ssh root@192.168.80.23 "chown -R nobody:nogroup /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/"
+```
+
+- [ ] **Step 1: Cloudflare cache purge** — `CF_ZONE_ID` + `CF_API_TOKEN` from `~/.claude/dev-secrets.env`.
+
+### Task 4.7: Close milestone and issues
+
+```bash
+for n in 745 746 747 749 750; do
+  gh issue close $n --comment "Released in v3.16.0. See https://github.com/seanmousseau/Simple-PHP-IPAM/releases/tag/v3.16.0"
+done
+gh api -X PATCH repos/seanmousseau/Simple-PHP-IPAM/milestones/44 -f state=closed
+```
+
+### Task 4.8: Memory MCP — RELEASED observation
+
+```text
+mcp__MCP_DOCKER__add_observations on project:simple-php-ipam:roadmap:v3.16.0:
+"RELEASED 2026-MM-DD. Tag v3.16.0 at merge commit <SHA> on main. Bundle SHA256: <hash>. Release URL: https://github.com/seanmousseau/Simple-PHP-IPAM/releases/tag/v3.16.0. All 5 issues closed. Milestone #44 closed. Deployed to demo + prod + 4 testing instances. Website updated. Cloudflare purged."
+```
+
+Update `project:simple-php-ipam` with new "Current shipped version: v3.16.0" observation, supersede prior v3.15.2 marker.
+
+### Task 4.9: Branch cleanup
+
+```bash
+git push origin --delete feat/v3.16.0
+git branch -D feat/v3.16.0
+```
+
+---
+
+## Process Hard Rules (apply to every task)
+
+1. **No push without local docker pass.** Every push to a remote branch requires `bash testing/playwright/bootstrap-app.sh <engine>` + full Playwright + `test_api.sh` green for every engine the change could touch (sqlite always; mysql + pgsql for the migration in Task 1.4 and the search rewrite in Task 1.1). GitHub Action minutes are paid; do not burn them on broken pushes.
+
+2. **No push or PR creation without explicit user permission.** This includes Phase 4 Task 4.1 (push + open release PR) and Task 4.3 (merge). State the action and wait for confirmation.
+
+3. **No merge without explicit user permission.** Same rule, separate decision point.
+
+4. **All local test failures must be resolved before committing.** No skipping, no muting, no `// TODO: fix this test`. Either the app is wrong or the test is wrong; either way, fix it.
+
+5. **Flaky test failures are not acceptable.** A test that passes 4 of 5 runs has a race condition. Find it. Fix it. Do not retry-loop.
+
+6. **Use `gh` and `git` CLIs, not MCP GitHub tools.** Per user preference.
+
+7. **Use `Write` tool over `sed` / `cat` for file writes.** Per user preference.
+
+8. **Use Memory MCP throughout.** Read at start of every fresh subagent dispatch (`open_nodes(['user:sean', 'project:simple-php-ipam', 'project:simple-php-ipam:roadmap:v3.16.0'])`). Write a one-sentence observation with the git short SHA after every meaningful change.
+
+9. **Sub-skill invocations are not optional.** When a task says "invoke ui-ux-pro-max" or "invoke documentation", do it as the first step.
+
+10. **Bundle-matches-code invariant.** The merged tarball under `releases/ipam-3.16.0/` must match the final code commit. After every CR fix round, rebuild the bundle and commit it.
+
+---
+
+## Self-Review
+
+- [x] **Spec coverage** — every issue in milestone #44 mapped to a task. #750 → 1.1, #747 → 1.2, #745 → 1.3, #746 → 1.4, #749 → 1.5.
+- [x] **No placeholders.** Every step contains the action it requires; the issue body is referenced where it carries the canonical spec.
+- [x] **Type / function name consistency** — `ipam_user_mfa_methods`, `ipam_user_preferred_mfa`, `ipam_passkey_dispatch_challenge` (existing), `ipam_setting`, `ipam_render` used consistently.
+- [x] **Process rules visible** — sections 1–10 capture every rule the user specified.
+- [x] **Memory MCP touch points** — observations specified at the close of every phase + after every meaningful change.
+- [x] **Documentation phase invokes the skill.**
+- [x] **Release gate runs all three engines.**
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-27-v3.16.0.md`.
+
+Per the user's explicit instruction, execution will use **`superpowers:subagent-driven-development`** — fresh subagent per task with two-stage review.
+
+**Awaiting user approval to begin Phase 0 (branch setup).**


### PR DESCRIPTION
## Summary
- Post-release docs polish: audit-action coverage in docs/backups.md, docs/restore.md, docs/security.md (token signing, path containment, checksum verification, type column).
- CLAUDE.md release procedure step 9 now requires linking new docs/*.md guides from the relevant feature card on website/front-page.php.
- Cache-purge instruction corrected: simplephpipam.com is fronted by QUIC.cloud + LSCache (not Cloudflare). Cloudflare purge applies only to demo.simplephpipam.com.

## Test plan
- [x] No code changes — docs + CLAUDE.md only
- [x] Marketing-site docs links already deployed (commit 220d87e on website repo, verified live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced backup scheduling documentation with clarified timing recalculation and retry behavior
  * Expanded audit logging documentation with new schedule lifecycle actions
  * Improved security documentation for restore operations, including failure-aware logging and integrity verification measures
  * Added comprehensive release planning for upcoming WebAuthn/Passkeys support as a third 2FA method
  * Added detailed roadmap for v3.16.0 covering UX and MFA enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->