### PR TITLE
fix(webhooks): record host only in test-fire audit details (#1152)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -9025,6 +9025,25 @@ function ipam_validate_webhook_url(string $url, array $config = []): bool
     return true;
 }
 
+/**
+ * Build the audit_log.details string for a webhook test-fire row.
+ *
+ * Records the webhook id and host only — never the full URL — so query
+ * strings carrying tokens/secrets and any XSS-shaped path or fragment
+ * never land in the audit details column. (#1152, S-001)
+ */
+function ipam_webhook_test_fire_audit_detail(int $id, string $url): string
+{
+    $host = parse_url($url, PHP_URL_HOST);
+    if (!is_string($host) || $host === '') {
+        $host = '(invalid)';
+    }
+    if (strlen($host) > 100) {
+        $host = substr($host, 0, 100);
+    }
+    return "id={$id} host={$host}";
+}
+
 /** Sign a webhook payload with HMAC-SHA256. */
 function ipam_webhook_sign(string $payload, string $secret): string
 {

--- a/Simple-PHP-IPAM/webhooks.php
+++ b/Simple-PHP-IPAM/webhooks.php
@@ -121,7 +121,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
         $sig    = ipam_webhook_sign($payload, $secretPlain);
         $result = ipam_webhook_deliver($row, 'test.ping', $payload, $sig);
-        audit($db, 'webhook.test_fire', 'webhook', $id, "url=" . to_str($row['url']));
+        audit($db, 'webhook.test_fire', 'webhook', $id, ipam_webhook_test_fire_audit_detail($id, to_str($row['url'])));
         echo json_encode([
             'ok'        => $result['status'] !== null && $result['status'] >= 200 && $result['status'] < 300,
             'status'    => $result['status'],

--- a/tests/WebhookTestFireAuditTest.php
+++ b/tests/WebhookTestFireAuditTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+final class WebhookTestFireAuditTest extends TestCase
+{
+    public function testAuditDetailsContainsHostOnly(): void
+    {
+        $detail = ipam_webhook_test_fire_audit_detail(42, 'https://hooks.example.com/path?token=secret&xss=<script>');
+        $this->assertSame('id=42 host=hooks.example.com', $detail);
+    }
+
+    public function testInvalidUrlFallback(): void
+    {
+        $this->assertSame('id=7 host=(invalid)', ipam_webhook_test_fire_audit_detail(7, 'not a url'));
+    }
+
+    public function testHostLengthCapped(): void
+    {
+        $longHost = str_repeat('a', 200) . '.example.com';
+        $detail = ipam_webhook_test_fire_audit_detail(1, "https://{$longHost}/path");
+        $this->assertLessThanOrEqual(120, strlen($detail));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1152 (S-001).

- New helper `ipam_webhook_test_fire_audit_detail(int \$id, string \$url): string` in `lib.php`. Returns `id=N host=H`. Host extracted via `parse_url(\$url, PHP_URL_HOST)`, falls back to `(invalid)` on malformed input, truncated at 100 chars.
- Wired into `webhooks.php:124`. Admin-supplied test URL (with query string / fragment / XSS-shaped content) no longer flows into `audit_log.details`.
- Three test cases in `tests/WebhookTestFireAuditTest.php`: host-only extraction, invalid-URL fallback, length cap.

## Test plan

- [x] `vendor/bin/phpunit --filter WebhookTestFireAudit` (3 new tests pass)
- [x] Full `vendor/bin/phpunit` suite green (1063 total)
- [x] `vendor/bin/phpstan analyse` (L9) clean
- [x] `vendor/bin/phpcs` clean
- [ ] CR review

First of nine sequential PRs into \`dev\` for the v3.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced webhook test audit logging to prevent sensitive information (such as tokens) from appearing in audit records; only essential details are now captured.

* **Tests**
  * Added test coverage for webhook audit logging validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->