### PR TITLE
fix(api): reject IPv6 sync-scan with HTTP 400 (#1160, F-S2-01)

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -2566,11 +2566,17 @@ function api_scan_run(PDO $db, array $apiKey): never
     if ($subnetId <= 0) api_error(400, 'subnet_id is required.');
 
     // Load subnet and enforce /28 (16 addresses) cap
-    $st = $db->prepare("SELECT id, cidr, prefix FROM subnets WHERE id = :id");
+    $st = $db->prepare("SELECT id, cidr, prefix, ip_version FROM subnets WHERE id = :id");
     $st->execute([':id' => $subnetId]);
     /** @var array<string, mixed>|false $subnet */
     $subnet = $st->fetch();
     if (!$subnet) api_error(404, 'Subnet not found.');
+
+    // #1160 (PASS-C F-S2-01): ipam_scan_subnet() is IPv4-only. An IPv6 /64 has
+    // prefix=64 which would pass the /28 cap below, so guard ip_version first.
+    if (to_int($subnet['ip_version']) !== 4) {
+        api_error(400, 'Synchronous scan is IPv4-only. Use the CLI scanner for IPv6 subnets: php scan_run.php --subnet-id=' . $subnetId);
+    }
 
     if (to_int($subnet['prefix']) < 28) {
         api_error(400, 'Synchronous scan is limited to /28 or smaller (16 IPs). Use the CLI scanner for larger subnets: php scan_run.php --subnet-id=' . $subnetId);

--- a/tests/ApiScanRunIPv6Test.php
+++ b/tests/ApiScanRunIPv6Test.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source-level regression test pinning that api_scan_run rejects IPv6
+ * subnets with HTTP 400 BEFORE the /28 prefix check.
+ *
+ * ipam_scan_subnet() is IPv4-only; without this guard an IPv6 /64
+ * (prefix=64 >= 28) would pass the cap check and fall into the IPv4-only
+ * scanner. (#1160, PASS-C F-S2-01)
+ *
+ * A direct functional test is impractical because api_scan_run is
+ * declared `: never` and api_error()/api_json() call exit(). This test
+ * pins the guard at the source level: the function body must SELECT
+ * ip_version, and reject ip_version != 4 before checking prefix < 28.
+ */
+final class ApiScanRunIPv6Test extends TestCase
+{
+    private string $body = '';
+
+    protected function setUp(): void
+    {
+        $apiPath = __DIR__ . '/../Simple-PHP-IPAM/api.php';
+        $src = file_get_contents($apiPath);
+        $this->assertNotFalse($src, 'api.php must be readable');
+
+        $start = strpos($src, 'function api_scan_run');
+        $this->assertNotFalse($start, 'api_scan_run not found');
+        $bodyStart = strpos($src, '{', $start);
+        $this->assertNotFalse($bodyStart);
+        $depth = 0;
+        $i = $bodyStart;
+        $len = strlen($src);
+        for (; $i < $len; $i++) {
+            $ch = $src[$i];
+            if ($ch === '{') {
+                $depth++;
+            } elseif ($ch === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    break;
+                }
+            }
+        }
+        $this->body = substr($src, $bodyStart, $i - $bodyStart + 1);
+    }
+
+    public function testSelectsIpVersionColumn(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/SELECT[^"]*\bip_version\b[^"]*FROM\s+subnets/i',
+            $this->body,
+            'api_scan_run must SELECT ip_version so the IPv6 guard can read it'
+        );
+    }
+
+    public function testRejectsNonIPv4(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/to_int\(\s*\$subnet\[\s*[\'"]ip_version[\'"]\s*\]\s*\)\s*!==\s*4/',
+            $this->body,
+            'api_scan_run must compare ip_version !== 4 before the prefix check'
+        );
+        $this->assertStringContainsString(
+            'IPv4-only',
+            $this->body,
+            'rejection message must mention "IPv4-only"'
+        );
+    }
+
+    public function testIPv6GuardPrecedesPrefixCheck(): void
+    {
+        $ipv6Pos  = strpos($this->body, 'ip_version');
+        $prefixPos = strpos($this->body, "to_int(\$subnet['prefix']) < 28");
+        $this->assertNotFalse($ipv6Pos);
+        $this->assertNotFalse($prefixPos);
+        $this->assertLessThan(
+            $prefixPos,
+            $ipv6Pos,
+            'IPv6 reject must come before the /28 prefix check so IPv6 /64 does not pass'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1160 (PASS-C F-S2-01).

`api_scan_run` (api.php:2560) is IPv4-only — `ipam_scan_subnet()` does not handle IPv6 — but the existing `/28 prefix < 28` guard didn't catch IPv6 because an IPv6 /64 has `prefix=64 >= 28`.

- Add `ip_version` to the SELECT and reject `ip_version != 4` with HTTP 400 before the prefix check.
- Source-level regression test pins the SELECT column, the guard expression, and ordering relative to the prefix check.

`api_scan_run` is declared `: never` and `api_error()` calls `exit`, so a functional test is impractical. The source-level test is sufficient for a single-statement guard.

## Test plan

- [x] `vendor/bin/phpunit --filter ApiScanRunIPv6` (3 new tests pass)
- [x] Full `vendor/bin/phpunit` suite green (1063 total)
- [x] `vendor/bin/phpstan analyse Simple-PHP-IPAM/api.php` (L9) clean
- [x] `vendor/bin/phpcs Simple-PHP-IPAM/api.php` clean

Fourth of nine sequential PRs into \`dev\` for the v3.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)