### PR TITLE
fix(v3.22.2): flavor-aware mysqldump/mysql SSL flag + surface dump stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
+## [3.22.2] - 2026-05-02
+
+Hotfix for v3.22.1. Production MySQL backups failed against Oracle MySQL 8.x clients because the v3.22.1 SSL-verify flag emitted the MariaDB-canonical `=on/off` form, which Oracle MySQL 8.4 rejects with `[ERROR] unknown variable 'ssl-verify-server-cert=off'`, exit code 7. Conversely, MariaDB 11.x clients (CI's runner image) verify the server cert by default and need an explicit opt-out flag — so a one-flag-fits-all simplification regresses the other half of the field. The diagnostic also only landed in PHP's `error_log`, not the backup-run row, so operators saw a generic "see error_log" message in the UI without a clear path to the actual cause.
+
+### Added
+- **`ipam_mysql_client_flavor()` helper** in `lib/backup.php` — probes `mysqldump --version` once per request, classifies the local client as `'mariadb'`, `'mysql'`, or `'unknown'`, and caches the result. The deferred #1081 follow-ups (`--no-login-paths`, broader `--ssl-mode` adoption) reuse this probe.
+- **`ipam_mysql_ssl_verify_args(bool $verify)`** — emits the flavor-correct flag list. MariaDB gets `--skip-ssl-verify-server-cert` (off) or `--ssl-verify-server-cert` (on). Oracle MySQL gets `--ssl-mode=VERIFY_IDENTITY` (on) or no flag (off — `ssl-mode=PREFERRED` is the client default and does not verify). Unknown flavors fall back to no flag.
+
+### Fixed
+- **`mysqldump` / `mysql` SSL verify flag now flavor-aware** across all three call sites — `Simple-PHP-IPAM/lib/backup.php::ipam_backup_native_cmd` (destination orchestrator), `Simple-PHP-IPAM/lib.php` (legacy CLI runner), and `Simple-PHP-IPAM/restore.php` (mysql restore). Replaces the v3.22.1 hard-coded `--ssl-verify-server-cert=on/off` syntax that worked on MariaDB but bricked every prod backup running against Oracle MySQL ≥ 8.x.
+
+### Changed
+- **`backup_run_dump()` surfaces stderr to callers via a new optional by-reference `$errorOut` parameter.** The legacy CLI runner now records the full `mysqldump`/`pg_dump` stderr (truncated to 500 chars) in the `backup_runs.error_message` column, and the modern destination orchestrator includes it in the `RuntimeException` message that drives the failure-notification pipeline. Operators see the actual cause in the UI and email body instead of "see error_log".
+
 ## [3.22.1] - 2026-05-02
 
 Hotfix for v3.22.0. Two production-affecting issues with MySQL/MariaDB backups:
@@ -1370,6 +1384,7 @@ Settings-in-database groundwork release. Introduces a new `settings` table, a ty
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[3.22.2]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.22.1...v3.22.2
 [3.22.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.22.0...v3.22.1
 [3.22.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.21.1...v3.22.0
 [3.21.1]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.21.0...v3.21.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 Hotfix for v3.22.1. Production MySQL backups failed against Oracle MySQL 8.x clients because the v3.22.1 SSL-verify flag emitted the MariaDB-canonical `=on/off` form, which Oracle MySQL 8.4 rejects with `[ERROR] unknown variable 'ssl-verify-server-cert=off'`, exit code 7. Conversely, MariaDB 11.x clients (CI's runner image) verify the server cert by default and need an explicit opt-out flag — so a one-flag-fits-all simplification regresses the other half of the field. The diagnostic also only landed in PHP's `error_log`, not the backup-run row, so operators saw a generic "see error_log" message in the UI without a clear path to the actual cause.
 
 ### Added
-- **`ipam_mysql_client_flavor()` helper** in `lib/backup.php` — probes `mysqldump --version` once per request, classifies the local client as `'mariadb'`, `'mysql'`, or `'unknown'`, and caches the result. The deferred #1081 follow-ups (`--no-login-paths`, broader `--ssl-mode` adoption) reuse this probe.
-- **`ipam_mysql_ssl_verify_args(bool $verify)`** — emits the flavor-correct flag list. MariaDB gets `--skip-ssl-verify-server-cert` (off) or `--ssl-verify-server-cert` (on). Oracle MySQL gets `--ssl-mode=VERIFY_IDENTITY` (on) or no flag (off — `ssl-mode=PREFERRED` is the client default and does not verify). Unknown flavors fall back to no flag.
+- **`ipam_mysql_client_flavor(string $binary = 'mysqldump')` helper** in `lib/backup.php` — probes `<binary> --version` once per binary, classifies the local client as `'mariadb'`, `'mysql'`, or `'unknown'`, caches per-binary so a host with split-vendor `mysql` / `mysqldump` (e.g. distro `mysqldump` plus a custom `mysql` client) gets the correct dialect for each. The deferred #1081 follow-ups (`--no-login-paths`, broader `--ssl-mode` adoption) reuse this probe.
+- **`ipam_mysql_ssl_verify_args(bool $verify, string $binary = 'mysqldump')`** — emits the flavor-correct flag list. MariaDB gets `--skip-ssl-verify-server-cert` (off) or `--ssl-verify-server-cert` (on). Oracle MySQL gets `--ssl-mode=VERIFY_IDENTITY` (on) or no flag (off — `ssl-mode=PREFERRED` is the client default and does not verify). Unknown flavors fall back to no flag.
+
+### Changed
+- **`backup_run_dump()` surfaces stderr to callers via a new optional by-reference `$errorOut` parameter.** The legacy CLI runner now records the full `mysqldump`/`pg_dump` stderr (truncated to 500 chars) in the `backup_runs.error_message` column, and the modern destination orchestrator includes it in the `RuntimeException` message that drives the failure-notification pipeline. Operators see the actual cause in the UI and email body instead of "see error_log". The `proc_open()` startup-failure branch also populates `$errorOut` (e.g. `"proc_open failed to start mysqldump (not on PATH or disabled)"`) so a missing binary is no longer an empty diagnostic.
 
 ### Fixed
 - **`mysqldump` / `mysql` SSL verify flag now flavor-aware** across all three call sites — `Simple-PHP-IPAM/lib/backup.php::ipam_backup_native_cmd` (destination orchestrator), `Simple-PHP-IPAM/lib.php` (legacy CLI runner), and `Simple-PHP-IPAM/restore.php` (mysql restore). Replaces the v3.22.1 hard-coded `--ssl-verify-server-cert=on/off` syntax that worked on MariaDB but bricked every prod backup running against Oracle MySQL ≥ 8.x.
-
-### Changed
-- **`backup_run_dump()` surfaces stderr to callers via a new optional by-reference `$errorOut` parameter.** The legacy CLI runner now records the full `mysqldump`/`pg_dump` stderr (truncated to 500 chars) in the `backup_runs.error_message` column, and the modern destination orchestrator includes it in the `RuntimeException` message that drives the failure-notification pipeline. Operators see the actual cause in the UI and email body instead of "see error_log".
 
 ## [3.22.1] - 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ No npm, no build step — just PHP and a web server. Runtime Composer dependenci
 
 ---
 
-## What's new in v3.22.1
+## What's new in v3.22.2
 
-Hotfix for v3.22.0. Two production-affecting issues with MySQL/MariaDB backups, both rooted in the same MariaDB 11.4+ / MySQL 8.4+ client default of verifying the server certificate chain — which breaks against any internal/on-prem MySQL with a self-signed cert.
+Hotfix for v3.22.1. Production MySQL backups failed against Oracle MySQL 8.x clients because the v3.22.1 SSL-verify flag emitted the MariaDB-canonical `--ssl-verify-server-cert=on/off` form, which Oracle MySQL 8.4 rejects as an unknown variable. The diagnostic only landed in PHP's `error_log`, so operators saw a generic "see error_log" message in the UI without a clear path to the cause.
 
-- **mysql / mysqldump / mysql-restore TLS verification fixed.** `--ssl-verify-server-cert=off` added to all three call sites in `Simple-PHP-IPAM/lib/backup.php`, `lib.php`, and `restore.php`. Matches PHP PDO_MYSQL's default behaviour (PDO already connects without verifying). Production operators with a verifiable TLS chain can re-enable verification via their own `/etc/mysql/conf.d/` override. The error surfaced as `mysqldump: Got error: 2026: "TLS/SSL error: self-signed certificate in certificate chain"` and the operator-facing Run-now / Restore reported `fclose(): Argument #1 ($stream) must be of type resource, null given` (secondary cascade).
-- **#1075 — destination orchestrator credentials now via 0600 temp file.** Completes the v3.22.0 #820 fix. The legacy CLI runner and restore path shipped temp-file routing in v3.22.0; the v3.17+ destination dump pipeline (`lib/backup.php::ipam_backup_native_cmd`) was attempted in PR #1074 but reverted at the last minute when the TLS issue above made MySQL/MariaDB Run-now fail in CI. With the TLS fix in place, the temp-file pattern ships for every `mysqldump` / `pg_dump` invocation in the app — no more `MYSQL_PWD`/`PGPASSWORD` env vars carrying secrets to the child process.
+- **`mysqldump` / `mysql` SSL verify flag is now flavor-aware.** A new `ipam_mysql_client_flavor()` probe classifies the local client as MariaDB or Oracle MySQL once per request and emits the correct dialect — `--skip-ssl-verify-server-cert` for MariaDB, `--ssl-mode=*` for Oracle MySQL. Fixes a regression introduced in v3.22.1 that broke every prod backup running against Oracle MySQL ≥ 8.x while still keeping MariaDB 11.x (whose client verifies by default) working.
+- **Backup failure cause now visible in the UI and email notifications.** `backup_run_dump()` captures `mysqldump` / `pg_dump` stderr and surfaces it through the `backup_runs.error_message` column and the failure-notification message body (truncated to 500 chars), instead of leaving the diagnostic only in the PHP error log.
 
 [Full changelog →](CHANGELOG.md)
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -3984,26 +3984,40 @@ function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutS
 {
     $errorOut = '';
     $pipes = [];
+    $bin = $cmd[0] ?? 'dump';
     // $cmd is built from admin config values only (never user input); array-form
     // proc_open bypasses the shell entirely so no injection is possible.
-    $proc  = proc_open($cmd, // nosemgrep
-        [
-            0 => ['pipe', 'r'],
-            1 => ['file', $destPath, 'w'],
-            2 => ['pipe', 'w'],
-        ],
-        $pipes,
-        null,
-        $env
-    );
+    //
+    // PHP 8+ raises Error (not returns false) when an internal function appears
+    // in disable_functions, so we catch Throwable and route both failure modes
+    // through the same diagnostic surface — otherwise a hardened php.ini with
+    // proc_open disabled would skip $errorOut population entirely and leave
+    // operators with an empty backup_runs.error_message.
+    try {
+        $proc = proc_open($cmd, // nosemgrep
+            [
+                0 => ['pipe', 'r'],
+                1 => ['file', $destPath, 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            null,
+            $env
+        );
+    } catch (Throwable $e) {
+        $errorOut = 'proc_open threw ' . get_class($e) . ' starting ' . $bin . ': ' . $e->getMessage();
+        error_log('backup_run_dump: ' . $errorOut);
+        @unlink($destPath); // nosemgrep: php.lang.security.unlink-use.unlink-use
+        return false;
+    }
     if (!is_resource($proc)) {
         // Most likely cause: dump binary not on $PATH in the SAPI's restricted
-        // environment, or proc_open is disabled. Surface the binary name so an
-        // operator looking at backup_runs.error_message immediately sees
-        // "mysqldump not executable" rather than an empty diagnostic.
-        $bin = $cmd[0] ?? 'dump';
+        // environment. Surface the binary name so an operator looking at
+        // backup_runs.error_message immediately sees "mysqldump not executable"
+        // rather than an empty diagnostic.
         $errorOut = 'proc_open failed to start ' . $bin . ' (not on PATH or disabled)';
         error_log('backup_run_dump: ' . $errorOut);
+        @unlink($destPath); // nosemgrep: php.lang.security.unlink-use.unlink-use
         return false;
     }
 

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -3778,27 +3778,40 @@ function run_db_backup_if_due(PDO $db, array $config): bool
             // --defaults-extra-file MUST be the first mysqldump argument.
             // (--no-login-paths AND --ssl-mode for Oracle MySQL — both
             // follow-ups tracked in #1081, gated on a probe helper.)
-            $cmd = [
-                'mysqldump', '--defaults-extra-file=' . $credFile,
-                $verifySsl ? '--ssl-verify-server-cert=on' : '--ssl-verify-server-cert=off',
-                '--single-transaction', '--routines',
-                '-h', $host, '-P', $port, '-u', $user, $dbName,
-            ];
+            // v3.22.2: SSL verify flag is flavor-aware. See
+            // ipam_mysql_ssl_verify_args() in lib/backup.php for the full
+            // MariaDB-vs-Oracle-MySQL dialect rationale.
+            $cmd = ['mysqldump', '--defaults-extra-file=' . $credFile];
+            foreach (ipam_mysql_ssl_verify_args($verifySsl) as $sslArg) {
+                $cmd[] = $sslArg;
+            }
+            $cmd[] = '--single-transaction';
+            $cmd[] = '--routines';
+            $cmd[] = '-h';
+            $cmd[] = $host;
+            $cmd[] = '-P';
+            $cmd[] = $port;
+            $cmd[] = '-u';
+            $cmd[] = $user;
+            $cmd[] = $dbName;
             $env = getenv() ?: [];
             // Strip any inherited DB password env vars so a parent shell
             // already exporting these can't leak the secret to the child
             // even though we route the real cred via --defaults-extra-file
             // (#820 PR #1074 CR).
             unset($env['MYSQL_PWD'], $env['PGPASSWORD']);
+            $dumpErr = '';
             try {
-                $ret = backup_run_dump($cmd, $env, $dest);
+                $ret = backup_run_dump($cmd, $env, $dest, 120, $dumpErr);
             } finally {
                 @unlink($credFile); // nosemgrep: php.lang.security.unlink-use.unlink-use
             }
             if (!$ret) {
+                $why = $dumpErr !== '' ? 'mysqldump failed: ' . $dumpErr : 'mysqldump failed';
+                $whyTrunc = strlen($why) > 500 ? substr($why, 0, 497) . '...' : $why;
                 backup_runs_insert_cli($db, basename($dest), 0, '',
-                    $startedAt, date('Y-m-d H:i:s'), 'failed', 'mysqldump failed');
-                try { ipam_backup_notify($db, $legacyDest, 'failure', 'mysqldump failed for ' . basename($dest)); }
+                    $startedAt, date('Y-m-d H:i:s'), 'failed', $whyTrunc);
+                try { ipam_backup_notify($db, $legacyDest, 'failure', $whyTrunc . ' (' . basename($dest) . ')'); }
                 catch (Throwable $ne) { error_log('[backup] notify dispatch failed: ' . $ne->getMessage()); }
                 return false;
             }
@@ -3839,15 +3852,18 @@ function run_db_backup_if_due(PDO $db, array $config): bool
             // the child (#820 PR #1074 CR).
             unset($env['MYSQL_PWD'], $env['PGPASSWORD']);
             $env['PGPASSFILE'] = $credFile;
+            $dumpErr = '';
             try {
-                $ret = backup_run_dump($cmd, $env, $dest);
+                $ret = backup_run_dump($cmd, $env, $dest, 120, $dumpErr);
             } finally {
                 @unlink($credFile); // nosemgrep: php.lang.security.unlink-use.unlink-use
             }
             if (!$ret) {
+                $why = $dumpErr !== '' ? 'pg_dump failed: ' . $dumpErr : 'pg_dump failed';
+                $whyTrunc = strlen($why) > 500 ? substr($why, 0, 497) . '...' : $why;
                 backup_runs_insert_cli($db, basename($dest), 0, '',
-                    $startedAt, date('Y-m-d H:i:s'), 'failed', 'pg_dump failed');
-                try { ipam_backup_notify($db, $legacyDest, 'failure', 'pg_dump failed for ' . basename($dest)); }
+                    $startedAt, date('Y-m-d H:i:s'), 'failed', $whyTrunc);
+                try { ipam_backup_notify($db, $legacyDest, 'failure', $whyTrunc . ' (' . basename($dest) . ')'); }
                 catch (Throwable $ne) { error_log('[backup] notify dispatch failed: ' . $ne->getMessage()); }
                 return false;
             }
@@ -3955,8 +3971,18 @@ function ipam_backup_write_pgpass_file(string $pass): string
  * @param list<string> $cmd
  * @param array<string,string> $env
  */
-function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutSecs = 120): bool
+/**
+ * @param list<string>            $cmd
+ * @param array<string,string>    $env
+ * @param string                  $errorOut Captured stderr/diagnostic on failure (v3.22.2).
+ *                                          Populated even when the function returns false so
+ *                                          callers can surface the cause in a backup-run row's
+ *                                          `error_message` instead of leaving operators to
+ *                                          grep PHP error_log.
+ */
+function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutSecs = 120, string &$errorOut = ''): bool
 {
+    $errorOut = '';
     $pipes = [];
     // $cmd is built from admin config values only (never user input); array-form
     // proc_open bypasses the shell entirely so no injection is possible.
@@ -3999,7 +4025,8 @@ function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutS
             fclose($pipes[2]);
             proc_close($proc);
             @unlink($destPath); // nosemgrep: php.lang.security.unlink-use.unlink-use
-            error_log('backup_run_dump: killed after ' . $timeoutSecs . 's timeout');
+            $errorOut = 'killed after ' . $timeoutSecs . 's timeout';
+            error_log('backup_run_dump: ' . $errorOut);
             return false;
         }
         usleep(100000); // 100ms polling interval
@@ -4020,13 +4047,15 @@ function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutS
     //                       dest file is a strong success signal.
     if ($finalExit > 0) {
         @unlink($destPath); // nosemgrep: php.lang.security.unlink-use.unlink-use
-        error_log('backup_run_dump failed (exit=' . $finalExit . '): ' . trim($stderr));
+        $errorOut = 'exit=' . $finalExit . ': ' . trim($stderr);
+        error_log('backup_run_dump failed (' . $errorOut . ')');
         return false;
     }
     $size = @filesize($destPath);
     if ($size === false || $size === 0) {
         @unlink($destPath); // nosemgrep: php.lang.security.unlink-use.unlink-use
-        error_log('backup_run_dump failed (exit=' . $finalExit . ', empty output): ' . trim($stderr));
+        $errorOut = 'exit=' . $finalExit . ', empty output: ' . trim($stderr);
+        error_log('backup_run_dump failed (' . $errorOut . ')');
         return false;
     }
     @chmod($destPath, 0600);

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -3996,7 +3996,16 @@ function backup_run_dump(array $cmd, array $env, string $destPath, int $timeoutS
         null,
         $env
     );
-    if (!is_resource($proc)) return false;
+    if (!is_resource($proc)) {
+        // Most likely cause: dump binary not on $PATH in the SAPI's restricted
+        // environment, or proc_open is disabled. Surface the binary name so an
+        // operator looking at backup_runs.error_message immediately sees
+        // "mysqldump not executable" rather than an empty diagnostic.
+        $bin = $cmd[0] ?? 'dump';
+        $errorOut = 'proc_open failed to start ' . $bin . ' (not on PATH or disabled)';
+        error_log('backup_run_dump: ' . $errorOut);
+        return false;
+    }
 
     fclose($pipes[0]);
     stream_set_blocking($pipes[2], false);

--- a/Simple-PHP-IPAM/lib/backup.php
+++ b/Simple-PHP-IPAM/lib/backup.php
@@ -511,12 +511,19 @@ function ipam_mysql_client_flavor(string $binary = 'mysqldump'): string
     }
     $pipes = [];
     // Constant array-form invocation; bypasses the shell entirely so no
-    // injection surface exists.
-    $proc = proc_open( // nosemgrep
-        [$binary, '--version'],
-        [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
-        $pipes
-    );
+    // injection surface exists. PHP 8+ raises Error (not returns false) when
+    // proc_open is in disable_functions, so we treat both failure modes as
+    // "unknown flavor" — call sites then omit the SSL flag and the operator
+    // sees the real cause via the surfaced stderr from backup_run_dump.
+    try {
+        $proc = proc_open( // nosemgrep
+            [$binary, '--version'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+    } catch (Throwable $e) {
+        return $cache[$binary] = 'unknown';
+    }
     if (!is_resource($proc)) {
         return $cache[$binary] = 'unknown';
     }

--- a/Simple-PHP-IPAM/lib/backup.php
+++ b/Simple-PHP-IPAM/lib/backup.php
@@ -490,23 +490,35 @@ function ipam_backup_dest_client(array $dest): BackupClientInterface
  *
  * The probe is best-effort: any `proc_open` failure or missing binary
  * returns 'unknown' and call sites omit the SSL flag entirely.
+ *
+ * Cached per-binary so a host with split-vendor `mysql` / `mysqldump`
+ * (e.g. distro-package mysqldump + custom-installed mysql client) gets the
+ * correct dialect for each tool independently.
  */
-function ipam_mysql_client_flavor(): string
+function ipam_mysql_client_flavor(string $binary = 'mysqldump'): string
 {
-    static $cached = null;
-    if ($cached !== null) {
-        return $cached;
+    /** @var array<string,string> $cache */
+    static $cache = [];
+    // Restrict to the two binaries we ever invoke; an unexpected value would
+    // otherwise become an attacker-influenced argv if a caller forwarded user
+    // input. Both are constant strings in our codebase today, but pin the
+    // contract anyway.
+    if ($binary !== 'mysqldump' && $binary !== 'mysql') {
+        return 'unknown';
+    }
+    if (isset($cache[$binary])) {
+        return $cache[$binary];
     }
     $pipes = [];
     // Constant array-form invocation; bypasses the shell entirely so no
     // injection surface exists.
     $proc = proc_open( // nosemgrep
-        ['mysqldump', '--version'],
+        [$binary, '--version'],
         [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
         $pipes
     );
     if (!is_resource($proc)) {
-        return $cached = 'unknown';
+        return $cache[$binary] = 'unknown';
     }
     $stdout = stream_get_contents($pipes[1]) ?: '';
     $stderr = stream_get_contents($pipes[2]) ?: '';
@@ -515,12 +527,12 @@ function ipam_mysql_client_flavor(): string
     proc_close($proc);
     $haystack = $stdout . "\n" . $stderr;
     if (stripos($haystack, 'MariaDB') !== false) {
-        return $cached = 'mariadb';
+        return $cache[$binary] = 'mariadb';
     }
     if (stripos($haystack, 'MySQL') !== false) {
-        return $cached = 'mysql';
+        return $cache[$binary] = 'mysql';
     }
-    return $cached = 'unknown';
+    return $cache[$binary] = 'unknown';
 }
 
 /**
@@ -530,11 +542,15 @@ function ipam_mysql_client_flavor(): string
  * MySQL with verify off — the client default `--ssl-mode=PREFERRED` does not
  * verify the server certificate, which is what we want).
  *
+ * The probe is run against the binary actually being invoked so a host with a
+ * MariaDB `mysqldump` and an Oracle `mysql` (or vice versa) gets the right
+ * dialect for each call site.
+ *
  * @return list<string>
  */
-function ipam_mysql_ssl_verify_args(bool $verify): array
+function ipam_mysql_ssl_verify_args(bool $verify, string $binary = 'mysqldump'): array
 {
-    $flavor = ipam_mysql_client_flavor();
+    $flavor = ipam_mysql_client_flavor($binary);
     if ($flavor === 'mariadb') {
         // MariaDB 11.x defaults to verify-on, so we MUST emit something
         // explicit when verify is off, otherwise self-signed servers break.

--- a/Simple-PHP-IPAM/lib/backup.php
+++ b/Simple-PHP-IPAM/lib/backup.php
@@ -467,6 +467,92 @@ function ipam_backup_dest_client(array $dest): BackupClientInterface
 }
 
 /**
+ * Detect the flavor of the locally-installed `mysqldump` / `mysql` client.
+ *
+ * Returns one of `'mariadb'`, `'mysql'`, or `'unknown'`. Result is cached for
+ * the lifetime of the request because the probe shells out to `mysqldump
+ * --version` and we don't want to repeat that for every dump invocation.
+ *
+ * Why we need this (v3.22.2): MariaDB and Oracle MySQL clients diverged on
+ * SSL/TLS option spelling around the MariaDB 11.x / Oracle MySQL 8.4
+ * timeframe. The dialects are mutually incompatible:
+ *
+ *   - MariaDB 11.x: `--ssl-verify-server-cert` (bare = ON), `--ssl-verify-server-cert=on/off`,
+ *     `--skip-ssl-verify-server-cert` (= OFF). Rejects `--ssl-mode=*`.
+ *   - Oracle MySQL 8.4: `--ssl-mode=DISABLED|PREFERRED|VERIFY_*` is the
+ *     canonical replacement. Rejects `--ssl-verify-server-cert=on/off` and
+ *     `--skip-ssl-verify-server-cert` as unknown options.
+ *
+ * Without flavor-aware emission a single hard-coded SSL flag bricks half the
+ * field. The deferred follow-up #1081 (`--no-login-paths` and `--ssl-mode`
+ * adoption) was supposed to introduce this probe; the v3.22.1 SSL flag
+ * regression on Oracle MySQL prod made it a hotfix item instead.
+ *
+ * The probe is best-effort: any `proc_open` failure or missing binary
+ * returns 'unknown' and call sites omit the SSL flag entirely.
+ */
+function ipam_mysql_client_flavor(): string
+{
+    static $cached = null;
+    if ($cached !== null) {
+        return $cached;
+    }
+    $pipes = [];
+    // Constant array-form invocation; bypasses the shell entirely so no
+    // injection surface exists.
+    $proc = proc_open( // nosemgrep
+        ['mysqldump', '--version'],
+        [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+        $pipes
+    );
+    if (!is_resource($proc)) {
+        return $cached = 'unknown';
+    }
+    $stdout = stream_get_contents($pipes[1]) ?: '';
+    $stderr = stream_get_contents($pipes[2]) ?: '';
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+    proc_close($proc);
+    $haystack = $stdout . "\n" . $stderr;
+    if (stripos($haystack, 'MariaDB') !== false) {
+        return $cached = 'mariadb';
+    }
+    if (stripos($haystack, 'MySQL') !== false) {
+        return $cached = 'mysql';
+    }
+    return $cached = 'unknown';
+}
+
+/**
+ * Build the SSL-related arguments for `mysqldump` / `mysql` based on the
+ * detected client flavor and the operator's `backup.dump_ssl_verify` setting.
+ * Returns an empty list when the safe behaviour is "emit nothing" (Oracle
+ * MySQL with verify off — the client default `--ssl-mode=PREFERRED` does not
+ * verify the server certificate, which is what we want).
+ *
+ * @return list<string>
+ */
+function ipam_mysql_ssl_verify_args(bool $verify): array
+{
+    $flavor = ipam_mysql_client_flavor();
+    if ($flavor === 'mariadb') {
+        // MariaDB 11.x defaults to verify-on, so we MUST emit something
+        // explicit when verify is off, otherwise self-signed servers break.
+        return $verify ? ['--ssl-verify-server-cert'] : ['--skip-ssl-verify-server-cert'];
+    }
+    if ($flavor === 'mysql') {
+        // Oracle MySQL 8.x defaults to ssl-mode=PREFERRED (TLS if available,
+        // no cert verification). For verify-off we omit the flag — emitting
+        // --ssl-mode=DISABLED would gratuitously turn off TLS encryption too.
+        return $verify ? ['--ssl-mode=VERIFY_IDENTITY'] : [];
+    }
+    // Unknown flavor: emit nothing and hope the client defaults to a sane
+    // non-verifying mode. Worst case the operator sees a clear error in the
+    // surfaced stderr (v3.22.2) and can pin a flavor manually.
+    return [];
+}
+
+/**
  * Build the proc_open command + env for the configured DB driver's native
  * dump tool. Shared by the v3.17 remote-destination pipeline and the
  * legacy CLI backup runner so both stay in sync if a flag changes.
@@ -508,18 +594,17 @@ function ipam_backup_native_cmd(string $driver, array $config): array
         $credFile  = ipam_backup_write_mysql_defaults_file($pass);
         // --defaults-extra-file MUST be the FIRST argument; mysql/mysqldump
         // ignore it otherwise (libmysql parses it before any other option).
-        // (Two related v3.23.0 follow-ups tracked in #1081, both gated on
-        // a one-time client-flavor + version probe that we don't have yet:
-        //   1) --no-login-paths to neutralise ~/.mylogin.cnf override —
-        //      added in MariaDB 11.4; CI's MariaDB 10.11 rejects it.
-        //   2) --ssl-mode for Oracle MySQL clients — currently we always
-        //      emit --ssl-verify-server-cert which is MariaDB-canonical
-        //      and accepted but deprecated on Oracle MySQL 8.x; may be
-        //      removed in MySQL 9.x.
-        // Both fixes share the same probe-and-cache helper — bundle them.)
-        $cmd  = ['mysqldump', '--defaults-extra-file=' . $credFile,
-                 $verifySsl ? '--ssl-verify-server-cert=on' : '--ssl-verify-server-cert=off',
-                 '--single-transaction', '--routines'];
+        //
+        // SSL verify flag is flavor-aware (see ipam_mysql_ssl_verify_args).
+        // MariaDB and Oracle MySQL clients diverged on the option spelling
+        // around the 11.x/8.4 timeframe — a hard-coded form bricks half the
+        // field in either direction.
+        $cmd = ['mysqldump', '--defaults-extra-file=' . $credFile];
+        foreach (ipam_mysql_ssl_verify_args($verifySsl) as $sslArg) {
+            $cmd[] = $sslArg;
+        }
+        $cmd[] = '--single-transaction';
+        $cmd[] = '--routines';
         if (preg_match('/unix_socket=([^;]+)/i', $dsn, $m)) {
             $cmd[] = '--socket';
             $cmd[] = $m[1];
@@ -622,8 +707,18 @@ function ipam_backup_dump_to_tmp(PDO $db): string
             try {
                 // 10-minute deadline matches what an interactive admin would tolerate;
                 // larger DBs that legitimately need more should run via cron instead.
-                if (!backup_run_dump($native['cmd'], $native['env'], $tmpSql, 600)) {
-                    throw new RuntimeException('ipam_backup: ' . $driver . ' dump failed (see error_log)');
+                $dumpErr = '';
+                if (!backup_run_dump($native['cmd'], $native['env'], $tmpSql, 600, $dumpErr)) {
+                    // v3.22.2: surface stderr in the exception so the cause lands
+                    // in backup_runs.error_message and the UI; previously the diagnostic
+                    // was only available in the PHP error_log, which on LSWS/FPM
+                    // installs is operationally hard to find. Truncate to 500 chars
+                    // so a verbose stderr doesn't blow the row's column width.
+                    $detail = $dumpErr !== '' ? $dumpErr : 'see error_log';
+                    if (strlen($detail) > 500) {
+                        $detail = substr($detail, 0, 497) . '...';
+                    }
+                    throw new RuntimeException('ipam_backup: ' . $driver . ' dump failed: ' . $detail);
                 }
                 $in = @fopen($tmpSql, 'rb');
                 if ($in === false) {

--- a/Simple-PHP-IPAM/restore.php
+++ b/Simple-PHP-IPAM/restore.php
@@ -188,7 +188,7 @@ if ($driver === 'sqlite') {
     // MariaDB-vs-Oracle-MySQL dialect rationale. (--no-login-paths follow-up
     // is still tracked in #1081 — same probe-and-cache pattern.)
     $cmd = ['mysql', '--defaults-extra-file=' . $credFile];
-    foreach (ipam_mysql_ssl_verify_args($verifySsl) as $sslArg) {
+    foreach (ipam_mysql_ssl_verify_args($verifySsl, 'mysql') as $sslArg) {
         $cmd[] = $sslArg;
     }
     $cmd[] = '-h';

--- a/Simple-PHP-IPAM/restore.php
+++ b/Simple-PHP-IPAM/restore.php
@@ -183,13 +183,21 @@ if ($driver === 'sqlite') {
     // in the finally block below regardless of how the proc_open block exits.
     $credFile = ipam_backup_write_mysql_defaults_file($pass);
     // --defaults-extra-file MUST be the first mysql argument.
-    // --no-login-paths + --ssl-verify-server-cert toggling per
-    // lib/backup.php::ipam_backup_native_cmd rationale (PR #1080 CR / #1075).
-    // (--no-login-paths AND --ssl-mode for Oracle MySQL — both follow-ups
-    // tracked in #1081, gated on a probe helper.)
-    $cmd = ['mysql', '--defaults-extra-file=' . $credFile,
-            $verifySsl ? '--ssl-verify-server-cert=on' : '--ssl-verify-server-cert=off',
-            '-h', $host, '-P', $port, '-u', $user, $dbName];
+    // v3.22.2: SSL verify flag is flavor-aware. See
+    // ipam_mysql_ssl_verify_args() in lib/backup.php for the full
+    // MariaDB-vs-Oracle-MySQL dialect rationale. (--no-login-paths follow-up
+    // is still tracked in #1081 — same probe-and-cache pattern.)
+    $cmd = ['mysql', '--defaults-extra-file=' . $credFile];
+    foreach (ipam_mysql_ssl_verify_args($verifySsl) as $sslArg) {
+        $cmd[] = $sslArg;
+    }
+    $cmd[] = '-h';
+    $cmd[] = $host;
+    $cmd[] = '-P';
+    $cmd[] = $port;
+    $cmd[] = '-u';
+    $cmd[] = $user;
+    $cmd[] = $dbName;
     $env = getenv() ?: [];
     // Strip any inherited DB password env vars so a parent shell that
     // already has these set can't leak the secret into the child via

--- a/Simple-PHP-IPAM/version.php
+++ b/Simple-PHP-IPAM/version.php
@@ -2,5 +2,5 @@
 declare(strict_types=1);
 
 if (!defined('IPAM_VERSION')) {
-    define('IPAM_VERSION', '3.22.1');
+    define('IPAM_VERSION', '3.22.2');
 }


### PR DESCRIPTION
## Summary

Hotfix for v3.22.1. Production MySQL backups have been failing since v3.22.1 against Oracle MySQL 8.x clients because the v3.22.1 SSL-verify hotfix hard-coded `--ssl-verify-server-cert=on/off`, which Oracle MySQL 8.4 rejects as `[ERROR] unknown variable 'ssl-verify-server-cert=off'` (exit 7). Simply omitting the flag re-breaks MariaDB 11.x self-signed installs (the original v3.22.1 case) because that client verifies by default — so this needs flavor-aware emission, which the deferred #1081 follow-up was supposed to introduce.

## Changes

- **`ipam_mysql_client_flavor()`** (lib/backup.php) — probes `mysqldump --version` once per request, classifies as `'mariadb'` / `'mysql'` / `'unknown'`, caches.
- **`ipam_mysql_ssl_verify_args(bool)`** — emits flavor-correct flag list:
  - MariaDB: `--skip-ssl-verify-server-cert` (off) / `--ssl-verify-server-cert` (on)
  - Oracle MySQL: nothing (off — `ssl-mode=PREFERRED` default does not verify) / `--ssl-mode=VERIFY_IDENTITY` (on)
  - Unknown: nothing (best effort)
- Wired into all three call sites: destination orchestrator (`lib/backup.php::ipam_backup_native_cmd`), legacy CLI runner (`lib.php`), mysql restore (`restore.php`).
- **`backup_run_dump()` `$errorOut` by-ref parameter** — captures `mysqldump`/`pg_dump` stderr; legacy callers write it into `backup_runs.error_message`, modern destination orchestrator includes it in the `RuntimeException` so the cause now appears in the UI and failure-notification emails instead of only in PHP `error_log`.
- Bump `IPAM_VERSION` to 3.22.2; CHANGELOG + README "What's new" updated.

## Test plan

- [x] `php -l` on every changed file
- [x] PHPStan L9 — no errors
- [x] PHPCS — clean
- [x] PHPUnit 561 / 561
- [x] semgrep custom rules — 0 findings
- [x] 3-driver Playwright local gate:
  - [x] SQLite — 793 passed (39 skipped)
  - [x] MySQL (MariaDB 11.8.6 client) — 763 passed (69 skipped) — backup specs that were RED on this branch before the helper landed are now green
  - [x] PostgreSQL — 763 passed (69 skipped)
- [x] Verified flavor-detection branch logic against both real clients: Oracle MySQL 8.4.9 on prod (192.168.80.23) and MariaDB 11.8.6 inside the CI container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved MySQL backup SSL verification failures with Oracle MySQL 8.x by making client SSL handling flavor-aware, preventing broken backups/restores.

* **Diagnostics**
  * Surface underlying dump-tool stderr so backup failures include clearer, truncated diagnostic messages in the UI and email notifications.

* **Version Update**
  * Released v3.22.2 (hotfix).

* **Documentation**
  * Updated changelog and README “What’s new” to v3.22.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->