### PR TITLE
fix(dhcp): canonical hostname normalisation for Kea + dhcpd (#1163, F-S6-01)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -10811,9 +10811,10 @@ function ipam_render_dhcpd_conf(PDO $db, array $subnetIds): string
         foreach (ipam_dhcp_load_reservations($db, to_int($s['id'])) as $r) {
             $mac  = ipam_normalize_mac_for_dhcp(to_str($r['mac']));
             if ($mac === null) continue;
-            $raw    = $r['hostname'] !== '' ? to_str($r['hostname']) : 'host';
-            $suffix = str_replace('.', '-', to_str($r['ip']));
-            $name   = (preg_replace('/[^a-zA-Z0-9\-]/', '-', $raw) ?? 'host') . '-' . $suffix;
+            $rawHost = to_str($r['hostname']);
+            $label   = ipam_dhcp_normalize_hostname($rawHost) ?? 'host';
+            $suffix  = str_replace('.', '-', to_str($r['ip']));
+            $name    = $label . '-' . $suffix;
             $lines[] = '  host ' . $name . ' {';
             $lines[] = '    hardware ethernet ' . $mac . ';';
             $lines[] = '    fixed-address ' . to_str($r['ip']) . ';';
@@ -10887,8 +10888,9 @@ function ipam_render_kea_json(PDO $db, array $subnetIds): string
                     'hw-address' => $mac,
                     'ip-address' => to_str($r['ip']),
                 ];
-                if (to_str($r['hostname']) !== '') {
-                    $resEntry['hostname'] = to_str($r['hostname']);
+                $label = ipam_dhcp_normalize_hostname(to_str($r['hostname']));
+                if ($label !== null) {
+                    $resEntry['hostname'] = $label;
                 }
                 $resArr[] = $resEntry;
             }
@@ -10964,6 +10966,31 @@ function ipam_normalize_mac_for_dhcp(string $mac): ?string
     $hex = preg_replace('/[^0-9a-fA-F]/', '', $mac);
     if (!is_string($hex) || strlen($hex) !== 12) return null;
     return implode(':', str_split(strtolower($hex), 2));
+}
+
+/**
+ * Normalise a DHCP reservation hostname for both Kea and ISC dhcpd output.
+ * Returns null if no usable label can be derived; caller falls back to
+ * 'host' synthesis.
+ *
+ * Single-label, RFC 1123 letter-digit-hyphen, leading alpha (after trimming
+ * leading digits/hyphens), max 63 chars per label. Dotted inputs take the
+ * leftmost label — multi-label FQDNs are out of scope; neither current
+ * renderer supports them well.
+ *
+ * (#1163, PASS-C F-S6-01) — both renderers must agree on what's emitted.
+ */
+function ipam_dhcp_normalize_hostname(string $raw): ?string
+{
+    $raw = trim($raw);
+    if ($raw === '') return null;
+    $label = explode('.', $raw, 2)[0];
+    $label = preg_replace('/[^a-zA-Z0-9-]/', '-', $label) ?? '';
+    $label = ltrim($label, '0123456789-');
+    $label = rtrim($label, '-');
+    if ($label === '') return null;
+    if (strlen($label) > 63) $label = substr($label, 0, 63);
+    return $label;
 }
 
 // ── Custom field definitions (v3.5.0, #313/#596) ──────────────────────────

--- a/tests/DhcpFqdnParityTest.php
+++ b/tests/DhcpFqdnParityTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ipam_dhcp_normalize_hostname() — the canonical hostname
+ * normaliser shared by the ISC dhcpd and Kea JSON DHCP generators so
+ * the two configs agree on what's emitted for any given raw input.
+ *
+ * (#1163, PASS-C F-S6-01)
+ */
+final class DhcpFqdnParityTest extends TestCase
+{
+    /** @return array<string, array{0:string,1:?string}> */
+    public static function hostnames(): array
+    {
+        return [
+            'simple'                  => ['printer1', 'printer1'],
+            'dotted_takes_left_label' => ['printer1.lan.example', 'printer1'],
+            'underscores'             => ['my_printer', 'my-printer'],
+            'spaces'                  => ['my printer', 'my-printer'],
+            'leading_digit'           => ['1printer', 'printer'],
+            'empty'                   => ['', null],
+            'whitespace_only'         => ['   ', null],
+            'punctuation_only'        => ['!!!', null],
+            'too_long'                => [str_repeat('a', 80), str_repeat('a', 63)],
+            'xss_shape'               => ['<script>', 'script'],
+            'trailing_hyphens'        => ['name---', 'name'],
+            'leading_hyphens'         => ['---name', 'name'],
+            'unicode_alpha_collapses' => ['αβγ', null],   // all non-ASCII → all '-' → trimmed to ''
+        ];
+    }
+
+    /** @dataProvider hostnames */
+    public function testNormalize(string $in, ?string $expected): void
+    {
+        $this->assertSame($expected, ipam_dhcp_normalize_hostname($in));
+    }
+
+    public function testNormalizedLabelIsAlwaysSingleLabel(): void
+    {
+        // No matter the input, the result must never contain a dot.
+        foreach (['a.b.c', 'name.example.com', 'sub.domain'] as $raw) {
+            $out = ipam_dhcp_normalize_hostname($raw);
+            $this->assertNotNull($out, "expected non-null result for {$raw}");
+            $this->assertStringNotContainsString('.', $out);
+        }
+    }
+
+    public function testNormalizedLabelMatchesRfc1123Shape(): void
+    {
+        // Letter-digit-hyphen, leading alpha, max 63 chars.
+        foreach (['printer1', 'my-printer', str_repeat('a', 63), 'a1b2c3'] as $in) {
+            $out = ipam_dhcp_normalize_hostname($in);
+            $this->assertNotNull($out);
+            $this->assertMatchesRegularExpression(
+                '/^[a-zA-Z][a-zA-Z0-9-]{0,62}$/',
+                $out,
+                "expected {$out} to match single-label RFC 1123 shape"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1163 (PASS-C F-S6-01).

The two DHCP config generators disagreed on what's a valid reservation hostname for any given DB row:
- dhcpd path sanitised via `preg_replace('/[^a-zA-Z0-9-]/','-',\$raw)` and synthesized `host '<slug>-<ip>'`
- Kea path passed `to_str(\$r['hostname'])` straight through with no sanitisation

Route both through new `ipam_dhcp_normalize_hostname(string \$raw): ?string`: single-label, RFC 1123 letter-digit-hyphen, leading alpha (after trimming leading digits/hyphens), max 63 chars per label. Dotted inputs take the leftmost label — multi-label FQDNs are out of scope; neither current renderer supports them well.

13 dataProvider cases pin the normaliser (simple, dotted, underscore, space, leading digit, empty, whitespace, punctuation, too-long, XSS-shape, trailing/leading hyphens, unicode) plus 2 invariants (never contains a dot, always matches RFC 1123 shape).

## Test plan

- [x] `vendor/bin/phpunit --filter DhcpFqdnParity` (15 new tests pass)
- [x] Full `vendor/bin/phpunit` suite green (1075 total)
- [x] `vendor/bin/phpstan analyse Simple-PHP-IPAM/lib.php` (L9) clean
- [x] `vendor/bin/phpcs` clean

Seventh of nine sequential PRs into \`dev\` for the v3.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)