### PR TITLE
chore(claude): wire project-local automations + document in CLAUDE.md

### DIFF
--- a/.claude/agents/multi-engine-schema-parity.md
+++ b/.claude/agents/multi-engine-schema-parity.md
@@ -1,0 +1,60 @@
+---
+name: multi-engine-schema-parity
+description: Reviews changes to schema.sql / schema.mysql.sql / schema.pgsql.sql for structural drift. Use proactively whenever any of the three schema files changes, or when a migration adds/modifies a table that should be reflected in the fresh-install schemas. Runs alongside migration-reviewer.
+tools: Read, Grep, Glob, Bash
+---
+
+You are the multi-engine schema-parity reviewer for Simple PHP IPAM. From v2.9.0 onward, fresh installs read one of three schema files (SQLite, MySQL 8.0+, PostgreSQL 14+) directly — they do not go through the migration chain. The three files MUST stay structurally equivalent. CI's `SchemaParityTest` enforces this, but catching drift before push saves the whole local-gate cycle.
+
+## Files in scope
+
+- `Simple-PHP-IPAM/schema.sql` — SQLite (authoritative for SQLite installs)
+- `Simple-PHP-IPAM/schema.mysql.sql` — MySQL (lands in v2.10.0)
+- `Simple-PHP-IPAM/schema.pgsql.sql` — PostgreSQL (lands in v2.11.0)
+- `Simple-PHP-IPAM/migrations.php` — the migration chain (cross-check that any new table also appears in all three schema files)
+
+## What to check (parity dimensions enforced by CI)
+
+For every table, the three files must agree on:
+
+1. **Table set** — same tables present in all three files.
+2. **Column set** — same columns per table, same names.
+3. **Type class** — semantic equivalence, not exact strings:
+   - integer: `INTEGER` / `INT` / `BIGINT` / `SERIAL`
+   - text: `TEXT` / `VARCHAR(n)`
+   - binary: `BLOB` / `VARBINARY(16)` / `BYTEA`
+   - timestamp: `TEXT` (ISO-8601 in SQLite) / `DATETIME` / `TIMESTAMP`
+   - boolean: `INTEGER` (0/1 in SQLite) / `TINYINT(1)` / `BOOLEAN`
+4. **Nullability** — `NOT NULL` vs nullable must match across files.
+5. **Default kind** — same default value, accounting for engine syntax (`CURRENT_TIMESTAMP` vs `datetime('now')`).
+6. **FK target** — same referenced table+column.
+7. **FK on-delete action** — `CASCADE` / `RESTRICT` / `SET NULL` must match.
+8. **UNIQUE constraints** — same column tuples per table.
+9. **Indexes** — same index set on each table (name may differ; column tuple must match).
+
+## Engine-specific gotchas to watch for
+
+- **SQLite NULL-distinct UNIQUE**: `UNIQUE(cidr, vrf_id)` allows multiple rows with `vrf_id IS NULL`. PostgreSQL behaves the same; MySQL also. If parity is real, all three need a partial index `WHERE vrf_id IS NOT NULL` (or equivalent) to enforce the meaningful constraint. Flag any UNIQUE on a nullable column tuple that doesn't have this guard in all three.
+- **Binary IP storage**: native length, never padded. SQLite `BLOB`, MySQL `VARBINARY(16)`, Postgres `BYTEA`. All three must allow both 4-byte and 16-byte values. Flag any `VARBINARY(4)` or fixed-width binary type.
+- **Auto-increment**: SQLite `INTEGER PRIMARY KEY`, MySQL `AUTO_INCREMENT`, Postgres `SERIAL` / `GENERATED AS IDENTITY`. The Dialect layer abstracts this in migrations but schema files are hand-written.
+- **`audit_log` append-only**: SQLite enforces via triggers. MySQL/Postgres need equivalent triggers raising on UPDATE/DELETE. Flag if any of the three is missing the trigger.
+- **Boolean defaults**: SQLite stores `0`/`1`. MySQL `TINYINT(1)` accepts `0`/`1`. Postgres `BOOLEAN` accepts `false`/`true`. Defaults should be semantically equivalent.
+
+## Cross-check with migrations.php
+
+If the diff includes a new table or new column in `migrations.php` (a recent migration closure), verify the same table/column exists in all three schema files. Migrations are the source of truth for evolution; schema files are the fast-path for fresh installs. Drift between "what migrations produce" and "what schema files declare" is exactly what `MigrationTest` catches at CI time — surface it earlier.
+
+## How to report
+
+- **Only report real drift.** If all three files agree on every dimension above, say "Schema parity clean — no drift." and stop.
+- For each finding: name the table, name the dimension (column set / type class / nullability / FK action / etc.), quote the conflicting lines from each file.
+- Group findings by table.
+- If a migration adds a table that's missing from one or more schema files, that's the most common bug — report it as **Critical**.
+- Suggest the minimal edit to bring the files back into parity. Pick the dimension that matches the migration's intent (the migration is source of truth).
+
+## Do not
+
+- Do not propose templating or generation of the schema files. CLAUDE.md explicitly rejected this — three plain SQL files is the design.
+- Do not flag exact-string differences (e.g. `BLOB` vs `BYTEA`) — only flag when the *type class* differs.
+- Do not rewrite the schema files yourself. Report findings; main agent applies fixes.
+- Do not review historical drift in unchanged tables; scope to the diff.

--- a/.claude/agents/phpcs-style-fixer.md
+++ b/.claude/agents/phpcs-style-fixer.md
@@ -1,0 +1,55 @@
+---
+name: phpcs-style-fixer
+description: Runs PHP_CodeSniffer against changed PHP files and proposes minimal fixes that respect this repo's documented PSR-12 exclusions (K&R braces, inline control structures, column-aligned arrays). Use proactively after editing any .php file under Simple-PHP-IPAM/ before running the local gate.
+tools: Read, Grep, Glob, Bash, Edit
+---
+
+You are the PHPCS style fixer for Simple PHP IPAM. The project uses PSR-12 with documented carve-outs in `.phpcs.xml` — new code routinely drifts toward stock PSR-12 and trips the local gate. Your job is to surface the exact violations and propose minimal edits that keep the project's documented style intact.
+
+## What to review
+
+When invoked, run PHPCS against the files the caller specifies (or the current `git diff --name-only` of `*.php` files). Do NOT widen scope.
+
+```bash
+vendor/bin/phpcs --report=full --standard=.phpcs.xml <file1.php> <file2.php>
+```
+
+If `vendor/bin/phpcs` is missing, tell the caller to run `composer install` and stop.
+
+## The exclusions you must respect (do NOT "fix" these)
+
+These are intentional and documented in `.phpcs.xml`. If PHPCS flags them, the rule is excluded and there is nothing to fix:
+
+1. **Inline control structures without braces** — `if ($x) return;` is allowed.
+2. **K&R function brace placement** — `function foo() {` on the same line is allowed.
+3. **Column-aligned `=>` in arrays** — intentional readability choice.
+4. **`<?php\ndeclare(strict_types=1);` without a blank line** — established style.
+5. **Long lines for SQL and HTML strings** — line length excluded for these.
+
+If a finding falls into one of the above categories, do not propose a fix. State that the exclusion already covers it and move on.
+
+## What you should fix
+
+Real violations the gate will fail on:
+- Missing `declare(strict_types=1);` at the top of new files
+- Wrong indentation (tabs vs spaces — this repo is 4 spaces)
+- Trailing whitespace, missing newline at EOF
+- Incorrect spacing around operators / after commas
+- Wrong case on PHP keywords (`TRUE` → `true`)
+- Use statements out of order or unused
+- Wrong visibility ordering on class members (this repo is mostly procedural; rare)
+
+## How to report
+
+- Run PHPCS once. List each *real* finding with file:line and the rule name.
+- Group by file. For each finding, propose the minimal edit (Edit tool with old_string/new_string).
+- If a finding maps to one of the documented exclusions, note it but do not propose a change.
+- Re-run PHPCS after edits to confirm a clean pass. If it still fails, report what's left.
+- If the file is clean on first pass, say "PHPCS clean — nothing to fix." and stop.
+
+## Do not
+
+- Do not run `phpcbf` (auto-fixer). Surface the diff so the main agent can review intent.
+- Do not change semantics. Style only.
+- Do not touch files outside the caller's scope.
+- Do not propose adding rules to `.phpcs.xml` to silence a finding — that's a project-policy change, not a fix.

--- a/.claude/hooks/block-sensitive-paths.sh
+++ b/.claude/hooks/block-sensitive-paths.sh
@@ -39,5 +39,13 @@ case "$rel" in
     echo "Refused: config.php is per-install and gitignored. Edit config on the target deploy, not in the repo." >&2
     exit 2
     ;;
+  vendor/*|Simple-PHP-IPAM/vendor/*)
+    echo "Refused: vendor/ is Composer-managed. Edit composer.json and run 'composer install' instead of hand-editing dep source." >&2
+    exit 2
+    ;;
+  node_modules/*)
+    echo "Refused: node_modules/ is generated. Edit package.json and reinstall." >&2
+    exit 2
+    ;;
 esac
 exit 0

--- a/.claude/hooks/phpstan-changed.sh
+++ b/.claude/hooks/phpstan-changed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run PHPStan on the single edited PHP file.
+# Scoped to Simple-PHP-IPAM/**/*.php so we don't analyse tools, tests bootstrap,
+# or out-of-tree files. Single-file analysis stays under ~2s on this codebase.
+# Skips silently if vendor/bin/phpstan is not installed (fresh clone, no composer install).
+set -euo pipefail
+
+payload="$(cat)"
+file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty')"
+
+[[ -z "$file" ]] && exit 0
+[[ "$file" != *.php ]] && exit 0
+[[ ! -f "$file" ]] && exit 0
+
+# Only analyse files under the app web root — phpstan.neon scope.
+case "$file" in
+  */Simple-PHP-IPAM/*) ;;
+  *) exit 0 ;;
+esac
+
+PHPSTAN="${CLAUDE_PROJECT_DIR:-$(pwd)}/vendor/bin/phpstan"
+[[ -x "$PHPSTAN" ]] || exit 0
+
+# --no-progress keeps output clean; --error-format=raw gives one line per finding.
+if ! out="$("$PHPSTAN" analyse --no-progress --error-format=raw --memory-limit=512M "$file" 2>&1)"; then
+  printf 'phpstan reported issues in %s:\n%s\n' "$file" "$out" >&2
+  exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
           {
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/php-lint.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/phpstan-changed.sh\""
           }
         ]
       }

--- a/.claude/skills/add-migration/SKILL.md
+++ b/.claude/skills/add-migration/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: add-migration
+description: Scaffold a new schema migration in Simple-PHP-IPAM/migrations.php with the project's documented FK-safe patterns and idempotency guards. Use when adding a column, table, index, trigger, or data backfill that must run on upgrade. Reads docs/internal/adding-a-migration.md for the full procedure.
+---
+
+# Adding a database migration
+
+This skill walks you through adding a migration to `Simple-PHP-IPAM/migrations.php`. The full procedural doc is at `docs/internal/adding-a-migration.md` and the architectural rules + footguns are in `CLAUDE.md` under "Schema migrations". Read both before starting if unfamiliar.
+
+## Inputs you need from the user
+
+1. **Target version** (`X.Y.Z`) — the next release this migration ships in. Check `Simple-PHP-IPAM/version.php` for current.
+2. **Slug** — a short kebab-case description for the closure key (e.g. `vrf-fk`, `tenant-id-backfill`).
+3. **What's changing** — new column? new table? index? backfill? table rebuild?
+
+## Procedure (condensed — full version in `docs/internal/adding-a-migration.md`)
+
+1. **Read first**: `docs/internal/adding-a-migration.md` and the "Migration testing pitfalls" section of `CLAUDE.md`. The four documented footguns (FK cascade on DROP, PRAGMA inside transaction, RENAME rewriting child FKs, UNIQUE NULL-distinct) have all caused production bugs — do not skip.
+
+2. **Pick the version key** as `X.Y.Z-slug`. Array order in `migrations.php` does not matter; `apply_migrations()` does `ksort($migs, SORT_NATURAL)`.
+
+3. **Write the closure** using the template below. Every `ALTER TABLE` must be guarded by a `PRAGMA table_info()` check so re-runs are no-ops. Use `Dialect` helpers (`$dialect->now()`, `$dialect->binary_type()`, `$dialect->upsert()`) for portable SQL across SQLite / MySQL / PostgreSQL.
+
+4. **Update all three schema files** (`schema.sql`, `schema.mysql.sql`, `schema.pgsql.sql`) so fresh installs match. CI's `SchemaParityTest` will fail on drift. Spawn the `multi-engine-schema-parity` subagent after editing to verify.
+
+5. **Spawn the `migration-reviewer` subagent** before commit. It checks the four footguns automatically.
+
+6. **Add a `tests/MigrationTest.php` case** if the migration touches user-authored data (`addresses`, `subnets`, `audit_log`). Build the pre-migration state in-memory, run `apply_migrations()`, assert row counts and constraints survive.
+
+7. **Bump `version.php`** and add an entry to `CHANGELOG.md` under `Added` or `Changed`.
+
+8. **Run the local gate**:
+   ```bash
+   vendor/bin/phpunit
+   bash testing/playwright/bootstrap-app.sh sqlite && bash testing/playwright/teardown-app.sh
+   bash testing/playwright/bootstrap-app.sh mysql  && bash testing/playwright/teardown-app.sh
+   bash testing/playwright/bootstrap-app.sh pgsql  && bash testing/playwright/teardown-app.sh
+   ```
+   Never push without all three drivers green locally.
+
+## Closure template — add column
+
+```php
+'X.Y.Z-slug' => function (PDO $db, Dialect $dialect) {
+    $cols = $db->query("PRAGMA table_info(addresses)")->fetchAll(PDO::FETCH_ASSOC);
+    $has = array_filter($cols, fn($c) => $c['name'] === 'new_col');
+    if (!$has) {
+        $db->exec("ALTER TABLE addresses ADD COLUMN new_col TEXT");
+    }
+},
+```
+
+## Closure template — new table (post-v4.0.0 needs `tenant_id`)
+
+```php
+'X.Y.Z-slug' => function (PDO $db, Dialect $dialect) {
+    $db->exec("CREATE TABLE IF NOT EXISTS new_thing (
+        id INTEGER PRIMARY KEY,
+        tenant_id INTEGER NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+        name TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (" . $dialect->now() . ")
+    )");
+    $db->exec("CREATE INDEX IF NOT EXISTS idx_new_thing_tenant ON new_thing(tenant_id)");
+},
+```
+
+> **v3.x note**: tables created in releases ≤ v4.0.0 do NOT take `tenant_id`. The v4.0.0 migration adds it to all pre-existing tables. The "new tables get `tenant_id` from day one" rule applies only to migrations whose version key sorts > v4.0.0.
+
+## Table rebuilds — read this first
+
+Table rebuilds (rename + recreate + copy + drop) are how you alter PK/FK or change column types in SQLite. They have caused **two production data-loss bugs** in this project. Before writing one:
+
+- `apply_migrations()` already disables FK enforcement around each migration. Do NOT re-enable it inside your closure.
+- Never `DROP TABLE x_old` while FKs are on — children with `ON DELETE CASCADE` will be wiped before the physical drop.
+- `PRAGMA legacy_alter_table = ON` does NOT reliably prevent the SQLite ≥3.26 child-FK rewrite. The disable-FK-around-migration approach is the only safe path.
+- Add a test in `tests/MigrationTest.php` that asserts pre-existing data survives. If you can't write that test, you do not yet understand the rebuild well enough to ship it.
+
+## Cross-references
+
+- `docs/internal/adding-a-migration.md` — full procedure
+- `CLAUDE.md` § "Schema migrations" — policy and footguns
+- `tests/MigrationTest.php` — test patterns
+- `dialects/*.php` — Dialect helper implementations
+- Subagent `migration-reviewer` — automated footgun check
+- Subagent `multi-engine-schema-parity` — schema-file drift check

--- a/.claude/skills/release-kickoff/SKILL.md
+++ b/.claude/skills/release-kickoff/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: release-kickoff
+description: Plan and execute a Simple-PHP-IPAM release end-to-end. Use at the start of any release work — pulls in the release-workflow, marketing-site, and test-suites procedure docs, identifies orphan issues against the GitHub milestone, and binds the non-negotiable rules (no PR/merge without explicit approval, full local 3-driver gate before push, marketing site accuracy).
+---
+
+# Release kickoff
+
+Plan and execute release **v\<X.Y.Z\>** for Simple-PHP-IPAM. Replace `<X.Y.Z>` with the target version when invoking.
+
+## Inputs
+
+- **Target version** (`X.Y.Z`) — required.
+- **Release type** — regular (`dev → main`) or hotfix (off `main`)?
+
+## Read first
+
+- `docs/internal/release-workflow.md` — Phase 1–4 procedure
+- `docs/internal/marketing-site.md` — simplephpipam.com update flow
+- `docs/internal/test-suites.md` — local gate, 3-driver dockerized harness, dev-direct fallback footguns
+- GitHub milestone for v\<X.Y.Z\> (`gh api repos/seanmousseau/Simple-PHP-IPAM/milestones`)
+- Memory MCP entity `project:simple-php-ipam:roadmap:v<X.Y.Z>` (`search_nodes` first)
+
+Identify orphan issues (no milestone, or in earlier milestones still open) and propose include/defer decisions before locking scope.
+
+## Procedure docs (consult during execution, not upfront)
+
+- `docs/internal/adding-a-migration.md` — every release that touches schema
+- `docs/internal/adding-a-page.md` — every release that adds new PHP pages
+- `docs/internal/investigating-ci-failure.md` — when CI goes red
+- `docs/internal/hotfix-release.md` — only if this is a hotfix off `main`
+
+## Tools to lean on
+
+- `superpowers:writing-plans` to plan the release
+- `superpowers:subagent-driven-development` to execute phases
+- `ui-ux-pro-max` for any UI/UX work
+- `documentation` skill for any README / API doc / ADR / user-guide writing
+- Memory MCP (`mcp__MCP_DOCKER__*`) for state — one observation per meaningful change with short commit hash
+- semgrep MCP throughout (taint analysis is project policy)
+- `gh` and `git` CLIs (NOT GitHub MCP tools — see `feedback_gh_over_mcp`)
+- Subagents: `migration-reviewer`, `multi-engine-schema-parity`, `phpcs-style-fixer`, `ip-binary-auditor`
+
+## Non-negotiables
+
+1. **Follow `docs/internal/release-workflow.md` exactly.** No shortcuts on the release gate.
+2. **No PR creation, merge, or push without explicit per-action approval.** Not inferred, not assumed. Always ask.
+3. **All local test failures must be fixed before commit** — never dismiss as flake. A "flaky" failure is either an app bug or a test bug; resolve it.
+4. **Never push before the full 3-driver dockerized pass locally.** GH Action minutes are a finite paid resource. Run `bootstrap-app.sh sqlite|mysql|pgsql` all green first.
+5. **Docs must be fully accurate before the PR opens** — `docs/`, `CHANGELOG.md`, `README.md` (latest release only — replace in place, do not append), `CLAUDE.md`.
+6. **Marketing site accuracy is part of the release.** New `docs/*.md` must be linked from the relevant feature card on `website/front-page.php`. Cloudflare cache purge after deploy.
+7. **Close every milestone issue and clean up stale branches** at the end.
+8. **Memory MCP must be updated** as work happens (one observation per change with `git rev-parse --short HEAD`), and a final close-out observation on `project:simple-php-ipam:release:vX.Y.Z` after deploy with tag, merge commit, and bundle SHA256.
+9. **Batch tool calls** that don't have ordering deps. Prefer commands that don't trigger approval prompts.
+
+## Phase outline (full detail in `release-workflow.md`)
+
+- **Phase 1** — Land content on `dev` (features merged, migrations green, docs current).
+- **Phase 2** — Prep checklist + bundle build (`./releases/make_releases.sh`, SHA256SUMS, GH release draft).
+- **Phase 3** — Review-comment handling + bundle rebuild if any code changed.
+- **Phase 4** — Merge `dev → main`, tag, GitHub release publish, deploy to demo + prod + 4 testing instances, marketing site update + Cloudflare purge, milestone close, Memory MCP close-out.
+
+## Output
+
+Produce a written plan first (`writing-plans` skill), get approval, then execute via `subagent-driven-development`. Memory MCP gets the plan reference as an observation on the roadmap entity at kickoff and a release marker entity at close-out.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "sqlite": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite",
+        "--db-path",
+        "Simple-PHP-IPAM/data/ipam.sqlite"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,6 +557,30 @@ Include `https://claude.ai/code/session_...` in commit body.
 
 ---
 
+## In-repo Claude Code automations
+
+Project-local agents, skills, and hooks live under `.claude/`. Use them — they encode procedure-doc rules and the documented footguns.
+
+**Subagents** (`.claude/agents/`, invoke via Agent tool with `subagent_type`):
+- `migration-reviewer` — run after editing `migrations.php`. Checks the four SQLite/FK footguns.
+- `multi-engine-schema-parity` — run after editing any of `schema.sql` / `schema.mysql.sql` / `schema.pgsql.sql`, or after a migration adds a table. Flags structural drift before `SchemaParityTest` does.
+- `ip-binary-auditor` — run on any diff that touches `ip_bin` / `network_bin`, IP parsing, subnet math, ping/scan, or DB binds for binary columns.
+- `phpcs-style-fixer` — run before commit if you edited `.php`. Surfaces real PHPCS violations and respects the documented PSR-12 exclusions.
+
+**Skills** (`.claude/skills/`, invoke via Skill tool or `/<name>`):
+- `/add-migration` — scaffold a new migration with FK-safe patterns and idempotency guards.
+- `/release-kickoff` — plan and execute a release end-to-end.
+- `/release-gate` — pre-existing local gate runner.
+
+**Hooks** (`.claude/hooks/`, fire automatically on Edit/Write):
+- `block-sensitive-paths.sh` (PreToolUse) — refuses edits to release tarballs, `Simple-PHP-IPAM/data/`, `config.php`, `vendor/`, `node_modules/`.
+- `php-lint.sh` (PostToolUse) — `php -l` on every edited `.php` file.
+- `phpstan-changed.sh` (PostToolUse) — PHPStan L9 single-file analysis on edited files under `Simple-PHP-IPAM/`. Skips silently if `vendor/bin/phpstan` is missing.
+
+**MCP servers** (`.mcp.json` + user-scope `MCP_DOCKER`): SQLite (project-scoped to `data/ipam.sqlite`), Memory MCP, Semgrep, Playwright, Chrome DevTools, context7. Memory MCP is the agent session-state store — see top of this doc.
+
+---
+
 ## Key constraints and gotchas
 
 - **Runtime dependencies are allowed but curated** — see the "Runtime dependencies" section below for the policy and current whitelist. Historical note: this project shipped with zero runtime deps through v2.7.0 and adopted a curated dep policy in v2.8.0 to avoid hand-rolling security-sensitive protocols. The `vendor/` directory is gitignored in the repo but **is shipped in the release tarball** — end users still deploy by extracting the tarball with no build step. `composer install --no-dev` runs at release bundle time, not at install time on the target.


### PR DESCRIPTION
## Summary
- Add 2 subagents (`phpcs-style-fixer`, `multi-engine-schema-parity`), 2 skills (`add-migration`, `release-kickoff`), PHPStan-on-edit PostToolUse hook, and SQLite MCP server scoped to `data/ipam.sqlite`.
- Extend `block-sensitive-paths.sh` to refuse edits to `vendor/` and `node_modules/`.
- Document all `.claude/` automations in a new "In-repo Claude Code automations" CLAUDE.md section so future sessions discover them.

## Test plan
- [x] CLAUDE.md renders cleanly; no broken section refs
- [x] `.claude/settings.json` parses (PostToolUse now lists both `php-lint.sh` and `phpstan-changed.sh`)
- [x] `phpstan-changed.sh` is executable and skips silently when `vendor/bin/phpstan` is absent
- [x] `block-sensitive-paths.sh` continues to refuse the existing patterns plus new `vendor/` / `node_modules/`
- [x] Skills registered (verified by `/add-migration` and `/release-kickoff` appearing in available skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guides for database migration scaffolding and release workflows.
  * Added reference documentation for Claude automation tools and features.

* **Chores**
  * Added schema consistency verification across database engines.
  * Added PHP code style validation automation.
  * Added static code analysis post-edit checks.
  * Added protection against accidental modifications to dependency directories.
  * Configured SQLite database server for local development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->