### PR TITLE
docs(overhaul): file legacy backup-runner retirement in §C (#1058 v3.23.0 + #1059 v3.26.0)

### DIFF
--- a/docs/internal/backup_overhaul.md
+++ b/docs/internal/backup_overhaul.md
@@ -749,8 +749,9 @@ Each milestone is now ≤16 items, single-theme. Less context-switching mid-rele
 | T2 | Test | OpenSSH-server sidecar for SFTP coverage | — | v3.23 | P0 | Test debt |
 | T3 | Test | Local destination CI coverage | — | v3.23 | P0 | Test debt |
 | T4 | Test | Restore-to-empty-DB row-count parity | — | v3.23 | P0 | All 3 engines |
+| F-LEGACY-DEPR | Func | Deprecate Settings → Data & Maintenance → Backup; migrate `backup.enabled=true` config to a Local destination + schedule on first page load; make Notifications tab editable | #1058 | v3.23 | P1 | Surfaced post-v3.21.0 ship: §1 row at line 19 documents the gap but no F-item existed. Pairs with F21 (Notifications config resolution). Pre-req for B-P1-15 ("After legacy retires"). Hard removal of `run_db_backup_if_due` + `backup.*` keys is tracked in v3.26.0 #1059. |
 
-**v3.23.0 total: ~12 items.** Mostly mechanical cleanups; F18 is the visible feature.
+**v3.23.0 total: ~13 items.** Mostly mechanical cleanups; F18 is the visible feature.
 
 ### v3.24.0 — Encryption v3 (`IPAMBKP3`) + manual restore
 
@@ -801,6 +802,7 @@ Each milestone is now ≤16 items, single-theme. Less context-switching mid-rele
 |---|---|---|---|---|---|---|
 | Cross-engine restore | Func | sqlite-dump → mysql-target, etc. | — | v3.26+ | P2 | AGREED defer §5c' |
 | T5 | Test | Cross-engine restore tests | — | v3.26+ | P2 | Follows F18+F19 |
+| F-LEGACY-RM | Func | Retire `run_db_backup_if_due` and remove the 6 `backup.*` settings keys + Settings → Data & Maintenance → Backup group | #1059 | v3.26 | P0 | Final cutover for the legacy v3.7 single-destination filesystem-only runner. Depends on #1058 (v3.23.0 deprecation + migration helper). Last backup-focus release before v4.0.0 — appropriate place for the hard removal so v4.0.0 ships clean of both backup paths. |
 | ~~F20~~ | ~~Func~~ | ~~Backup type selector `Database` vs `Data`~~ | — | **DROPPED** | — | Resolved 2026-04-29: superseded by §2.1.1 two-type model |
 
 ### v4.0.0 — multi-tenancy (frozen scope; 25 issues already filed)


### PR DESCRIPTION
## Summary

backup_overhaul.md §1 (line 19) flagged the dual configuration surfaces (Settings → Data & Maintenance → Backup vs. the v3.21.0 unified `backup_admin.php`) as a problem but never got an F-item or tracking issue. Surfaced post-v3.21.0 ship when an operator asked the obvious question — why are there two backup config entry points?

This PR adds the missing §C rows for the two issues filed today:

- **#1058** — v3.23.0 deprecation: banner on Settings → Data & Maintenance → Backup, auto-migrate `backup.enabled=true` config to a Local destination + schedule, make Notifications tab editable. Pairs with F21 (Notifications config resolution).
- **#1059** — v3.26.0 hard removal: retire `run_db_backup_if_due`, drop the six `backup.*` settings keys, drop the Settings → Backup group entirely. v3.26.0 is the last backup-focus release before v4.0.0, which makes it the appropriate place for the cutover so v4.0.0 ships clean of both backup paths.

No code changes. Pure planning-doc update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This is an internal documentation update with no user-visible changes at this time. The modifications outline planned deprecation and removal schedules for legacy backup functionality in future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->