### PR TITLE
docs: add 4 procedure docs (migrations, hotfix, new-page, CI failure) + wire into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,22 @@ Other top-level directories: `testing/` (API test suite and sample datasets), `r
 
 Dev tooling at the repo root (not deployed): `composer.json`, `composer.lock`, `phpstan.neon`, `phpstan-baseline.neon`, `.phpcs.xml`, `phpunit.xml`. Run `composer install` once to install tools into `vendor/` (gitignored).
 
+### Procedure docs (`docs/internal/`)
+
+Operational procedures live alongside the code, one Read away. CLAUDE.md is policy and architecture; these are the "how do I do X" recipes.
+
+| Doc | Use when |
+|---|---|
+| `docs/internal/page-inventory.md` | Looking up existing pages or adding a new one |
+| `docs/internal/test-suites.md` | Running tests locally or fixing CI failures (Local gate before push) |
+| `docs/internal/release-workflow.md` | Cutting a regular release (Phase 1–4) |
+| `docs/internal/hotfix-release.md` | Cutting a hotfix off `main` |
+| `docs/internal/marketing-site.md` | Anything touching `simplephpipam.com` (version bump, new docs, cache purge) |
+| `docs/internal/adding-a-migration.md` | Writing a `migrations.php` closure |
+| `docs/internal/adding-a-page.md` | Creating a new PHP page |
+| `docs/internal/investigating-ci-failure.md` | A check went red on a PR |
+| `docs/internal/release-kickoff-prompt.md` | Starting a new release session (paste-and-go template) |
+
 ---
 
 ## Page inventory

--- a/docs/internal/adding-a-migration.md
+++ b/docs/internal/adding-a-migration.md
@@ -1,0 +1,55 @@
+# Adding a database migration
+
+> Procedural walkthrough for adding a schema migration to `migrations.php`. The architectural rules and migration-history footguns live in `CLAUDE.md` under "Schema migrations" — read that first if you have not before. This doc is the *how*; CLAUDE.md is the *why*.
+
+## When you need a migration
+
+Any change that alters the runtime database structure on an existing install: new table, new column, new index, new trigger, dropped/renamed entity, FK addition, default change. Pure data backfills (no DDL) also belong here so they run once on upgrade.
+
+## Procedure
+
+1. **Pick the version key.** Use the next release's `vX.Y.Z` as the array key. `apply_migrations()` does `ksort($migrations, SORT_NATURAL)` before iterating, so array order in `migrations.php` does not matter — version sort order does.
+
+2. **Write the closure.** Inside `ipam_migrations()`, return:
+   ```php
+   'X.Y.Z-short-slug' => function (PDO $db, Dialect $dialect) {
+       // Idempotency guard — required for ALTER TABLE
+       $cols = $db->query("PRAGMA table_info(addresses)")->fetchAll(PDO::FETCH_ASSOC);
+       $hasNew = array_filter($cols, fn($c) => $c['name'] === 'new_col');
+       if (!$hasNew) {
+           $db->exec("ALTER TABLE addresses ADD COLUMN new_col TEXT");
+       }
+   },
+   ```
+   Use `Dialect` helpers (`$dialect->now()`, `$dialect->upsert()`, `$dialect->binary_type()`, etc.) for portable SQL across SQLite/MySQL/PostgreSQL.
+
+3. **For table rebuilds (rare but high-risk) — read the SQLite footguns first.** `apply_migrations()` already disables FK enforcement (`PRAGMA foreign_keys = OFF`) outside the transaction; do not re-enable it inside. Never `DROP TABLE t_old` with FKs on, never rely on `legacy_alter_table` — both have caused production data loss. See CLAUDE.md "Schema migrations" → "Migration testing pitfalls" for the full list (4 distinct ways this has gone wrong before).
+
+4. **Update all three schema files.** Fresh installs go through `schema.sql` / `schema.mysql.sql` / `schema.pgsql.sql`, not the migration chain. They must stay structurally equivalent. CI's `SchemaParityTest` will fail the build on any divergence (table set, column set, type class, nullability, default kind, FK target, FK on-delete action). Type names normalise — `BLOB` / `VARBINARY(16)` / `BYTEA` all map to `"binary"` — so you don't need exact-string parity, just semantic.
+
+5. **Extend `tests/MigrationTest.php` if you need to prove behaviour.** Standard cases: pre-existing data is preserved, idempotency (running the migration twice is a no-op), constraints behave as expected. Build the pre-migration DB state in-memory in the test setup; do not point at a fixture file.
+
+6. **Run the local gate, then the 3-driver containerized harness:**
+   ```bash
+   vendor/bin/phpunit                              # MigrationTest + SchemaParityTest
+   bash testing/playwright/bootstrap-app.sh sqlite && bash testing/playwright/teardown-app.sh
+   bash testing/playwright/bootstrap-app.sh mysql  && bash testing/playwright/teardown-app.sh
+   bash testing/playwright/bootstrap-app.sh pgsql  && bash testing/playwright/teardown-app.sh
+   ```
+   `bootstrap-app.sh` runs `migrate.php` against a fresh DB — if your migration is broken on any engine, it surfaces here before CI.
+
+7. **Bump `version.php`** and add the migration mention to the release `## [X.Y.Z]` entry in `CHANGELOG.md` under either `Added` (new tables/columns) or `Changed` (modified existing).
+
+## Pitfalls (already burned)
+
+- **`DROP TABLE` with FKs ON cascades to children.** SQLite executes a row-by-row DELETE before dropping. v2.2.1 wiped every IP address on upgrade because of this. `apply_migrations()` now disables FKs around each migration; do not re-enable them inside your closure.
+- **`PRAGMA foreign_keys` is silently ignored inside an active transaction.** Set it before `BEGIN`. The migration runner already does — your closure should not touch it.
+- **`ALTER TABLE t RENAME TO t_old` rewrites child FK references** in SQLite ≥3.26. Renaming `subnets` to `subnets_old` automatically rewrites `addresses.subnet_id` to point at `subnets_old`. Then dropping `subnets_old` cascades. The disable-FK approach (point 1) is the only reliable workaround.
+- **`UNIQUE(a, b)` treats `NULL` as distinct.** Two rows with `(cidr, vrf_id) = ('10.0.0.0/8', NULL)` are both allowed. Test UNIQUE constraints with non-NULL values.
+- **Don't introduce a schema templating system.** Three plain SQL files + the parity test is the chosen design (evaluated and rejected templating during v2.9.0 planning).
+
+## Cross-references
+
+- CLAUDE.md "Schema migrations" — policy, multi-tenancy rules, multi-engine deployment model, runtime-deps policy.
+- `tests/MigrationTest.php` — assertion patterns, in-memory DB setup.
+- `dialects/*.php` — Dialect helper implementations per engine.

--- a/docs/internal/adding-a-page.md
+++ b/docs/internal/adding-a-page.md
@@ -1,0 +1,126 @@
+# Adding a new page
+
+> Procedural checklist for adding a new PHP page to the application. Every page in this codebase follows the same shape — bootstrap → auth → CSRF → query → render → footer. This doc walks through the boilerplate so nothing gets missed.
+>
+> Architectural conventions and the inventory of existing pages live in `CLAUDE.md` and `docs/internal/page-inventory.md`.
+
+## Procedure
+
+1. **Create the file** under `Simple-PHP-IPAM/<page>.php`.
+
+2. **Bootstrap line — first executable line of every page:**
+   ```php
+   <?php
+   require __DIR__ . '/init.php';
+   ```
+   `init.php` enforces HTTPS, configures the session, opens `$db`, runs migrations if pending, runs lazy housekeeping, initialises the CSRF token. After this line `$db` and `$config` are in scope.
+
+   **Exceptions** (do NOT include `init.php`): `api.php` and `status.php` — those are stateless and load `lib.php` + `config.php` directly.
+
+3. **Auth gates — one of the following based on access level:**
+   ```php
+   require_login();              // any authenticated user
+   require_role('admin');        // admin only
+   require_write_access();       // admin + write — readonly users blocked
+   ```
+   Place these immediately after the `init.php` require.
+
+4. **CSRF on every POST handler — non-negotiable:**
+   ```php
+   if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+       csrf_require();
+       // ... handler logic
+   }
+   ```
+   Every form must include the hidden token field:
+   ```html
+   <form method="post">
+     <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
+     ...
+   </form>
+   ```
+
+5. **Output goes through `e()`.** Never echo user-controlled data without `e()` (which wraps `htmlspecialchars`). Semgrep rule `ipam-xss-unsanitized-echo` enforces this; `e()` is registered as a sanitizer.
+
+6. **Page chrome:**
+   ```php
+   page_header('Page title');
+   // ... main content
+   page_footer();
+   ```
+   `page_header()` opens the full `<html>...<body>` and renders the nav. `page_footer()` closes `</div></body></html>` and renders the footer with version + update check. **`page_footer()` does not call `exit()`** — do not output anything after it.
+
+7. **Audit every write.** Convention: `<entity>.<action>` (e.g. `subnet.create`, `address.update`, `user.delete`).
+   ```php
+   audit($db, 'subnet.create', 'subnet', $subnetId, "cidr=$cidr");
+   ```
+   Audit log is append-only — SQLite triggers reject UPDATE/DELETE on `audit_log`.
+
+8. **Add the page to the sidebar nav** in `lib.php` (search for the existing `<nav class="sidebar">` block in `page_header()`). Use a Heroicon SVG from `assets/icons.svg` for consistency. Admin-only pages go in the Admin section.
+
+9. **Bump asset cache-buster** if you added or changed CSS/JS in `assets/app.css` or `assets/app.js`. Two places:
+   - `?v=X.Y.Z` in `page_header()` (`lib.php`)
+   - `?v=X.Y.Z` in `demo_gate.php` lines 74–75 (separate `<head>`, does not call `page_header()`)
+
+10. **Update `docs/internal/page-inventory.md`** — add a row in the table with auth requirement, role, and a one-line description.
+
+11. **Add a Playwright spec** (or extend an existing one in `testing/playwright/tests/`). At minimum cover: page loads at the expected URL, auth gate behaves correctly, primary form POST works end-to-end. Use the `loginAs(page, 'admin'|'readonly')` fixture from `tests/fixtures/auth.ts`.
+
+12. **Run the local gate** before pushing — at minimum:
+    ```bash
+    php -l Simple-PHP-IPAM/<page>.php
+    vendor/bin/phpstan analyse --memory-limit=1G
+    vendor/bin/phpcs
+    semgrep --config=.semgrep/rules.yml --error Simple-PHP-IPAM/
+    bash testing/playwright/bootstrap-app.sh sqlite
+    (cd testing/playwright && IPAM_BASE_URL=https://127.0.0.1:8443 \
+      IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+      npx playwright test <page>.spec.ts --project=chromium)
+    bash testing/playwright/teardown-app.sh
+    ```
+
+## Common omissions (caught in review)
+
+- **Forgot `csrf_require()`** — the most common silent omission. POST handlers without it accept any browser request.
+- **Forgot `audit()` call** — the second-most common. Writes that don't audit are invisible in the audit log.
+- **Echo without `e()`** — semgrep catches most, but watch for indirect output like `header()` calls or JSON without `htmlspecialchars`.
+- **Output after `page_footer()`** — produces visible whitespace + can break HTML when a stale handler echoes after redirect intent.
+- **Page added to sidebar but not to `page-inventory.md`** — the inventory drifts.
+- **No Playwright spec** — every other page has at least basic coverage.
+- **Asset cache-buster bumped in `lib.php` but not `demo_gate.php`** — demo gate has its own `<head>`.
+
+## CLI-only pages
+
+Pages meant to run via cron or CLI (`cron.php`, `migrate.php`, `backup.php`, `restore.php`, `tmp_cleanup.php`, `demo_reset.php`, `demo_seed.php`, `scan_run.php`) must guard against web access at the top:
+
+```php
+if (PHP_SAPI !== 'cli') {
+    header('HTTP/1.1 403 Forbidden');
+    exit(1);
+}
+```
+
+Add the `CLI` row to `page-inventory.md` under "Auth required" and dash for "Role".
+
+## AJAX endpoints
+
+For JSON-returning AJAX endpoints (e.g. `ping_host.php`, `set_theme.php`, `smtp_test.php`, `test_destination.php`):
+
+```php
+require __DIR__ . '/init.php';
+require_login();  // or require_role('admin')
+csrf_require();   // required even for AJAX
+
+header('Content-Type: application/json');
+echo json_encode(['ok' => true, 'message' => '...']);
+```
+
+Do not call `page_header()` / `page_footer()` — pure JSON response only.
+
+## Cross-references
+
+- `CLAUDE.md` "Bootstrap sequence" — what `init.php` does.
+- `CLAUDE.md` "Authentication & authorisation" — role + helper details.
+- `CLAUDE.md` "UI conventions" — CSS classes, Heroicon usage.
+- `CLAUDE.md` "Audit logging" — full action-name convention list.
+- `docs/internal/page-inventory.md` — the master table to update.

--- a/docs/internal/hotfix-release.md
+++ b/docs/internal/hotfix-release.md
@@ -1,0 +1,87 @@
+# Hotfix release procedure
+
+> A hotfix release ships a narrow fix directly off `main` without going through the regular `dev`-integration window. It exists for security issues, post-release regressions, and time-sensitive bugs that should not wait for the next regular release. The shared release machinery (Phase 2 prep checklist, Phase 4 deploy) is unchanged from `docs/internal/release-workflow.md`; only the branch model and scope rules differ.
+>
+> **Use only when a regular release won't do.** If the fix can wait, it goes on `dev` like any other change.
+
+## Examples
+
+- **v3.15.1** — post-release fixes for v3.15.0 (post-login redirect, UTF-8 mail body, app_secret onboarding banner). Branched off `main` directly the day after v3.15.0 shipped.
+- **v3.16.0** — narrow scope (3 fixes) treated like a hotfix even though it was MINOR-bumped. Same branch-off-main pattern.
+
+## When this applies
+
+- The fix is for a regression in the most recently shipped version.
+- The fix is security-sensitive and time-sensitive.
+- The fix is small enough that bundling it with unrelated `dev` work would mean either (a) waiting on unrelated work, or (b) cherry-picking, which is messier than just branching off `main`.
+
+If the fix is large, multi-week, or has dependencies on other in-flight work, do **not** hotfix — land it on `dev` and ship in the next regular release.
+
+## Versioning
+
+- **PATCH bump** for bug fixes only (v3.15.0 → v3.15.1).
+- **MINOR bump** if the hotfix necessarily ships a small backwards-compatible feature alongside (v3.15.x → v3.16.0). Avoid this if you can — minor bumps create user-facing release-notes obligations that hotfixes are trying to skip.
+
+## Procedure
+
+1. **Branch off `main`, not `dev`:**
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b hotfix/v<X.Y.Z>
+   ```
+
+2. **Land the fix.** Each commit on the hotfix branch is its own normal review cycle (CodeRabbit + CI). Follow the Local Gate from `docs/internal/test-suites.md`. If the fix touches migrations, schema, dialects, or any multi-engine code, run all three drivers locally before pushing.
+
+3. **Documentation audit (narrower than a regular release):**
+   - `CHANGELOG.md` — add `## [X.Y.Z] - YYYY-MM-DD` with **Fixed** (and **Security** if applicable). No new comparison link tier; just the patch entry.
+   - `README.md` — replace "What's new" in place if the change is user-visible. Skip if it's an invisible bug fix.
+   - `CLAUDE.md` — bump "Current shipped version" line. Add to page inventory if any new pages (rare in a hotfix). Update any policy section that genuinely changed.
+   - `docs/upgrading.md` — add a `### vX.Y.Z` section under "Version-specific upgrade notes" if there's anything operators must do.
+   - `docs/<area>.md` — only the file(s) genuinely affected by the fix.
+
+4. **Bump `version.php`** to `X.Y.Z` and the asset cache-buster `?v=X.Y.Z` in `lib.php` `page_header()` + `demo_gate.php:74-75` if any CSS/JS changed.
+
+5. **Build the bundle** (same as regular release Phase 2 step 14):
+   ```bash
+   rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt
+   ./releases/make_releases.sh Simple-PHP-IPAM X.Y.Z
+   mkdir -p releases/ipam-X.Y.Z
+   mv ipam-X.Y.Z/ipam-X.Y.Z.tar.gz ipam-X.Y.Z/SHA256SUMS releases/ipam-X.Y.Z/
+   git add releases/ipam-X.Y.Z/
+   git commit -m "chore(release): add vX.Y.Z release bundle and SHA256SUMS"
+   ```
+
+6. **Open the PR `hotfix/v<X.Y.Z> → main`.** This is the deviation from the regular release workflow — there is no `dev` PR. CodeRabbit and CI review the full changeset. Same review-loop expectations as a regular release: every CR comment fixed, bundle rebuilt after every code-fix round (`docs/internal/release-workflow.md` Phase 3 — apply identically here).
+
+7. **Merge** with explicit user approval. Tag, push tag, create the GitHub release, and deploy following Phase 4 of the regular release workflow:
+   - Demo site (`demo.simplephpipam.com`)
+   - Prod (`ipam.seanmousseau.com`)
+   - 4 testing instances on `192.168.80.15`
+   - Marketing site update if the release is visible (`docs/internal/marketing-site.md`)
+   - Close milestone issues + Memory MCP "RELEASED" observation
+
+8. **Bring the fix back to `dev`.** After merge, fast-forward `dev` from `main` (or merge `main` into `dev`) so the fix is part of the next regular release's history. Do this immediately — letting `dev` diverge from `main` causes pain in the next dev → main PR.
+
+## What does **not** change vs a regular release
+
+- The local gate (php -l, phpstan, phpcs, phpunit, semgrep, 3-driver Playwright if relevant)
+- The release-bundle ships with the PR (not a follow-up)
+- Bundle rebuilt after every code-fix review round
+- Phase 4 deploy targets (demo, prod, 4 testing, marketing site)
+- Memory MCP observation cadence
+- The "no PR creation or merge without explicit user approval" rule
+
+## What **does** change
+
+- Branch source: `main`, not `dev`
+- PR target: `main`, not `dev → main`
+- No multi-feature integration window
+- Scope is narrower — anything outside the targeted fix gets pushed back to `dev`
+- README "What's new" can be skipped if the fix is invisible to users
+- After-merge step: bring the fix back to `dev` (not in regular release flow)
+
+## Cross-references
+
+- `docs/internal/release-workflow.md` — the shared Phase 2/3/4 procedure.
+- `docs/internal/test-suites.md` — Local gate + 3-driver pass requirement.
+- `docs/internal/marketing-site.md` — only if the hotfix is user-visible.

--- a/docs/internal/investigating-ci-failure.md
+++ b/docs/internal/investigating-ci-failure.md
@@ -1,0 +1,104 @@
+# Investigating a CI failure
+
+> Procedural guide for diagnosing failures in the GitHub Actions CI pipeline. The goal is always to **reproduce locally** before guessing — most "weird CI failures" reproduce verbatim with the right driver locally.
+
+## Step 1 — find the failing run
+
+```bash
+# By PR number
+gh pr checks <PR>
+
+# By branch (current branch by default)
+gh run list --branch <branch> --limit 5
+
+# Open the failure in browser
+gh run view <run-id> --web
+```
+
+## Step 2 — pull the failed-step log
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+This dumps just the failed step's stdout/stderr — usually enough to identify the failure. Pipe to `less` if it's long.
+
+For the full run log: `gh run view <run-id> --log`.
+
+## Step 3 — identify the **first** failure
+
+Failures cluster. If the auth fixture or the login flow fails, every dependent test fails too — the count is meaningless. Always look at the first red test or first non-zero exit code, not the total.
+
+Common first-failure shapes:
+
+| Symptom | Usual cause |
+|---|---|
+| `database is locked` partway through Playwright | Stale `cron.php` or scan process holding the SQLite write lock (dev-direct only — containerized runs are fresh per job) |
+| Every Playwright test redirects to `/login.php` | Auth fixture broken — wrong creds, rate-limited, container down |
+| `Too many failed login attempts` | `login_attempts` table was not cleared; usually cascades from a prior bad-creds run |
+| `SchemaParityTest` red | One of the three `schema.X.sql` files diverged from the others. Diff the failing pair and re-sync |
+| MigrationTest red | A migration changes pre-existing data; the test asserts row preservation. Read CLAUDE.md "Schema migrations" → "Migration testing pitfalls" before patching |
+| Semgrep red on lines that look fine | Project rule (`.semgrep/rules.yml`) caught real issue. Registry-default rules can false-positive (post-edit hook), but the project gate is what matters |
+| `composer audit` flagged a CVE | Pin or upgrade the affected package — see "Runtime dependencies" in CLAUDE.md for the policy |
+| PHPStan red on lines you didn't touch | Pre-existing baseline drift. Check `phpstan-baseline.neon` — fix the new error if real, do not extend the baseline to suppress real bugs |
+| `playwright.yml` `api-tests` job red but local `test_api.sh` passes | The CI uses `DOCKER_CONTAINER=ipam-pw-test`; reproduce with the same env var (see `docs/internal/test-suites.md`) |
+
+## Step 4 — reproduce locally
+
+The CI Playwright job runs `bootstrap-app.sh <driver>` against a fresh Docker image. To reproduce verbatim:
+
+```bash
+# Use the same driver as the failing matrix job
+bash testing/playwright/bootstrap-app.sh sqlite   # or mysql / pgsql
+
+# For API failures
+DOCKER_CONTAINER=ipam-pw-test bash testing/scripts/test_api.sh https://127.0.0.1:8443
+
+# For Playwright failures — narrow to the failing spec
+(cd testing/playwright && \
+  IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test <file>.spec.ts:<line> --project=chromium --reporter=line)
+
+bash testing/playwright/teardown-app.sh
+```
+
+If the failure repros, debug locally with `--debug` or `--ui`. If it does not repro, suspect:
+- The CI image has different package versions (`composer.lock` drift between local and CI)
+- Timing issues (CI is slower; add `await page.waitForLoadState('networkidle')`)
+- Concurrency — the CI matrix runs jobs in parallel, but each job is in its own container, so this is unlikely
+
+## Step 5 — download the Playwright HTML report (if applicable)
+
+For Playwright failures the workflow uploads an HTML report as an artifact:
+
+```bash
+gh run download <run-id> --name playwright-report
+# Open the unpacked report — it has screenshots + traces of every failed test
+open playwright-report/index.html
+```
+
+The trace viewer is gold for failures that repro on CI but not locally — you see the exact DOM state at every step.
+
+## Step 6 — fix the bug, do not dismiss the failure
+
+> **Non-negotiable rule:** A flaky failure is either an app bug or a test bug. Never dismiss as "flake." Fix the underlying cause.
+
+If a test is genuinely time-sensitive (e.g. depends on a webhook delivery that completes asynchronously), the fix is usually `await page.waitForResponse()` or `expect(...).toPass({ timeout })` — not retries, not skips, not `.skip(true)`.
+
+## Step 7 — push the fix
+
+After fixing locally and getting the local 3-driver gate green, push the branch. CI re-runs automatically. Required reading before push: `docs/internal/test-suites.md` "Local gate" section.
+
+## CI workflow files
+
+For reference when you need to know what runs:
+
+- `.github/workflows/php-qa.yml` — lint + PHPStan + PHPCS + PHPUnit on every push and PR
+- `.github/workflows/playwright.yml` — full containerized Playwright + `test_api.sh` per driver matrix on every PR
+- `.github/workflows/composer-audit.yml` (if present) — runtime-dep CVE check, scheduled nightly + on PR
+
+## Cross-references
+
+- `docs/internal/test-suites.md` — Local gate, how to run the containerized harness, dev-direct footguns.
+- `CLAUDE.md` "Static analysis & testing" — tool-by-tool overview.
+- `CLAUDE.md` "Schema migrations" → "Migration testing pitfalls" — required when MigrationTest is red.

--- a/docs/internal/release-kickoff-prompt.md
+++ b/docs/internal/release-kickoff-prompt.md
@@ -8,6 +8,12 @@ Plan and execute release **v\<X.Y.Z\>** for Simple-PHP-IPAM.
 
 **Read first:** `docs/internal/release-workflow.md`, `docs/internal/marketing-site.md`, `docs/internal/test-suites.md`, and the GitHub milestone for v\<X.Y.Z\> + Memory MCP entity `project:simple-php-ipam:roadmap:v<X.Y.Z>`. Identify orphan issues (no milestone, or from earlier milestones still open) and propose inclusion/deferral decisions before locking scope.
 
+**Procedure docs to consult during execution (don't read upfront, reach for them when relevant):**
+- `docs/internal/adding-a-migration.md` — every release that touches schema
+- `docs/internal/adding-a-page.md` — every release that adds new PHP pages
+- `docs/internal/investigating-ci-failure.md` — when CI goes red
+- `docs/internal/hotfix-release.md` — only if this release is a hotfix off `main` instead of regular `dev → main`
+
 **Use:** `superpowers:writing-plans` to plan, `superpowers:subagent-driven-development` to execute, `ui-ux-pro-max` for any UI/UX work, `documentation` for any README / API doc / ADR / user-guide writing, Memory MCP for state, semgrep MCP and `gh`/`git` CLIs throughout. Keep Memory MCP updated as you go (one observation per meaningful change, with short commit hash).
 
 **Non-negotiable:**

--- a/docs/internal/release-workflow.md
+++ b/docs/internal/release-workflow.md
@@ -156,3 +156,14 @@ If CodeRabbit or a human reviewer asks for a change on the open PR:
    gh issue close <N> --comment "Released in vX.Y.Z. See https://github.com/seanmousseau/Simple-PHP-IPAM/releases/tag/vX.Y.Z"
    ```
 11. **Update Memory MCP** — write a final "RELEASED" observation to the `project:simple-php-ipam:roadmap:vX.Y.Z` entity with: merge commit hash, bundle SHA256, tag, deploy confirmation, and all issues closed. Also update the bare `project:simple-php-ipam` entity if it has a "current version" observation.
+
+---
+
+## Related procedure docs
+
+- `docs/internal/hotfix-release.md` — when the fix can't wait for the regular `dev → main` cycle.
+- `docs/internal/marketing-site.md` — Phase 4 step 9 expanded.
+- `docs/internal/test-suites.md` — Local gate + 3-driver pass.
+- `docs/internal/adding-a-migration.md` — Phase 2 schema/migration steps.
+- `docs/internal/adding-a-page.md` — when the release introduces new pages.
+- `docs/internal/investigating-ci-failure.md` — when Phase 2/3 CI goes red.


### PR DESCRIPTION
## Summary
Adds 4 procedure docs under \`docs/internal/\` for the most-frequently-needed operational tasks that were not yet documented:

| New doc | Why |
|---|---|
| \`adding-a-migration.md\` | Schema migration closure pattern + the four SQLite footguns that caused historical data loss |
| \`hotfix-release.md\` | Branch-off-main flow (v3.15.1, v3.16.0 precedent), deltas vs regular release |
| \`adding-a-page.md\` | Bootstrap→auth→CSRF→audit→page_header boilerplate + commonly-omitted pieces |
| \`investigating-ci-failure.md\` | gh CLI log retrieval, first-failure-clustering, local repro per driver |

Wires them into:
- \`CLAUDE.md\` via a new "Procedure docs" table near the top (orientation)
- \`docs/internal/release-workflow.md\` via a Related-procedures footer
- \`docs/internal/release-kickoff-prompt.md\` as "consult during execution"

## Test plan
- [x] No code changes — pure docs
- [x] Headings + cross-references checked
- [x] Each doc cross-references CLAUDE.md sections it depends on (architectural rules stay there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal procedure guides for database migrations, page additions, hotfix releases, and CI failure investigation.
  * Updated release workflow documentation with cross-references to related procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->