### PR TITLE
docs(deploy-targets): fix stale post-deploy probe (version.php is constant-only)

### DIFF
--- a/docs/internal/deploy-targets.md
+++ b/docs/internal/deploy-targets.md
@@ -54,11 +54,11 @@ OpenLiteSpeed runs PHP as `nobody:nogroup` — the chown is non-optional or `dat
 ### Verify
 
 ```bash
-curl -sk https://demo.simplephpipam.com/version.php  | grep -o "v${TAG}"
-curl -sk https://ipam.seanmousseau.com/version.php   | grep -o "v${TAG}"
+curl -sk https://demo.simplephpipam.com/login.php | grep -oE "app\.css\?v=${TAG}"
+curl -sk https://ipam.seanmousseau.com/login.php  | grep -oE "app\.css\?v=${TAG}"
 ```
 
-The `version.php` endpoint emits a plain-text `vX.Y.Z` string and is the cheapest post-deploy probe.
+The `login.php` page is the cheapest post-deploy probe — unauthenticated, fast, and the `<link rel="stylesheet" href="assets/app.css?v=X.Y.Z.<mtime>">` cache-buster (emitted by `page_header()` in `lib.php`) carries the deployed version string. **`version.php` is not a probe** — it only defines the `IPAM_VERSION` constant and emits no body, so OpenLiteSpeed/Apache return 403 on a direct GET.
 
 ---
 
@@ -95,12 +95,12 @@ Apache inside the container runs as `www-data`. The trailing host-side chown is 
 for inst in ipam ipam-maria ipam-mysql ipam-postgres; do
   printf "%-16s " "${inst}:"
   curl -sk -u "${IPAM_BASIC_USER}:${IPAM_BASIC_PASS}" \
-    "https://dev-direct.seanmousseau.com:8343/testing/${inst}/version.php"
-  echo
+    "https://dev-direct.seanmousseau.com:8343/testing/${inst}/login.php" \
+    | grep -oE "app\.css\?v=${TAG}" | head -1
 done
 ```
 
-Each line should print `vX.Y.Z`. A blank line or a `<br>`-laden 500 error means the migration failed for that engine — investigate before declaring the deploy complete.
+Each line should print `app.css?v=X.Y.Z` (the cache-buster carries the deployed version). A blank line or a `<br>`-laden 500 error means the migration failed for that engine — investigate before declaring the deploy complete. As above, `version.php` is not a probe.
 
 ### Migration verification
 


### PR DESCRIPTION
## Summary

`docs/internal/deploy-targets.md` told operators to verify deploys with `curl https://.../version.php | grep -o vX.Y.Z`, but `version.php` only **defines** the `IPAM_VERSION` constant — there's no `echo`. A direct GET against it on OpenLiteSpeed (Class 1) returns a 403 page; on Apache (Class 2) it returns an empty body. The doc has been wrong since the procedure consolidation, but anyone running the recipe would have to bring their own inside knowledge to recover.

Discovered while deploying v3.22.3 to all 7 targets — switched mid-deploy to scraping the `app.css?v=X.Y.Z.<mtime>` cache-buster from `login.php`, which is what this PR codifies.

## Change

Class 1 (production-grade hosts) + Class 2 (multi-engine testing instances) verify recipes both now scrape the asset cache-buster from `login.php`:

```bash
curl -sk https://demo.simplephpipam.com/login.php | grep -oE "app\\.css\\?v=${TAG}"
```

`login.php` is unauthenticated, fast, and `page_header()` in `lib.php` emits the cache-buster as `app.css?v=IPAM_VERSION.<mtime>` — so `grep -oE "app\\.css\\?v=${TAG}"` is a clean, deterministic version probe. Added an explicit "version.php is not a probe" sentence in both sections so the next reader doesn't repeat the mistake.

## Test plan

- [x] Probe works against `demo.simplephpipam.com` and `ipam.seanmousseau.com` (Class 1)
- [x] Probe works against all four `dev-direct...:8343/testing/{ipam,ipam-maria,ipam-mysql,ipam-postgres}/` instances (Class 2)
- [ ] CI green (docs-only change — no PHP gate impact expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal deployment verification procedures documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->