### PR TITLE
fix(backup): chmod 0640 staged restore upload (#1154)

### DIFF
--- a/Simple-PHP-IPAM/lib/backup.php
+++ b/Simple-PHP-IPAM/lib/backup.php
@@ -1434,6 +1434,29 @@ function ipam_restore_prepare_for_restore(PDO $db, array $config, int $destinati
 }
 
 /**
+ * Stage an uploaded backup file at the given path with 0640 mode.
+ *
+ * Used by ipam_restore_upload(); extracted so the post-move chmod can
+ * be exercised by unit tests without a full SAPI upload (#1154, S-004).
+ *
+ * @internal
+ */
+function ipam_restore_stage_uploaded_file(string $src, string $dst): bool
+{
+    $moved = is_uploaded_file($src)
+        ? @move_uploaded_file($src, $dst)
+        : @rename($src, $dst);
+    if (!$moved) {
+        return false;
+    }
+    if (!@chmod($dst, 0640)) {
+        @unlink($dst); // nosemgrep: php.lang.security.unlink-use.unlink-use -- $dst is caller-computed staging path; cleanup on chmod failure
+        return false;
+    }
+    return true;
+}
+
+/**
  * Stage an operator-uploaded backup file (#837, v3.24.0).
  *
  * Mirrors ipam_restore_prepare_for_restore()'s output contract so the
@@ -1527,8 +1550,8 @@ function ipam_restore_prepare_for_upload(array $config, ?string $passphrase = nu
     $rand         = bin2hex(random_bytes(8));
     $downloadPath = $tmpDir . '/restore_dl_' . $rand;
 
-    if (!@move_uploaded_file($tmp, $downloadPath)) {
-        throw new RuntimeException('ipam_restore_upload: cannot move uploaded file into tmp');
+    if (!ipam_restore_stage_uploaded_file($tmp, $downloadPath)) {
+        throw new RuntimeException('ipam_restore_upload: cannot stage uploaded file into tmp (move or chmod failed)');
     }
 
     try {

--- a/tests/BackupUploadFileModeTest.php
+++ b/tests/BackupUploadFileModeTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+final class BackupUploadFileModeTest extends TestCase
+{
+    public function testStagedUploadModeIs0640(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/ipam-bkup-' . bin2hex(random_bytes(4));
+        mkdir($tmpDir, 0700, true);
+        try {
+            $src = $tmpDir . '/src.bin';
+            file_put_contents($src, "IPAMBKP3");
+            chmod($src, 0666);
+            $dst = $tmpDir . '/restore_dl_test';
+            $this->assertTrue(ipam_restore_stage_uploaded_file($src, $dst));
+            clearstatcache(true, $dst);
+            $mode = fileperms($dst) & 0777;
+            $this->assertSame(0640, $mode, sprintf('expected 0640, got 0%o', $mode));
+        } finally {
+            @unlink($tmpDir . '/restore_dl_test');
+            @unlink($tmpDir . '/src.bin');
+            @rmdir($tmpDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1154 (S-004).

- Extract helper `ipam_restore_stage_uploaded_file(string $src, string $dst): bool` in `Simple-PHP-IPAM/lib/backup.php`. Performs move-then-chmod 0640; unlinks on chmod failure.
- Wired into `ipam_restore_prepare_for_upload()` replacing the bare `move_uploaded_file()` call. Other webserver users can no longer read staged backup payloads while they sit in tmp.
- Helper falls back to `rename()` when `is_uploaded_file()` is false so the post-move chmod is unit-testable without a SAPI upload.
- Annotated nosemgrep on the failure-path `@unlink($dst)` (caller-computed staging path, not user input) — matches the established convention in restore.php and lib/backup.php.
- New `tests/BackupUploadFileModeTest.php` asserts 0640 on the staged file.

## Test plan

- [x] `vendor/bin/phpunit --filter BackupUploadFileMode` (1 new test passes)
- [x] Full `vendor/bin/phpunit` suite green (1061 total)
- [x] `vendor/bin/phpstan analyse` (L9) clean
- [x] `vendor/bin/phpcs` clean

Second of nine sequential PRs into \`dev\` for the v3.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backup restore operations to properly manage file permissions when processing uploaded files, improving security during the restore process.

* **Tests**
  * Added test coverage to validate correct file permission handling when staging uploaded backup files during restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->