### PR TITLE
fix(restore): badge ground-truth from backup_runs (Bug B+C — v3.27.8 PR 2/5)

### DIFF
--- a/Simple-PHP-IPAM/lib/backup_admin_restore.php
+++ b/Simple-PHP-IPAM/lib/backup_admin_restore.php
@@ -303,7 +303,7 @@ function ipam_backup_admin_restore_handle(\PDO $db, array $config): array
             // status). Limited to runs against this destination so a same-
             // named file on another destination doesn't shadow.
             $runsStmt = $db->prepare(
-                "SELECT id, filename, checksum, backup_type, status
+                "SELECT id, filename, checksum, backup_type, encryption_mode, status
                    FROM backup_runs
                   WHERE destination_id = :d AND filename IS NOT NULL"
             );
@@ -317,28 +317,8 @@ function ipam_backup_admin_restore_handle(\PDO $db, array $config): array
             }
 
             foreach ($objects as $obj) {
-                $name = $obj['name'];
-                $run  = $runIndex[$name] ?? null;
-                // Default to 'unknown' rather than 'database' for objects
-                // with no backup_runs row. An IPAMBKL1 file copied into the
-                // destination, or one whose history was pruned, has no
-                // record here — defaulting to 'database' would let the
-                // degraded-restore gate disable Restore on mysql/pgsql
-                // installs missing the native CLI even though the file
-                // is actually a Logical-format dump that doesn't need it.
-                // The dispatcher in ipam_restore_apply() sniffs the magic
-                // bytes at stage time so the safe default is "I don't
-                // know yet, let staging decide".
-                $type = is_array($run) && is_string($run['backup_type'] ?? null) ? $run['backup_type'] : 'unknown';
-                $browseEntries[] = [
-                    'name'         => $name,
-                    'size'         => $obj['size'],
-                    'last_modified' => $obj['last_modified'],
-                    'is_encrypted' => str_ends_with($name, '.enc'),
-                    'backup_type'  => $type,
-                    'checksum'     => is_array($run) && is_string($run['checksum'] ?? null) ? $run['checksum'] : '',
-                    'run_id'       => is_array($run) ? to_int($run['id'] ?? 0) : 0,
-                ];
+                $run = $runIndex[$obj['name']] ?? null;
+                $browseEntries[] = ipam_restore_browse_entry_derive($obj, $run);
             }
         } catch (Throwable $e) {
             $browseError = 'Could not list backups for this destination: ' . $e->getMessage();
@@ -360,6 +340,70 @@ function ipam_backup_admin_restore_handle(\PDO $db, array $config): array
         'browseEntries'  => $browseEntries,
         'browseError'    => $browseError,
         'browseDegradedDb' => $degraded,
+    ];
+}
+
+/**
+ * v3.27.8 (Bug B+C) — derive a single Restore-tab browse-entry row from
+ * a destination object + its optional backup_runs row.
+ *
+ * Pure function (no DB, no I/O) so the badge ground-truth rules are
+ * unit-testable. Rules:
+ *
+ *   • When a backup_runs row exists, its `encryption_mode` and
+ *     `backup_type` win unconditionally — filename suffix is ignored.
+ *     This is the fix for #v3.27.8-B+C: pre-fix, a file ending in `.enc`
+ *     was always badged "encrypted" even if the recorded run was
+ *     `encryption_mode='unencrypted'` (and vice versa).
+ *   • When no run row is present (orphan object — listObjects() saw it
+ *     but no `backup_runs` row exists for that destination_id+filename),
+ *     `is_orphan=true` is set so the UI can surface a "no DB record"
+ *     marker. `is_encrypted` falls back to the `.enc` filename heuristic;
+ *     `encryption_mode` and `backup_type` are reported as `'unknown'`
+ *     rather than guessed from suffix so downstream UI can render a
+ *     distinct "Unknown" badge and the dispatcher in ipam_restore_apply()
+ *     keeps responsibility for magic-byte sniffing at stage time.
+ *
+ * @param array{name:string,size:int,last_modified:string} $obj
+ * @param array<string,mixed>|null $run
+ * @return array{
+ *   name:string,size:int,last_modified:string,
+ *   is_encrypted:bool,encryption_mode:string,backup_type:string,
+ *   checksum:string,run_id:int,is_orphan:bool
+ * }
+ */
+function ipam_restore_browse_entry_derive(array $obj, ?array $run): array
+{
+    if ($run !== null) {
+        $mode = is_string($run['encryption_mode'] ?? null)
+            ? (string)$run['encryption_mode']
+            : 'unencrypted';
+        $type = is_string($run['backup_type'] ?? null)
+            ? (string)$run['backup_type']
+            : 'unknown';
+        return [
+            'name'           => $obj['name'],
+            'size'           => $obj['size'],
+            'last_modified'  => $obj['last_modified'],
+            'is_encrypted'   => $mode !== 'unencrypted',
+            'encryption_mode' => $mode,
+            'backup_type'    => $type,
+            'checksum'       => is_string($run['checksum'] ?? null) ? (string)$run['checksum'] : '',
+            'run_id'         => to_int($run['id'] ?? 0),
+            'is_orphan'      => false,
+        ];
+    }
+
+    return [
+        'name'            => $obj['name'],
+        'size'            => $obj['size'],
+        'last_modified'   => $obj['last_modified'],
+        'is_encrypted'    => str_ends_with($obj['name'], '.enc'),
+        'encryption_mode' => 'unknown',
+        'backup_type'     => 'unknown',
+        'checksum'        => '',
+        'run_id'          => 0,
+        'is_orphan'       => true,
     ];
 }
 

--- a/Simple-PHP-IPAM/views/backup_admin_restore.php
+++ b/Simple-PHP-IPAM/views/backup_admin_restore.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
  * @var array{tables:list<mixed>, schema_diff:list<mixed>, total_statements:int, warnings:list<mixed>}|null                                 $dryRunResult
  * @var list<array<string, mixed>>                                                                                                          $destinations
  * @var int                                                                                                                                 $browseDestId
- * @var list<array{name:string,size:int,last_modified:string,is_encrypted:bool,backup_type:string,checksum:string,run_id:int}>             $browseEntries
+ * @var list<array{name:string,size:int,last_modified:string,is_encrypted:bool,encryption_mode:string,backup_type:string,checksum:string,run_id:int,is_orphan:bool}> $browseEntries
  * @var string                                                                                                                              $browseError
  * @var string                                                                                                                              $browseDegradedDb
  */
@@ -92,14 +92,25 @@ declare(strict_types=1);
                   $checksumShort = $checksum !== '' ? substr($checksum, 0, 12) . '&hellip;' : '&mdash;';
               ?>
                 <tr>
-                  <td><code><?= e($row['name']) ?></code></td>
+                  <td>
+                    <code><?= e($row['name']) ?></code>
+                    <?php if ($row['is_orphan']): ?>
+                      <span class="badge muted" title="This file exists in the destination but has no backup_runs row. Encryption and Type below are inferred from the filename, not the database.">no DB record</span>
+                    <?php endif; ?>
+                  </td>
                   <td><?= e(number_format($row['size'])) ?></td>
                   <td><?= e($row['last_modified']) ?></td>
                   <td>
-                    <?php if ($row['is_encrypted']): ?>
-                      <span class="badge badge-success" title="Encrypted with app_secret-derived AES-256-GCM key">IPAMBKP1+</span>
-                    <?php else: ?>
+                    <?php if ($row['encryption_mode'] === 'stored'): ?>
+                      <span class="badge badge-success" title="Encrypted with the vault key derived from app_secret + backup_vault_key (stored mode)">Encrypted &middot; stored</span>
+                    <?php elseif ($row['encryption_mode'] === 'transitory'): ?>
+                      <span class="badge badge-success" title="Encrypted with an operator-supplied passphrase (transitory mode) — passphrase required to restore">Encrypted &middot; transitory</span>
+                    <?php elseif ($row['encryption_mode'] === 'unencrypted'): ?>
                       <span class="badge">plaintext</span>
+                    <?php elseif ($row['is_encrypted']): ?>
+                      <span class="badge badge-success" title="Filename ends with .enc — no backup_runs row to confirm the mode">Encrypted &middot; inferred</span>
+                    <?php else: ?>
+                      <span class="badge" title="Filename has no .enc suffix — no backup_runs row to confirm">plaintext &middot; inferred</span>
                     <?php endif; ?>
                   </td>
                   <td>

--- a/tests/RestoreFilenameBadgeTest.php
+++ b/tests/RestoreFilenameBadgeTest.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib/backup_admin_restore.php';
+
+/**
+ * v3.27.8 Bug B+C — Restore-tab Encryption + Type badges must reflect
+ * backup_runs ground truth, not filename suffix. Orphan files (listed in
+ * the destination but missing from backup_runs) fall back to the filename
+ * heuristic and are flagged so the UI can label the inference.
+ *
+ * Pure-function tests on the extracted helper
+ * ipam_restore_browse_entry_derive(); no PDO + no BackupClientInterface
+ * mock required.
+ */
+final class RestoreFilenameBadgeTest extends TestCase
+{
+    /** @return array{name:string,size:int,last_modified:string} */
+    private function obj(string $name, int $size = 1024, string $lm = '2026-05-11T00:00:00Z'): array
+    {
+        return ['name' => $name, 'size' => $size, 'last_modified' => $lm];
+    }
+
+    public function testRunRowEncryptedStoredEncSuffix(): void
+    {
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('ipam-2026-05-11-stored.sql.gz.enc'),
+            ['id' => 7, 'filename' => 'ipam-2026-05-11-stored.sql.gz.enc',
+             'encryption_mode' => 'stored', 'backup_type' => 'database', 'checksum' => 'abc']
+        );
+        $this->assertTrue($entry['is_encrypted']);
+        $this->assertSame('stored', $entry['encryption_mode']);
+        $this->assertSame('database', $entry['backup_type']);
+        $this->assertFalse($entry['is_orphan']);
+        $this->assertSame(7, $entry['run_id']);
+        $this->assertSame('abc', $entry['checksum']);
+    }
+
+    public function testDbWinsWhenEncSuffixButRecordedUnencrypted(): void
+    {
+        // Mismatch case central to Bug B: file ends with .enc but the run
+        // row says unencrypted. DB must win, not the filename.
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('weird-name.enc'),
+            ['id' => 8, 'filename' => 'weird-name.enc',
+             'encryption_mode' => 'unencrypted', 'backup_type' => 'database', 'checksum' => '']
+        );
+        $this->assertFalse($entry['is_encrypted']);
+        $this->assertSame('unencrypted', $entry['encryption_mode']);
+        $this->assertFalse($entry['is_orphan']);
+    }
+
+    public function testDbWinsWhenPlainSuffixButRecordedStored(): void
+    {
+        // Other-direction mismatch: file lacks .enc but run row says stored.
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('renamed.sql.gz'),
+            ['id' => 9, 'filename' => 'renamed.sql.gz',
+             'encryption_mode' => 'stored', 'backup_type' => 'database', 'checksum' => '']
+        );
+        $this->assertTrue($entry['is_encrypted']);
+        $this->assertSame('stored', $entry['encryption_mode']);
+        $this->assertFalse($entry['is_orphan']);
+    }
+
+    public function testTransitoryModeIsEncrypted(): void
+    {
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('passphrased.sql.gz.enc'),
+            ['id' => 10, 'filename' => 'passphrased.sql.gz.enc',
+             'encryption_mode' => 'transitory', 'backup_type' => 'database', 'checksum' => '']
+        );
+        $this->assertTrue($entry['is_encrypted']);
+        $this->assertSame('transitory', $entry['encryption_mode']);
+    }
+
+    public function testOrphanWithEncSuffixInfersEncrypted(): void
+    {
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('stranded.sql.gz.enc'),
+            null
+        );
+        $this->assertTrue($entry['is_encrypted']);
+        $this->assertSame('unknown', $entry['encryption_mode']);
+        $this->assertSame('unknown', $entry['backup_type']);
+        $this->assertTrue($entry['is_orphan']);
+        $this->assertSame(0, $entry['run_id']);
+        $this->assertSame('', $entry['checksum']);
+    }
+
+    public function testOrphanWithPlainSuffixInfersPlaintext(): void
+    {
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('stranded.sql.gz'),
+            null
+        );
+        $this->assertFalse($entry['is_encrypted']);
+        $this->assertSame('unknown', $entry['encryption_mode']);
+        $this->assertSame('unknown', $entry['backup_type']);
+        $this->assertTrue($entry['is_orphan']);
+    }
+
+    public function testLogicalBackupTypePreserved(): void
+    {
+        $entry = ipam_restore_browse_entry_derive(
+            $this->obj('ipam-logical.ipambkl1.gz'),
+            ['id' => 11, 'filename' => 'ipam-logical.ipambkl1.gz',
+             'encryption_mode' => 'unencrypted', 'backup_type' => 'logical', 'checksum' => 'def']
+        );
+        $this->assertSame('logical', $entry['backup_type']);
+        $this->assertFalse($entry['is_encrypted']);
+        $this->assertFalse($entry['is_orphan']);
+    }
+}


### PR DESCRIPTION
## Summary

Restore-tab Encryption + Type badges now reflect `backup_runs.encryption_mode` and `backup_type` ground truth, not filename suffix. Files listed in the destination but missing a `backup_runs` row are flagged `is_orphan=true` so the UI can label the badges as inferred-from-filename rather than confirmed.

Closes Bug B (Encryption badge mislabel) + Bug C (Type column suffix-driven) from the v3.27.8 hotfix plan.

**Stacked PR:** base is `hotfix/v3.27.8` (PR #1168, Bug A). After PR #1168 merges, GitHub will retarget this to `main`.

## Changes

- `Simple-PHP-IPAM/lib/backup_admin_restore.php` — `SELECT` now pulls `encryption_mode`; extracted pure helper `ipam_restore_browse_entry_derive()` so DB-vs-filename precedence rules are unit-testable without a `BackupClientInterface` mock.
- `Simple-PHP-IPAM/views/backup_admin_restore.php` — three-state encryption badge (stored / transitory / unencrypted) plus `inferred` variants and a `no DB record` marker beside orphan filenames.
- `tests/RestoreFilenameBadgeTest.php` — 7 cases covering the mismatch directions central to Bug B (`.enc` filename + `encryption_mode='unencrypted'`, plain filename + `encryption_mode='stored'`) and the orphan inference path.

## Local gate (per `docs/internal/test-suites.md`)

- `php -l` on changed files: clean
- `vendor/bin/phpunit`: 994 tests pass (1 pre-existing failure in `RestoreDryRunTest::testIpambkl1ArchiveDoesNotErrorThroughSqlSplitter` reproduces on pristine `hotfix/v3.27.8` HEAD — unrelated to this change)
- `vendor/bin/phpstan` per-file on changed files: clean
- `vendor/bin/phpcs`: clean
- `semgrep --config=.semgrep/rules.yml`: 0 findings on changed files
- 3-driver dockerized Playwright via `bootstrap-app.sh`:
  - SQLite: **815 passed / 42 skipped / 0 failed** (7.6m)
  - MySQL: **786 passed / 71 skipped / 0 failed** (7.3m)
  - PgSQL: **786 passed / 71 skipped / 0 failed** (7.8m)

## Test plan

- [x] PHPUnit `RestoreFilenameBadgeTest` covers DB-wins-over-filename (both mismatch directions), 3-state encryption mode, orphan inference, logical-type preservation
- [x] Local Playwright across SQLite/MySQL/PgSQL — restore-tab visuals render without errors
- [ ] Manual CDP regression sweep against deployed v3.27.8 (pre-ship): confirm a recorded encrypted backup shows `Encrypted · stored`; confirm a plaintext backup shows `plaintext`; confirm an orphan file shows the `no DB record` marker

## Notes for reviewers

- Visual-regression baselines for `backup-admin-restore` will need refreshing post-merge because the badge column markup changed (vr-375/768/1024 × light/dark).
- The helper's contract: when a `backup_runs` row exists, the DB values win unconditionally — filename suffix is ignored. This is the load-bearing rule that fixes Bug B in both mismatch directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)