### PR TITLE
docs: strip Jekyll frontmatter from backups.md + restore.md

### DIFF
--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,8 +1,3 @@
----
-title: Backups
-nav_order: 9
----
-
 # Backups
 
 > **v3.21.0** consolidates every backup and restore screen into a single admin surface at **Admin → Backup & Restore** (`backup_admin.php`). Six legacy pages (`db_tools.php`'s backup half, `destinations.php`, `backup_history.php`, `remote_backups.php`, `restore_web.php`, and the Backups section of `settings.php`) are retired. Their URLs still resolve for now (legacy bookmarks 301 to the new location) but no documentation should reference them.

--- a/docs/restore.md
+++ b/docs/restore.md
@@ -1,8 +1,3 @@
----
-title: Restore
-nav_order: 10
----
-
 # Restore from a backup
 
 > **v3.21.0** moves the restore wizard into the unified backup admin surface at **Admin → Backup & Restore → Restore** (`backup_admin.php?tab=restore`). The legacy `restore_web.php` URL still resolves but new bookmarks should use the unified surface. The CLI restore (`restore.php`) is unchanged.


### PR DESCRIPTION
## Summary

Both docs/backups.md and docs/restore.md (rewritten in v3.21.0 #812 / #813) carried Jekyll frontmatter:

\`\`\`
---
title: Backups
nav_order: 9
---
\`\`\`

GitHub Pages strips this at build time, but the marketing site's marked.js renderer does **not** — it leaked as visible \`title: Backups / nav_order: 9\` text at the top of https://simplephpipam.com/docs/backups/ and the corresponding restore page.

Per \`docs/internal/marketing-site.md\` Pitfalls: "Jekyll frontmatter leaks visible. Never include \`---\\ntitle: …\\n---\` in new docs. marked.js does not strip it."

Existing user-facing docs (security.md, install.md, etc.) follow this convention. backups.md and restore.md are the only ones (besides docs/index.md, which isn't served by the marketing site) that violated it. Pages still build fine without the frontmatter — Jekyll falls back to defaults from \`_config.yml\`.

## Test plan

- [ ] CI green
- [ ] After merge: rsync `website/` is unaffected (this is a docs-only repo change), but the live-served content updates automatically since `page.php` fetches from `raw.githubusercontent.com/main/docs/<slug>.md`. Cache purge on the marketing site flushes any stale renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up metadata structure in backup and restore documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->