### PR TITLE
feat(backup): surface most recent failure on destination card

### DIFF
--- a/Simple-PHP-IPAM/lib/backup_admin_destinations.php
+++ b/Simple-PHP-IPAM/lib/backup_admin_destinations.php
@@ -1079,6 +1079,47 @@ function ipam_destinations_load_state(\PDO $db): array
     /** @var list<array<string, mixed>> $destinations */
     $destinations = $destStmt !== false ? $destStmt->fetchAll(PDO::FETCH_ASSOC) : [];
 
+    // v3.27.8 (#1172, PR 5/5): annotate each destination with its most
+    // recent backup_run if that run was 'failed', so the view can render
+    // a danger badge with the truncated error_message on the destination
+    // card. Operators get an at-a-glance signal on the Destinations admin
+    // page instead of having to switch to the History tab to discover a
+    // destination has been failing. The subquery picks the highest-id
+    // (newest) row per destination_id, which matches AUTOINCREMENT order
+    // and is portable across SQLite / MySQL / Postgres without window
+    // functions or driver-specific syntax.
+    $latestStmt = $db->query(
+        "SELECT br.destination_id, br.status, br.error_message, "
+        . "br.filename, br.started_at "
+        . "FROM backup_runs br "
+        . "WHERE br.destination_id IS NOT NULL "
+        . "AND br.id IN ("
+        . "  SELECT MAX(id) FROM backup_runs "
+        . "  WHERE destination_id IS NOT NULL GROUP BY destination_id"
+        . ")"
+    );
+    /** @var list<array<string,mixed>> $latestRuns */
+    $latestRuns = $latestStmt !== false ? $latestStmt->fetchAll(PDO::FETCH_ASSOC) : [];
+    /** @var array<int,array{error_message:string,filename:string,started_at:string}> $failedByDestId */
+    $failedByDestId = [];
+    foreach ($latestRuns as $row) {
+        if (($row['status'] ?? '') !== 'failed') continue;
+        $did = to_int($row['destination_id'] ?? 0);
+        if ($did <= 0) continue;
+        $failedByDestId[$did] = [
+            'error_message' => to_str($row['error_message'] ?? ''),
+            'filename'      => to_str($row['filename'] ?? ''),
+            'started_at'    => to_str($row['started_at'] ?? ''),
+        ];
+    }
+    foreach ($destinations as &$d) {
+        $did = to_int($d['id'] ?? 0);
+        if ($did > 0 && isset($failedByDestId[$did])) {
+            $d['last_failure'] = $failedByDestId[$did];
+        }
+    }
+    unset($d);
+
     $schedStmt = $db->query("SELECT * FROM backup_schedules ORDER BY destination_id, id");
     /** @var list<array<string, mixed>> $schedules */
     $schedules = $schedStmt !== false ? $schedStmt->fetchAll(PDO::FETCH_ASSOC) : [];

--- a/Simple-PHP-IPAM/views/backup_admin_destinations.php
+++ b/Simple-PHP-IPAM/views/backup_admin_destinations.php
@@ -194,6 +194,23 @@ $_isAdmin     = ($_currentUser['role'] ?? '') === 'admin';
                 <?php if ($destIsDefault): ?>
                   <span class="badge badge-default" title="Default destination">★ default</span>
                 <?php endif; ?>
+                <?php
+                // v3.27.8 (#1172, PR 5/5): surface the most-recent failed
+                // run's reason on the destination card so operators see
+                // ongoing failures without leaving the Destinations tab.
+                // Controller sets $d['last_failure'] only when the newest
+                // backup_runs row for this destination has status='failed'.
+                $lastFailure = is_array($d['last_failure'] ?? null) ? $d['last_failure'] : null;
+                if ($lastFailure !== null):
+                    $errMsg   = to_str($lastFailure['error_message'] ?? '');
+                    $started  = to_str($lastFailure['started_at'] ?? '');
+                    $hover    = $errMsg !== ''
+                        ? $errMsg . ($started !== '' ? "\n(started " . $started . ')' : '')
+                        : ($started !== '' ? 'Failed run started ' . $started : 'Most recent run failed');
+                ?>
+                  <br>
+                  <span class="badge badge-failed" title="<?= e($hover) ?>">⚠ last run failed</span>
+                <?php endif; ?>
               </td>
               <td><span class="badge badge-type-<?= e($destType) ?>"><?= e(strtoupper($destType)) ?></span></td>
               <td><span class="badge badge-format-<?= e($destBType) ?>"><?= $destBType === 'logical' ? 'Logical' : 'Database' ?></span></td>

--- a/tests/DestinationFailureBadgeTest.php
+++ b/tests/DestinationFailureBadgeTest.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib/backup_admin_destinations.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * v3.27.8 PR 5 of 5 (#1172) — destination-card failure-reason badge.
+ *
+ * The Destinations admin tab previously only surfaced ad-hoc test
+ * results in the Actions column; an operator could not tell from this
+ * page that a destination's scheduled backups were failing on every
+ * run. They had to switch to the History tab and scroll to find the
+ * pattern.
+ *
+ * Fix: `ipam_destinations_load_state` annotates each destination row
+ * with a `last_failure` shape when the newest `backup_runs` row for
+ * that destination has `status='failed'`. The view renders a
+ * `badge-failed` chip with the truncated error_message in the title
+ * attribute, right next to the destination name.
+ *
+ * These tests assert the controller-side annotation only — the view
+ * rendering itself is covered by Playwright visual-regression on the
+ * backup-admin-destinations page.
+ */
+final class DestinationFailureBadgeTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        $this->db = new PDO('sqlite::memory:');
+        $this->db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $schema = (string) file_get_contents(__DIR__ . '/../Simple-PHP-IPAM/schema.sql');
+        $this->db->exec($schema);
+        $this->db->exec('PRAGMA foreign_keys = ON');
+        ensure_migrations_table($this->db);
+        apply_migrations($this->db);
+
+        // $config global is read by ipam_vault_key_status() which the
+        // loader calls. Minimal shape — empty key means 'absent' state,
+        // which the loader handles cleanly.
+        $GLOBALS['config'] = ['app_secret' => ''];
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_GET = [];
+        $_SESSION = [];
+    }
+
+    private function seedDestination(string $name = 'wasabi'): int
+    {
+        $stmt = $this->db->prepare(
+            "INSERT INTO backup_destinations (name, type, config, encrypt, is_active) "
+            . "VALUES (:n, 's3', '{}', 1, 1)"
+        );
+        $stmt->execute([':n' => $name]);
+        return (int) $this->db->lastInsertId();
+    }
+
+    /** Insert a backup_runs row and return its id. */
+    private function seedRun(int $destId, string $status, string $errorMessage = '', string $filename = 'ipam-backup-test.enc'): int
+    {
+        $stmt = $this->db->prepare(
+            "INSERT INTO backup_runs "
+            . "(destination_id, backup_type, encryption_mode, triggered_by, status, filename, source_version, error_message, started_at) "
+            . "VALUES (:d, 'database', 'stored', 'manual', :s, :f, '3.27.8', :em, datetime('now'))"
+        );
+        $stmt->execute([
+            ':d'  => $destId,
+            ':s'  => $status,
+            ':f'  => $filename,
+            ':em' => $errorMessage === '' ? null : $errorMessage,
+        ]);
+        return (int) $this->db->lastInsertId();
+    }
+
+    public function testLastFailureAnnotatedWhenNewestRunFailed(): void
+    {
+        $destId = $this->seedDestination();
+        $this->seedRun($destId, 'success', '', 'old-success.enc');
+        $this->seedRun($destId, 'failed', 'vault envelope unreadable', '(preflight-failed-abcd1234)');
+
+        $state = ipam_destinations_load_state($this->db);
+        $this->assertCount(1, $state['destinations']);
+        $d = $state['destinations'][0];
+
+        $this->assertArrayHasKey('last_failure', $d, 'newest run was failed; controller must attach last_failure');
+        $this->assertSame('vault envelope unreadable', $d['last_failure']['error_message']);
+        $this->assertSame('(preflight-failed-abcd1234)', $d['last_failure']['filename']);
+        $this->assertNotSame('', $d['last_failure']['started_at']);
+    }
+
+    public function testNoLastFailureWhenNewestRunSucceeded(): void
+    {
+        $destId = $this->seedDestination();
+        $this->seedRun($destId, 'failed', 'transient s3 error');
+        $this->seedRun($destId, 'success', '', 'recovered.enc');
+
+        $state = ipam_destinations_load_state($this->db);
+        $d = $state['destinations'][0];
+
+        $this->assertArrayNotHasKey(
+            'last_failure',
+            $d,
+            'newest run was success; older failures must not bubble up to the card'
+        );
+    }
+
+    public function testNoLastFailureWhenDestinationHasNoRuns(): void
+    {
+        $this->seedDestination();
+
+        $state = ipam_destinations_load_state($this->db);
+        $d = $state['destinations'][0];
+
+        $this->assertArrayNotHasKey('last_failure', $d);
+    }
+
+    public function testPerDestinationIsolation(): void
+    {
+        $a = $this->seedDestination('alpha');
+        $b = $this->seedDestination('bravo');
+        $this->seedRun($a, 'failed', 'alpha failure', '(preflight-failed-aaaa)');
+        $this->seedRun($b, 'success', '', 'bravo-ok.enc');
+
+        $state = ipam_destinations_load_state($this->db);
+        $byName = [];
+        foreach ($state['destinations'] as $row) {
+            $byName[$row['name']] = $row;
+        }
+
+        $this->assertArrayHasKey('last_failure', $byName['alpha']);
+        $this->assertSame('alpha failure', $byName['alpha']['last_failure']['error_message']);
+        $this->assertArrayNotHasKey('last_failure', $byName['bravo']);
+    }
+}


### PR DESCRIPTION
## Summary
- **PR 5 of 5 (final) for v3.27.8.** Closes the Destinations-admin UX gap surfaced during the Bug D investigation.
- \`ipam_destinations_load_state()\` joins each destination with its newest \`backup_runs\` row (highest id per destination_id — portable across SQLite/MySQL/Postgres without window functions). When that row has \`status='failed'\`, the destination is annotated with a \`last_failure\` shape carrying the truncated \`error_message\`, the filename, and the started_at timestamp.
- The Destinations admin view renders a \`badge-failed\` chip beside the destination name, with the truncated error message in the \`title\` attribute on hover. Operators see failing destinations at a glance without leaving the page.

## Plan-doc reframe
The plan's PR 5 originally said "drop silent plaintext fallback (Security category) + new \`backup.preflight_failed\` audit verb." That goal is **already shipped**:
- \`backup.preflight_failed\` audit verb landed in v3.27.1 (Pass A observability) at \`lib/backup.php:442\`.
- \`ipam_backup_resolve_encrypt_to_tmp()\` has **no plaintext fallback** — its four-branch resolver hard-throws when encryption is requested but neither vault key nor app_secret is configured (\`lib/backup.php:1078-1083\`), and the orchestrator catches that throw as \`backup.preflight_failed\`.
- \`tests/BackupPreflightFailureTest.php\` already covers the matrix.

There is nothing security-substantive left to "drop." What did remain was the UX gap of operators needing to leave the Destinations tab to discover ongoing failures. This PR closes that gap with a tight UX-only change. **CHANGELOG bucket reframed from Security → Fixed.**

## Test plan
- [x] \`php -l\` on all 3 changed files
- [x] \`vendor/bin/phpstan analyse --memory-limit=512M\` — no errors
- [x] \`vendor/bin/phpcs\` — clean
- [x] \`vendor/bin/phpunit\` — 1000/1001 + 4 new (same documented \`RestoreDryRunTest\` pre-existing flake)
- [x] \`tests/DestinationFailureBadgeTest.php\` — 4/4 passing (newest-failed annotation, newest-success-after-failure no-annotation, no-runs no-annotation, per-destination isolation)
- [x] \`semgrep --config=.semgrep/rules.yml\` — 0 findings
- [x] Sqlite Playwright (full suite, all viewports) — 821 passed / 42 skipped / 0 failed
- [ ] CI 3-driver matrix green (this PR)

## Related
- Operational plan: \`docs/superpowers/plans/2026-05-11_v3.27.8.md\` → "Cross-cutting — Drop silent plaintext fallback" section
- Predecessor in v3.27.8 series: #1171 (Bug D diagnostics, merged \`0aae312\`)
- Closes the v3.27.8 hotfix series. Release ceremony follows once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Backup destinations now display a failure badge in the Destinations table when their most recent backup run failed, with error message and timestamp details visible on hover.

* **Tests**
  * Added test coverage validating accurate failure state tracking, per-destination isolation, and correct handling of successful or missing backup runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1172)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->