### PR TITLE
feat(backup): three-state vault status helper + diagnostic banner (Bug E — v3.27.8 PR 3/5)

### DIFF
--- a/Simple-PHP-IPAM/lib/backup_admin_destinations.php
+++ b/Simple-PHP-IPAM/lib/backup_admin_destinations.php
@@ -276,10 +276,20 @@ function ipam_destinations_redirect(string $base, string $flashCode = ''): never
  *   - has_encrypted_runs: true when any backup_runs row carries
  *                  encryption_mode != 'unencrypted' (replace path is gated
  *                  on this so a key swap cannot orphan existing archives)
+ *   - state:       three-state vault report (v3.27.8 Bug E) —
+ *                  'absent' / 'present' / 'unreadable'. Mirrors the
+ *                  `present` bool for absent/present, and adds the
+ *                  unreadable signal callers need to distinguish "envelope
+ *                  exists but unwrap failed (bootstrap_key rotated)" from
+ *                  "no envelope at all". Config-source keys always read
+ *                  cleanly so they remain 'present' here.
+ *   - error_message: human-readable unwrap-failure message when
+ *                  state==='unreadable', else null.
  *
  * @return array{
  *   present:bool, source:string, fingerprint:?string,
- *   created_at:?string, has_encrypted_runs:bool
+ *   created_at:?string, has_encrypted_runs:bool,
+ *   state:'absent'|'present'|'unreadable', error_message:?string
  * }
  */
 function ipam_vault_key_status(\PDO $db): array
@@ -292,24 +302,25 @@ function ipam_vault_key_status(\PDO $db): array
     /** @var array<string,mixed> $config */
     global $config;
 
-    // DB row first.
-    $envelope = '';
-    try {
+    // v3.27.8 Bug E: single source of truth for the three-state report.
+    // The DB-envelope branch below mirrors `state`; the legacy config
+    // fallback below can flip a state='absent' result to present.
+    $vaultStatus = ipam_vault_status();
+    $state        = $vaultStatus['state'];
+    $errorMessage = $vaultStatus['error_message'];
+
+    if ($state === 'present') {
+        // Re-unwrap to read the raw bytes for the fingerprint. Cheap
+        // (libsodium secretbox) and avoids leaking the plaintext out of
+        // ipam_vault_status()'s narrow contract.
         $envRaw   = ipam_setting('backup_vault_key', '');
         $envelope = is_string($envRaw) ? $envRaw : '';
-    } catch (\Throwable) {
-        $envelope = '';
-    }
-    if ($envelope !== '') {
         try {
             $raw = ipam_vault_unwrap($envelope, ipam_bootstrap_key());
             if (strlen($raw) === BACKUP_VAULT_KEY_LEN) {
                 $present     = true;
                 $source      = 'db';
                 $fingerprint = ipam_vault_fingerprint($raw);
-                // Read updated_at via a direct query — ipam_setting() does
-                // not expose it. Tolerates the post-v3.13.0 cascade
-                // (tenant_id NULL row) and the pre-cascade legacy schema.
                 $keyCol = ipam_key_col();
                 try {
                     $st = $db->prepare(
@@ -326,7 +337,10 @@ function ipam_vault_key_status(\PDO $db): array
                 }
             }
         } catch (\Throwable) {
-            // Bad envelope or wrong bootstrap key — fall through to legacy.
+            // Race window: state==='present' said unwrap succeeded but the
+            // re-unwrap here failed. Treat as unreadable.
+            $state        = 'unreadable';
+            $errorMessage = $errorMessage ?? 'vault key unwrap failed during fingerprint read';
         }
     }
 
@@ -382,6 +396,8 @@ function ipam_vault_key_status(\PDO $db): array
         'fingerprint'        => $fingerprint,
         'created_at'         => $createdAt,
         'has_encrypted_runs' => $hasEncryptedRuns,
+        'state'              => $state,
+        'error_message'      => $errorMessage,
     ];
 }
 

--- a/Simple-PHP-IPAM/lib/vault.php
+++ b/Simple-PHP-IPAM/lib/vault.php
@@ -195,3 +195,63 @@ function ipam_vault_fingerprint(string $rawKey): string
 {
     return substr(hash('sha256', $rawKey), 0, 8);
 }
+
+/**
+ * v3.27.8 (Bug E) — three-state report on the install's vault-key envelope.
+ *
+ * Pre-fix the rest of the codebase asked a single binary question
+ * ("does ipam_setting('backup_vault_key') unwrap cleanly?") and treated
+ * any failure mode as "no envelope". That meant the "No vault key
+ * configured yet" card on the Destinations tab silently lit up whenever
+ * the bootstrap_key had drifted from the one used to write the envelope,
+ * even though the operator HAD set a key — the system just couldn't
+ * read it. The contradiction surfaced as "no key" banner above a
+ * destinations table still showing per-row 'Stored key' badges.
+ *
+ * This helper distinguishes the three real states so callers can render
+ * a diagnostic banner for `unreadable` without touching the present /
+ * absent paths.
+ *
+ *   - absent     → no envelope row in `settings`
+ *   - present    → envelope row + unwrap succeeds with current bootstrap_key
+ *   - unreadable → envelope row exists but unwrap fails. Error message is
+ *                  the unwrap exception text (already operator-safe — see
+ *                  ipam_vault_unwrap()'s contract: never echoes envelope
+ *                  bytes or partial plaintext).
+ *
+ * v3.27.8 deliberately ships no in-band "Replace vault key" affordance
+ * for the unreadable state — recovery is documented in
+ * docs/upgrading.md §vault-recovery and goes through `config.php`
+ * directly. Adding an in-app overwrite while the operator can't prove
+ * key custody is a wider design decision than this hotfix scopes.
+ *
+ * @return array{state:'absent'|'present'|'unreadable', envelope_present:bool, error_message:?string}
+ */
+function ipam_vault_status(): array
+{
+    $envelope = '';
+    try {
+        $raw = ipam_setting('backup_vault_key', '');
+        $envelope = is_string($raw) ? $raw : '';
+    } catch (\Throwable) {
+        $envelope = '';
+    }
+
+    if ($envelope === '') {
+        return ['state' => 'absent', 'envelope_present' => false, 'error_message' => null];
+    }
+
+    try {
+        ipam_vault_unwrap($envelope, ipam_bootstrap_key());
+        return ['state' => 'present', 'envelope_present' => true, 'error_message' => null];
+    } catch (\Throwable $e) {
+        // Surface the helper's own message — it's intentionally
+        // operator-facing and never echoes envelope/plaintext bytes.
+        error_log('[ipam_vault_status] unreadable envelope: ' . $e->getMessage());
+        return [
+            'state'            => 'unreadable',
+            'envelope_present' => true,
+            'error_message'    => $e->getMessage(),
+        ];
+    }
+}

--- a/Simple-PHP-IPAM/views/backup_admin_destinations.php
+++ b/Simple-PHP-IPAM/views/backup_admin_destinations.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * @var bool                              $flashTestOk
  * @var string                            $flashTestMsg
  * @var int|null                          $flashTestLatency
- * @var array{present:bool, source:string, fingerprint:?string, created_at:?string, has_encrypted_runs:bool} $vaultStatus
+ * @var array{present:bool, source:string, fingerprint:?string, created_at:?string, has_encrypted_runs:bool, state:'absent'|'present'|'unreadable', error_message:?string} $vaultStatus
  * @var string                            $revealedKey
  */
 $_currentUser = function_exists('current_user') ? current_user() : ['role' => ''];
@@ -30,6 +30,31 @@ $_isAdmin     = ($_currentUser['role'] ?? '') === 'admin';
   <!-- v3.26.0 (#1098) — Encryption key (Stored mode) admin panel -->
   <section class="card" data-test="vault-key-panel">
     <h2>Encryption key (Stored mode)</h2>
+
+    <?php if ($vaultStatus['state'] === 'unreadable'): ?>
+      <div class="card danger" data-test="vault-unreadable-banner" style="margin:.25rem 0 .75rem">
+        <strong>Vault key envelope is unreadable.</strong>
+        <p style="margin:.25rem 0 0">
+          A <code>backup_vault_key</code> envelope is recorded in the database, but it can't
+          be unwrapped with this install's current <code>bootstrap_key</code>. The most
+          common cause is a rotated <code>bootstrap_key</code> in <code>config.php</code>
+          since the envelope was written. Stored-mode encryption is non-functional until
+          this is resolved: new IPAMBKP3 runs will fail their preflight check, and existing
+          IPAMBKP3 archives encrypted under this vault key cannot be restored on this host.
+        </p>
+        <?php if ($vaultStatus['error_message'] !== null): ?>
+          <p class="muted" style="margin:.25rem 0 0;font-size:.85em">
+            Helper reported: <code><?= e($vaultStatus['error_message']) ?></code>
+          </p>
+        <?php endif; ?>
+        <p style="margin:.5rem 0 0;font-size:.9em">
+          Recovery is operator-driven and goes through <code>config.php</code> directly
+          — see <a href="docs/upgrading.md#vault-recovery"><code>docs/upgrading.md</code> §vault-recovery</a>.
+          This release deliberately does not offer an in-app "Replace vault key" action
+          while the envelope is unreadable.
+        </p>
+      </div>
+    <?php endif; ?>
 
     <?php if ($vaultStatus['present']): ?>
       <div class="vault-status" style="display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;margin:.25rem 0 .75rem">

--- a/tests/VaultStatusTest.php
+++ b/tests/VaultStatusTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib.php';
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib/vault.php';
+
+/**
+ * v3.27.8 Bug E — `ipam_vault_status()` must report a three-state result:
+ *
+ *   - absent     → no envelope row in `settings`
+ *   - present    → envelope row + unwrap succeeds with current bootstrap_key
+ *   - unreadable → envelope row exists but unwrap fails (e.g. bootstrap_key
+ *                  rotated since the envelope was written)
+ *
+ * Pre-fix the helper signal was binary (present / not-present) and the
+ * unreadable branch was indistinguishable from absent — the Destinations
+ * tab silently said "No vault key configured yet" while the operator had
+ * in fact set one, contradicting the per-destination "Stored key" badge.
+ */
+final class VaultStatusTest extends TestCase
+{
+    private \PDO $db;
+
+    /** @var mixed */
+    private $previousGlobalDb = null;
+    private bool $hadGlobalDb = false;
+
+    /** @var mixed */
+    private $previousGlobalConfig = null;
+    private bool $hadGlobalConfig = false;
+
+    protected function setUp(): void
+    {
+        $this->hadGlobalDb      = array_key_exists('db', $GLOBALS);
+        $this->previousGlobalDb = $this->hadGlobalDb ? $GLOBALS['db'] : null;
+        $this->hadGlobalConfig      = array_key_exists('config', $GLOBALS);
+        $this->previousGlobalConfig = $this->hadGlobalConfig ? $GLOBALS['config'] : null;
+
+        $this->db = new \PDO('sqlite::memory:');
+        $this->db->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $schemaSql = (string) file_get_contents(__DIR__ . '/../Simple-PHP-IPAM/schema.sql');
+        $this->db->exec($schemaSql);
+        $GLOBALS['db'] = $this->db;
+
+        // Bootstrap_key in $GLOBALS['config'] so ipam_bootstrap_key() resolves
+        // without writing config.php from the test runner.
+        $GLOBALS['config'] = ['bootstrap_key' => base64_encode(random_bytes(IPAM_BOOTSTRAP_KEY_LEN))];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->hadGlobalDb) {
+            $GLOBALS['db'] = $this->previousGlobalDb;
+        } else {
+            unset($GLOBALS['db']);
+        }
+        if ($this->hadGlobalConfig) {
+            $GLOBALS['config'] = $this->previousGlobalConfig;
+        } else {
+            unset($GLOBALS['config']);
+        }
+    }
+
+    public function testAbsentWhenNoEnvelopeRow(): void
+    {
+        $status = ipam_vault_status();
+        $this->assertSame('absent', $status['state']);
+        $this->assertFalse($status['envelope_present']);
+        $this->assertNull($status['error_message']);
+    }
+
+    public function testPresentWhenEnvelopeWrappedWithCurrentBootstrap(): void
+    {
+        $rawVaultKey = random_bytes(BACKUP_VAULT_KEY_LEN);
+        $envelope    = ipam_vault_wrap($rawVaultKey, ipam_bootstrap_key());
+        ipam_setting_set($this->db, 'backup_vault_key', $envelope);
+
+        $status = ipam_vault_status();
+        $this->assertSame('present', $status['state']);
+        $this->assertTrue($status['envelope_present']);
+        $this->assertNull($status['error_message']);
+    }
+
+    public function testUnreadableWhenEnvelopeWrappedWithDifferentBootstrap(): void
+    {
+        $rawVaultKey = random_bytes(BACKUP_VAULT_KEY_LEN);
+        // Wrap under a DIFFERENT bootstrap key than the one currently in
+        // $config — simulates the rotated-bootstrap-key recovery scenario.
+        $strandedBootstrap = random_bytes(IPAM_BOOTSTRAP_KEY_LEN);
+        $envelope          = ipam_vault_wrap($rawVaultKey, $strandedBootstrap);
+        ipam_setting_set($this->db, 'backup_vault_key', $envelope);
+
+        $status = ipam_vault_status();
+        $this->assertSame('unreadable', $status['state']);
+        $this->assertTrue($status['envelope_present']);
+        $this->assertIsString($status['error_message']);
+        $this->assertNotSame('', $status['error_message']);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces \`ipam_vault_status()\` in \`lib/vault.php\` returning a three-state report — \`absent\` / \`present\` / \`unreadable\` — so callers can distinguish *no envelope* from *envelope exists but unwrap failed (bootstrap_key rotated)*. Surfaces an admin-facing diagnostic banner on the Destinations tab when the envelope is \`unreadable\`.

Closes Bug E (Stored-key badge contradicts \"No vault key\" card) from the v3.27.8 hotfix plan.

**Stacked PR:** base is \`hotfix/v3.27.8-pr2-badges\` (PR #1169, Bug B+C). The chain auto-rebases as upstream PRs merge.

## Why

Pre-fix the rest of the codebase asked a single binary question of \`ipam_setting('backup_vault_key')\` + \`ipam_vault_unwrap()\` and treated every failure mode as \"no envelope\". On rotated-bootstrap-key installs that silently lit the \"No vault key configured yet\" card on the Destinations tab while per-destination \"Stored key\" badges still rendered — a direct UX contradiction that left operators unsure whether the install actually had a configured key.

## Changes

- \`Simple-PHP-IPAM/lib/vault.php\` — new \`ipam_vault_status()\` helper. Pure status read; never hands back unwrapped plaintext.
- \`Simple-PHP-IPAM/lib/backup_admin_destinations.php\` — \`ipam_vault_key_status()\` now folds in \`state\` + \`error_message\` (additive — existing \`present\`/\`source\`/\`fingerprint\`/\`created_at\`/\`has_encrypted_runs\` keys preserved). Race window where a re-unwrap fails between the two status calls degrades to \`unreadable\`.
- \`Simple-PHP-IPAM/views/backup_admin_destinations.php\` — red danger banner on Destinations tab when \`state === 'unreadable'\`, with the helper's error message and a pointer to \`docs/upgrading.md\` §vault-recovery.
- \`tests/VaultStatusTest.php\` — 3 cases: absent envelope, envelope wrapped under current bootstrap_key (present), envelope wrapped under a different bootstrap_key (unreadable).

## Locked decisions in scope

- **No in-app \"Replace vault key\" affordance** while envelope is unreadable. Recovery in v3.27.8 is operator-driven via \`config.php\` directly — keeps the hotfix blast radius minimal. A managed in-app recovery is a wider design decision deferred to v3.28+.

## Local gate (per \`docs/internal/test-suites.md\`)

- \`php -l\` on changed files: clean
- \`vendor/bin/phpunit\`: 997 tests pass (1 pre-existing \`RestoreDryRunTest\` failure reproduces on pristine branch HEAD, unrelated)
- \`vendor/bin/phpstan --memory-limit=512M\` on changed files: clean
- \`vendor/bin/phpcs\`: clean
- \`semgrep --config=.semgrep/rules.yml\`: 0 findings on changed files
- 3-driver dockerized Playwright via \`bootstrap-app.sh\`:
  - SQLite: **815 passed / 42 skipped / 0 failed** (7.5m)
  - MySQL: **786 passed / 71 skipped / 0 failed** (7.2m)
  - PgSQL: **786 passed / 71 skipped / 0 failed** (7.6m)

## Test plan

- [x] PHPUnit \`VaultStatusTest\` covers all three states with real wrap/unwrap round-trips
- [x] Local Playwright across SQLite/MySQL/PgSQL — destinations-tab visuals render without errors
- [ ] Manual CDP verification (pre-ship): rotate \`bootstrap_key\` on a dev install, reload Destinations tab, confirm danger banner appears with error message + recovery pointer

## Notes for reviewers

- The helper deliberately does not return the unwrapped plaintext — only the *state*. Existing code that needs the raw key (e.g. \`ipam_vault_key_status()\` for the fingerprint, \`ipam_backup_vault_key_get_raw()\` for crypto operations) keeps calling \`ipam_vault_unwrap()\` directly.
- The danger banner is admin-only (renders inside \`<?php if (\$_isAdmin): ?>\`).
- The error message comes straight from \`ipam_vault_unwrap()\`, whose contract is already operator-safe (no envelope bytes / partial plaintext in error text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)