### PR TITLE
docs(claude-md): quick-start block + tense fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Operational procedures live alongside the code, one Read away. CLAUDE.md is poli
 | `docs/internal/adding-a-page.md` | Creating a new PHP page |
 | `docs/internal/investigating-ci-failure.md` | A check went red on a PR |
 | `docs/internal/release-kickoff-prompt.md` | Starting a new release session (paste-and-go template) |
+| `docs/internal/coderabbit-config.md` | Debugging `.coderabbit.yaml` ↔ org-config inheritance (early-access opt-in for pre-merge checks) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,18 @@ Two cheap calls. The first loads your profile + preferences. The second returns 
 
 ---
 
+## Quick start (new session)
+
+```bash
+composer install                              # one-time, installs dev tools to vendor/
+bash testing/bootstrap-app.sh sqlite          # spin up dockerized app + seed for local testing
+vendor/bin/phpunit && vendor/bin/phpstan analyse && vendor/bin/phpcs
+```
+
+Web root is `Simple-PHP-IPAM/`. Bootstrap entry is `Simple-PHP-IPAM/init.php`. See `docs/internal/test-suites.md` before pushing.
+
+---
+
 ## Project overview
 
 > **Current shipped version: v3.18.0** (see `Simple-PHP-IPAM/version.php`). This CLAUDE.md intentionally documents forward-looking policy for unreleased versions (v4.0.0+) so design intent survives across sessions. Any section or sentence that cites a version ≥ v4.0.0 describes future work — **do not apply it to current v3.x code**. Current-state rules are the ones that do not cite a future version.
@@ -216,8 +228,8 @@ Pre-v4.0.0 migrations do not need to worry about this — they predate tenancy a
 Once v2.9.0 lands, the project ships three schema files that must stay in sync:
 
 - `schema.sql` — SQLite (authoritative for fresh SQLite installs)
-- `schema.mysql.sql` — MySQL 8.0+ (lands in v2.10.0)
-- `schema.pgsql.sql` — PostgreSQL 14+ (lands in v2.11.0)
+- `schema.mysql.sql` — MySQL 8.0+ (shipped v2.10.0)
+- `schema.pgsql.sql` — PostgreSQL 14+ (shipped v2.11.0)
 
 **When adding or modifying a table, column, index, or constraint:** update all three files in the same PR. No exceptions. The `SchemaParityTest` in CI will fail the build if the three files diverge on any structural element (table set, column set, type class, nullability, default kind, FK target, FK on-delete action). Type classes are normalised — `BLOB` / `VARBINARY(16)` / `BYTEA` all map to `"binary"`, so you do not need to match exact type names, only semantic equivalents.
 
@@ -227,9 +239,9 @@ Migrations remain the source of truth for schema evolution. The three schema fil
 
 **Do not introduce a schema templating system.** This was evaluated during v2.9.0 planning and rejected: three plain SQL files are easier to review, easier to debug against a live database, and aligned with the project's vanilla-PHP ethos. The parity test plus migration-replay test is sufficient drift protection.
 
-### Runtime dependencies *(applies from v2.9.0+)*
+### Runtime dependencies *(in force since v2.9.0)*
 
-Adopted in v2.9.0. The project uses Composer-managed runtime dependencies under a narrow, curated policy. The goals are (1) to avoid hand-rolling security-sensitive network protocols and cryptography and (2) to preserve the "rsync and run" deployment story for end users.
+The project uses Composer-managed runtime dependencies under a narrow, curated policy. The goals are (1) to avoid hand-rolling security-sensitive network protocols and cryptography and (2) to preserve the "rsync and run" deployment story for end users.
 
 **Deployment model:**
 

--- a/docs/internal/coderabbit-config.md
+++ b/docs/internal/coderabbit-config.md
@@ -1,0 +1,79 @@
+# CodeRabbit configuration
+
+> How CodeRabbit's per-repo `.coderabbit.yaml` interacts with the org-level config, with a focus on the inheritance gotchas that have caused recurring confusion. Read this before changing CR settings or trying to debug a CR check that "should be inheriting from the org but isn't."
+
+## Two-level configuration
+
+CR resolves settings in this order:
+1. **Repo-level `.coderabbit.yaml`** at the repository root (this project: `/.coderabbit.yaml`)
+2. **Org-level config** managed in the CodeRabbit dashboard (sean's org settings)
+3. **CR's hardcoded platform defaults**
+
+The merge semantics are NOT "deep merge of org over repo." Per-key inheritance varies by feature class:
+
+| Feature class | Inheritance behaviour |
+|---|---|
+| Stable settings (`reviews.profile`, `reviews.auto_review`, title check, etc.) | Inherit normally — repo overrides where defined, org fills in everything else |
+| Early-access settings (most `pre_merge_checks` subkeys including `docstrings`) | **Only inherit if the repo also sets `early_access: true`** |
+| Free-form text (`tone_instructions`, `language`) | Repo wins where defined, org otherwise |
+
+The early-access gating is the most common gotcha: an org-level setting like `pre_merge_checks.docstrings.threshold: 40` will silently fall back to CR's hardcoded `80%` default unless the repo's `.coderabbit.yaml` opts into early-access by declaring `early_access: true` at the top level.
+
+## Current repo configuration
+
+This repo's `.coderabbit.yaml` opts into early-access AND pins the docstrings threshold explicitly as belt-and-suspenders:
+
+```yaml
+early_access: true
+
+reviews:
+  ...
+  pre_merge_checks:
+    docstrings:
+      threshold: 40
+```
+
+Both lines are intentional. The `early_access` flag unlocks org-config inheritance for the whole pre-merge-checks subtree; the explicit `threshold: 40` makes the override resilient to future CR inheritance-behaviour changes. Don't remove either without the other.
+
+## Symptoms that point at this gotcha
+
+- CR PR review header says "Docstring Coverage Required threshold is 80.00%" even though the org config says `40`.
+- Conventional-commit title check works (it inherits from org) but docstring threshold doesn't (it requires early-access opt-in).
+- A new repo added to the org has the same problem until its `.coderabbit.yaml` adds `early_access: true`.
+
+If you see a CR check using a different threshold than the org-level setting, the first thing to check is whether `early_access: true` is present in the repo config. The second thing is to explicitly pin the affected setting in the repo config — that's bulletproof regardless of inheritance behaviour.
+
+## Org-level settings that DO inherit reliably
+
+These work regardless of `early_access` flag because they're stable:
+
+- `reviews.auto_review.labels` and `base_branches`
+- `reviews.pre_merge_checks.title.requirements` (Conventional Commits requirement)
+- `reviews.sequence_diagrams`, `reviews.poem`, `reviews.suggested_labels`
+- `reviews.finishing_touches.docstrings.enabled`
+- `chat.allow_non_org_members`
+
+If you change one of these in the org config, the change applies to this repo automatically — no repo PR needed.
+
+## Org-level settings that need the repo opt-in
+
+These are early-access and need `early_access: true` in the repo config:
+
+- `reviews.pre_merge_checks.docstrings.threshold`
+- Any new pre-merge check that lands as early-access
+
+When CR promotes a setting from early-access to stable, the repo opt-in becomes redundant for that key but doesn't hurt to keep. The list above will become smaller over time as CR matures features out of early-access.
+
+## Verifying the effective config
+
+CR exposes the effective merged configuration in the PR review's "Effective configuration" panel (collapsed by default in the walkthrough comment). Expand it to see exactly what CR is using on a specific PR — that's the authoritative answer when troubleshooting.
+
+If the panel shows your org-level value, the repo is inheriting correctly. If it shows CR's hardcoded default, the early-access opt-in is likely missing.
+
+## When to update this doc
+
+Update this doc when:
+
+- CR ships a new pre-merge check (early-access or stable) — note which class.
+- An org-level setting that you expected to inherit doesn't, and the root cause is something other than the early-access flag.
+- CR changes the repo-vs-org merge semantics in a way that affects this project.

--- a/docs/internal/release-kickoff-prompt.md
+++ b/docs/internal/release-kickoff-prompt.md
@@ -8,11 +8,14 @@ Plan and execute release **v\<X.Y.Z\>** for Simple-PHP-IPAM.
 
 **Read first:** `docs/internal/release-workflow.md`, `docs/internal/marketing-site.md`, `docs/internal/test-suites.md`, and the GitHub milestone for v\<X.Y.Z\> + Memory MCP entity `project:simple-php-ipam:roadmap:v<X.Y.Z>`. Identify orphan issues (no milestone, or from earlier milestones still open) and propose inclusion/deferral decisions before locking scope.
 
+**Re-validate every milestone issue body against current code before locking scope.** Issue bodies are written at filing time and may not reflect post-CR-round reality — multiple v3.18.0 #762 line items had been silently shipped during v3.17 CR rounds. For each open milestone issue, grep for the named function / file / line ranges and confirm the described problem still exists. Propose closing already-shipped line items as part of scope-lock. Do not assume the issue body is authoritative.
+
 **Procedure docs to consult during execution (don't read upfront, reach for them when relevant):**
 - `docs/internal/adding-a-migration.md` — every release that touches schema
 - `docs/internal/adding-a-page.md` — every release that adds new PHP pages
 - `docs/internal/investigating-ci-failure.md` — when CI goes red
 - `docs/internal/hotfix-release.md` — only if this release is a hotfix off `main` instead of regular `dev → main`
+- `docs/internal/coderabbit-config.md` — when CR's pre-merge checks use the wrong threshold (early-access inheritance gotcha)
 
 **Use:** `superpowers:writing-plans` to plan, `superpowers:subagent-driven-development` to execute, `ui-ux-pro-max` for any UI/UX work, `documentation` for any README / API doc / ADR / user-guide writing, Memory MCP for state, semgrep MCP and `gh`/`git` CLIs throughout. Keep Memory MCP updated as you go (one observation per meaningful change, with short commit hash).
 
@@ -20,6 +23,9 @@ Plan and execute release **v\<X.Y.Z\>** for Simple-PHP-IPAM.
 
 - Follow `docs/internal/release-workflow.md` exactly. No shortcuts on the release gate.
 - All local test failures must be fixed before committing — never dismiss as flake. A "flaky" failure is either an app bug or a test bug; resolve it, don't justify it.
+- When changing settings/auth POST semantics, sweep specs for sibling-bool re-assertion bandages (`grep -rn "k_mfa__\|group: 'mfa'" testing/playwright/tests/`) — those bandages often encode load-bearing side-effect dependencies on the legacy group-cascade, not just self-contained setup. See `docs/internal/test-suites.md` "Tests that depend on cascade side-effects".
+- Each spec that creates subnets at module scope MUST claim a unique CIDR (see `docs/internal/test-suites.md` "Each spec needs a unique CIDR"). Do not introduce a new spec that uses the legacy shared `TEST_CIDR2`.
+- Always `git restore Simple-PHP-IPAM/config.php` and remove `*.prebootstrap-backup` / `data/sessions/` before any commit during a release session — `bootstrap-app.sh` overwrites `config.php` and these artifacts will land in commits otherwise.
 - Docs (in `docs/`, `CHANGELOG.md`, `README.md`, `CLAUDE.md`) must be fully accurate before the PR opens.
 - **No PR creation or merge without my explicit per-action approval.** Not inferred, not assumed.
 - Close every milestone issue and clean up stale branches at the end.

--- a/docs/internal/release-workflow.md
+++ b/docs/internal/release-workflow.md
@@ -10,6 +10,8 @@ The release bundle **ships with the release PR**, not in a follow-up PR. Feature
 
 Normal feature PRs into `dev` through the session. Every feature/fix/docs commit goes through its own review cycle; nothing in this phase is release-specific.
 
+**Before locking scope, re-validate every milestone issue body against current code.** Issue bodies are written at filing time and may not reflect post-CR-round reality. Two of five #762 items deferred from the v3.17.0 release were already shipped during v3.17 CR rounds before v3.18.0 kicked off — assuming the issue body was authoritative would have meant duplicate-fixing already-fixed code. For each open milestone issue, grep for the named function / file / line ranges and confirm the described problem still exists. Update the issue body or close the line item before scope-lock.
+
 ### Phase 2 — prepare the release on `dev`
 
 Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in order** on `dev`:
@@ -48,11 +50,16 @@ Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in orde
     ```
     Only proceed if the full suite is green (pre-existing flaky tests excepted — log them in the PR description).
 12. Run the dev-direct pipeline only if the release touches something the containerized harness can't cover (real-IdP OIDC, `test_api.sh` regressions, `timezone.spec.ts`).
-13. **Clean `Simple-PHP-IPAM/data/` of any local test debris** before building — the release script excludes `*.sqlite` but **not** `*.sqlite.*.bak`, `demo_last_reset.txt`, or any other runtime artifacts. Stray files get baked into the tarball otherwise:
+13. **Clean `Simple-PHP-IPAM/` of any local test debris** before building — the release script excludes `*.sqlite` but **not** the various artifacts produced by `bootstrap-app.sh` and prior runs. Run all of these:
     ```bash
+    git restore Simple-PHP-IPAM/config.php                       # bootstrap-app.sh rewrites this
+    rm -f Simple-PHP-IPAM/config.php.prebootstrap-backup         # bootstrap-app.sh's saved original
+    rm -f Simple-PHP-IPAM/config.php.bak-v3upgrade               # legacy upgrade-script backup
     rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt
+    rm -rf Simple-PHP-IPAM/data/sessions                         # PHP session files from local runs
     ls Simple-PHP-IPAM/data/   # expect only ipam.sqlite, tmp/, possibly .htaccess
     ```
+    Stray files baked into the tarball is a recurring class of bug across releases — the cleanup glob has grown over time. Treat `git status` showing anything under `Simple-PHP-IPAM/` other than your release-prep edits as a red flag.
 14. **Build the bundle:**
     ```bash
     ./releases/make_releases.sh Simple-PHP-IPAM X.Y.Z
@@ -77,7 +84,13 @@ Once everything that belongs in `vX.Y.Z` is on `dev`, do the following **in orde
 If CodeRabbit or a human reviewer asks for a change on the open PR:
 
 1. Make the code/doc/test fix on `dev` and re-run the relevant local gate checks.
-2. **Rebuild the bundle so it reflects the fix.** This is non-negotiable: the merged `releases/ipam-X.Y.Z/ipam-X.Y.Z.tar.gz` must match the final code state. Delete the old artifact, rerun the cleanup + build, commit as a new `chore(release): rebuild vX.Y.Z bundle after review fixes` commit (or amend, if the review round happens on a single unreviewed change):
+2. **Rebuild the bundle so it reflects the fix — but only if the fix touched files inside `Simple-PHP-IPAM/`.** The bundle is built from the `Simple-PHP-IPAM/` subtree only; top-level files (`.coderabbit.yaml`, `.github/`, `composer.json`, `docs/`, `releases/`, `tests/`, `website/`) are NOT in the tarball and changes to them do NOT require a rebuild. If the only files changed since the last bundle commit are outside `Simple-PHP-IPAM/`, the existing tarball still matches the deployed code state — skip the rebuild. Verify with:
+
+   ```bash
+   git diff --stat releases/ipam-X.Y.Z/SHA256SUMS..HEAD -- Simple-PHP-IPAM/
+   ```
+
+   If the diff is empty, no rebuild is needed and the tarball stays valid through merge. Otherwise rebuild is non-negotiable: the merged `releases/ipam-X.Y.Z/ipam-X.Y.Z.tar.gz` must match the final code state. Delete the old artifact, rerun the cleanup + build, commit as a new `chore(release): rebuild vX.Y.Z bundle after review fixes` commit (or amend, if the review round happens on a single unreviewed change):
    ```bash
    rm -rf releases/ipam-X.Y.Z ipam-X.Y.Z
    rm -f Simple-PHP-IPAM/data/*.bak Simple-PHP-IPAM/data/demo_last_reset.txt

--- a/docs/internal/test-suites.md
+++ b/docs/internal/test-suites.md
@@ -208,3 +208,57 @@ Do not push until **all drivers are green**. A failing CI run wastes Action minu
 - You suspect a bug that only reproduces behind the reverse-proxy / shared Chrome stack
 
 For those scenarios, follow the full dev-direct pipeline in the *Running the test suites* section above (Deploy → Pre-flight cleanup → Verify admin login → test_api.sh / Playwright dev-direct). For everything else, trust the CI run.
+
+## Containerized harness — recurring footguns
+
+The containerized harness is mostly self-contained, but it does mutate a few files in the working tree and a few categories of test interact in ways that are easy to miss until a full-suite run on pgsql or mysql surfaces them. Read this section before any release-gate run, and before any commit that includes `Simple-PHP-IPAM/config.php`.
+
+### `bootstrap-app.sh` overwrites `config.php`
+
+`bootstrap-app.sh sqlite|mysql|pgsql` rewrites `Simple-PHP-IPAM/config.php` to point at the per-driver test container, and saves the original to `Simple-PHP-IPAM/config.php.prebootstrap-backup`. `teardown-app.sh` restores the original — but only if you reach it cleanly. If the bootstrap is run again before teardown, or the teardown is interrupted, your working tree is left pointing at the test driver.
+
+**Always run before any commit:**
+
+```bash
+git restore Simple-PHP-IPAM/config.php
+rm -f Simple-PHP-IPAM/config.php.prebootstrap-backup
+```
+
+If you don't, your release-prep commit will land at `HEAD` with `config.php` pointing at `pgsql:host=ipam-pw-pgsql:5432;dbname=ipam_pw`, which is a real bug that ships in the bundle.
+
+The release-workflow Phase 2 step 13 cleanup list now includes this; do it routinely.
+
+### Tests that depend on cascade side-effects
+
+Several specs were authored against the legacy `group=mfa` POST cascade behaviour: posting a settings group with a missing boolean key sets that key to `false` as a side effect of HTML form convention. This was load-bearing — `email_otp.spec.ts`'s `beforeEach` posted `group=mfa, k_mfa__email_otp_enabled=1` to enable Email OTP AND, by side effect, disable `mfa.totp_enabled` and `mfa.passkeys_enabled` so the test user's login routed to email OTP rather than a competing verify page.
+
+When v3.18.0 (#756) added a per-key save path that does not cascade, those side-effect dependencies broke under parallel workers — the test user kept TOTP/passkey enrollments from earlier specs and login routed to the wrong verify page.
+
+**When changing settings/auth POST semantics, sweep specs for sibling-bool re-assertion bandages** before assuming you've covered all callers:
+
+```bash
+grep -rn "k_mfa__\|group: 'mfa'" testing/playwright/tests/
+```
+
+If a spec posts `group=mfa` with only one key set, it is almost certainly relying on the cascade as a side-effect setup mechanism — verify by reading the test, then either keep the legacy POST shape if you really need cascade-clear behaviour, or convert to per-key POSTs that explicitly disable each sibling. Don't migrate blindly.
+
+### Each spec needs a unique CIDR for fixtures it creates
+
+`testing/playwright/fixtures/ipam.ts` exports a shared `TEST_CIDR2='10.88.0.0/24'` and `TEST_IP='10.88.0.10'` constant. Five specs (`addresses`, `contacts`, `exports`, `search`, `unassigned`) all create `10.88.0.0/24` and address `10.88.0.10` in their `beforeAll`. Under parallel workers (the Playwright default), these specs race: one spec's `afterAll` deletes the subnet while another spec is mid-test, and `subnetIdFor()` starts returning the wrong row.
+
+**New specs that create subnets at module scope MUST claim a unique CIDR.** Convention: declare a local constant in the spec file, with a unique-to-the-file `10.NN.0.0/24`:
+
+```ts
+// testing/playwright/tests/my-new-feature.spec.ts
+const MY_FEATURE_CIDR = '10.NN.0.0/24'; // pick NN unique to this file
+const MY_FEATURE_IP   = '10.NN.0.10';
+```
+
+Currently in use:
+- `10.88.0.0/24` — `addresses`, `contacts`, `exports`, `search` (legacy shared via `TEST_CIDR2`)
+- `10.91.0.0/24` — `unassigned` (carved out in v3.18.0 #760)
+- `10.93.0.0/24` — `custom-fields-csv`
+
+Pick a fresh `NN` outside that set (`10.92`, `10.94`, `10.95`, …) for any new spec. The shared `TEST_CIDR2` constant is for legacy specs only — new specs declare a local constant. Do not migrate the four legacy specs off `TEST_CIDR2` unless you are also addressing the CIDR-race directly; partial migration leaves the same race in a smaller surface.
+
+The `deleteSubnet()` fixture in `testing/playwright/fixtures/ipam.ts` is now a bounded loop (defence-in-depth against orphan rows when `UNIQUE(cidr, vrf_id)` doesn't dedupe NULL `vrf_id` per SQL standard), but the loop is not a substitute for unique-CIDR-per-spec — the loop only handles the same spec's own orphans, not cross-spec races.


### PR DESCRIPTION
## Summary
- Add "Quick start (new session)" block to CLAUDE.md with composer/bootstrap/test commands so cold-start agent sessions have a 2-line orientation
- Fix stale future-tense phrasing on Runtime dependencies header (policy is in force since v2.9.0, not "adopted in v2.9.0")
- Fix stale phrasing on multi-engine schema files (`schema.mysql.sql` / `schema.pgsql.sql` shipped in v2.10.0 / v2.11.0, were phrased as "lands in")

## Test plan
- [x] CLAUDE.md renders cleanly
- [x] No code/behaviour changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development workflow and release procedures documentation to include enhanced validation steps, configuration guidelines, and testing constraints.

* **Chores**
  * Added new internal reference guides for debugging and troubleshooting.

**Note:** This release contains internal documentation updates only. No user-facing features or bug fixes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->