### PR TITLE
fix(restore): drawer-pattern Verify/Delete (Bug A — v3.27.8 PR 1/5)

### DIFF
--- a/Simple-PHP-IPAM/views/backup_admin_restore.php
+++ b/Simple-PHP-IPAM/views/backup_admin_restore.php
@@ -122,7 +122,11 @@ declare(strict_types=1);
                     </form>
 
                     <?php if ($row['run_id'] > 0): ?>
-                      <a class="action-pill" href="backup_run_detail.php?id=<?= $row['run_id'] ?>">Verify / Delete</a>
+                      <button type="button" class="action-pill"
+                              data-drawer-url="backup_run_detail.php?id=<?= $row['run_id'] ?>"
+                              data-drawer-title="Run #<?= $row['run_id'] ?>">
+                        Verify / Delete
+                      </button>
                     <?php endif; ?>
 
                     <!-- Restore — pre-fills the existing stage form -->

--- a/testing/playwright/tests/restore-browser.spec.ts
+++ b/testing/playwright/tests/restore-browser.spec.ts
@@ -151,4 +151,43 @@ test.describe('Restore tab — destination-driven backup browser (#1077)', () =>
     // in the destination-driven backup browser is now the sole stage path,
     // and `tests/restore-browser.spec.ts:click-row-Restore` above already
     // covers it end-to-end.
+
+    // v3.27.8 Bug A: Verify / Delete control on the Restore tab must open
+    // the same per-run drawer the History tab uses, not navigate to a
+    // partial-HTML page rendered without page_header(). Asserted both at
+    // the markup level (button + data-drawer-url) and via live click so
+    // a future regression to <a href=…> can't slip past.
+    test('Bug A: Verify/Delete uses drawer-pattern button, not anchor navigation', async () => {
+        await gotoRestore(page);
+        await selectDestinationByName(page, DEST_LOCAL);
+
+        const verifyBtn = page.locator(
+            'table.data-table tbody tr button[data-drawer-url^="backup_run_detail.php"]'
+        ).first();
+        const hasBtn = await verifyBtn.count();
+        test.skip(hasBtn === 0, 'no backup row with run_id > 0 in fixture; covered by integration spec');
+
+        // Markup contract: must be a <button>, must carry data-drawer-url,
+        // must NOT be a navigation anchor.
+        const tagName = await verifyBtn.evaluate(el => el.tagName.toLowerCase());
+        expect(tagName).toBe('button');
+        const drawerUrl = await verifyBtn.getAttribute('data-drawer-url');
+        expect(drawerUrl, 'data-drawer-url must point at backup_run_detail.php').toMatch(
+            /^backup_run_detail\.php\?id=\d+$/
+        );
+
+        // No same-row legacy anchor regression.
+        const anchorRegression = page.locator(
+            'table.data-table tbody tr a[href^="backup_run_detail.php"]'
+        );
+        expect(await anchorRegression.count(), 'no <a href=backup_run_detail.php> anchors should remain').toBe(0);
+
+        // Live behaviour: click opens the global drawer with the partial body.
+        // The URL must NOT change (full-page navigation would update location).
+        const urlBefore = page.url();
+        await verifyBtn.click();
+        await expect(page.locator('#global-drawer')).toBeVisible();
+        await expect(page.locator('#global-drawer-body')).not.toBeEmpty();
+        expect(page.url(), 'drawer open must not navigate the page').toBe(urlBefore);
+    });
 });


### PR DESCRIPTION
## Summary

PR 1 of 5 in the v3.27.8 backup/restore stabilization hotfix. Fixes **Bug A** from the post-v3.27.7 CDP diagnosis: on the Restore tab, clicking *Verify / Delete* loaded `backup_run_detail.php` as a full-page navigation, producing an unstyled HTML fragment because that endpoint is a drawer-partial (no `page_header()`).

## Root cause

`backup_run_detail.php` is intentionally a drawer-body partial (`docblock`: "read-only HTML partial endpoint for the Backup History drawer"). The History tab loads it via `data-drawer-url`; the Restore tab was loading the same endpoint via `<a href>`.

## Fix

`Simple-PHP-IPAM/views/backup_admin_restore.php` — anchor → `<button>` with `data-drawer-url` + `data-drawer-title`, mirroring `views/backup_admin_history.php:227`. The delegated click handler in `assets/app.js:2221` opens the drawer and fetches the partial.

## Test plan

- [x] `php -l` on the changed view file — clean
- [x] `vendor/bin/phpstan analyse` — clean (level 9)
- [x] `vendor/bin/phpcs` — clean
- [x] **SQLite dockerized Playwright pass** — 773 passed / 41 skipped / 1 flake (a11y-infrastructure first-test login timeout, unrelated to this change, re-runs 13/13 clean)
- [x] **test_api.sh** — 197/0/0
- [x] New spec `testing/playwright/tests/restore-browser.spec.ts:Bug A` — asserts both the markup contract (button + `data-drawer-url`, no `<a href>` regression) and live click behaviour (drawer opens, page does not navigate)
- [ ] CI: full 3-driver pass on `dev`/`main` (this PR runs on the `hotfix/v3.27.8` → `main` flow)

## v3.27.8 series

Operational plan: `docs/superpowers/plans/2026-05-11_v3.27.8.md`. Remaining PRs in the linear branch:
- PR 2: Bug B + C — badge ground-truth from `backup_runs` LEFT JOIN
- PR 3: Bug E — three-state vault status (`absent` / `present` / `unreadable`)
- PR 4: Bug D — orphan run-row investigation (time-boxed 4h)
- PR 5: Drop silent plaintext fallback + `backup.preflight_failed` audit verb

## Refs

- `docs/internal/roadmap.md` §3.7 (v3.27.8 scope)
- `docs/superpowers/plans/2026-05-11_v3.27.8.md` §Bug-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verify/Delete actions in the backup restore wizard now open in a drawer interface instead of direct navigation.

* **Tests**
  * Added test validation for drawer behavior on Verify/Delete controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->