### PR TITLE
refactor(backup): remove dead ipam_backup_vault_key_or_init() (#1176)

### DIFF
--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -4600,152 +4600,13 @@ function ipam_argon2id_derive(
     return $hash;
 }
 
-/**
- * Resolve the IPAMBKP3 stored-mode vault key, lazily generating and
- * persisting it on first use.
- *
- * Returns the raw 32-byte key (NOT base64). Idempotent within a request via
- * static cache; idempotent across requests via the config.php round-trip.
- *
- * Resolution order:
- *   1. Already in $config and well-formed → decode + return.
- *   2. Already in $config but malformed → throw (refuse to silently replace
- *      an operator-supplied value, even if broken).
- *   3. Empty / absent → generate 32 random bytes, write to config.php in
- *      place (replace empty slot OR inject before the trailing "];"), and
- *      return. On write failure, throw with an actionable message that
- *      includes the generated value as a copy-pasteable line so the
- *      operator can finish the install manually.
- *
- * @param string|null $configPathOverride  Internal hook for tests so they
- *        can exercise the autogen path against a tempfile rather than the
- *        production config.php. Production callers MUST pass null.
- * @throws RuntimeException if the existing value is malformed or the
- *         file rewrite fails.
- */
-function ipam_backup_vault_key_or_init(?string $configPathOverride = null): string
-{
-    // Defence-in-depth: the override is a test-only hook. Reject it
-    // outside CLI / PHPUnit context so a future caller that accidentally
-    // routes user input here cannot turn an `include` of an attacker-
-    // controlled path into LFI/RCE. Web-SAPI callers always operate on
-    // the production config.php only.
-    if ($configPathOverride !== null && PHP_SAPI !== 'cli') {
-        throw new RuntimeException(
-            'ipam_backup_vault_key_or_init: configPathOverride is test-only and not allowed in web SAPI'
-        );
-    }
-
-    // Static cache is keyed on the resolved config path so a test that
-    // overrides the path does not pin the production cache, and vice
-    // versa. Without keying, a single test run could leak a tempfile-
-    // generated key to a subsequent production-path call (or vice versa)
-    // and cause spurious assertion failures.
-    static $cachedRaw = [];
-    $rawPath = $configPathOverride ?? __DIR__ . '/config.php';
-    // Canonicalise so the include target is a resolved real path on
-    // disk, not a string with `..` segments or a non-existent file. The
-    // override path MUST exist when supplied; the production path always
-    // exists (init.php loaded it earlier this request).
-    $resolved = realpath($rawPath);
-    if ($resolved === false) {
-        throw new RuntimeException('ipam_backup_vault_key_or_init: config path does not resolve: ' . $rawPath);
-    }
-    $configPath = $resolved;
-    if (isset($cachedRaw[$configPath])) {
-        return $cachedRaw[$configPath];
-    }
-
-    // Source the existing-value check from $config (production path) or
-    // by re-including the override file (test / override path). Both
-    // paths apply the same well-formed/malformed validation so the
-    // semantics are identical for callers, regardless of where the key
-    // lives.
-    if ($configPathOverride === null) {
-        /** @var array<string,mixed> $config */
-        global $config;
-        $existingB64 = (isset($config['backup_vault_key']) && is_string($config['backup_vault_key']))
-            ? $config['backup_vault_key']
-            : '';
-    } else {
-        $overrideCfg = include $configPath;
-        $existingB64 = '';
-        if (is_array($overrideCfg)
-            && isset($overrideCfg['backup_vault_key'])
-            && is_string($overrideCfg['backup_vault_key'])) {
-            $existingB64 = $overrideCfg['backup_vault_key'];
-        }
-    }
-    if ($existingB64 !== '') {
-        $decoded = base64_decode($existingB64, true);
-        if (is_string($decoded) && strlen($decoded) === BACKUP_VAULT_KEY_LEN) {
-            $cachedRaw[$configPath] = $decoded;
-            return $decoded;
-        }
-        throw new RuntimeException(
-            'backup_vault_key in config.php is malformed (expected ' .
-            BACKUP_VAULT_KEY_LEN . ' bytes base64). Clear the value to allow ' .
-            'auto-generation, or replace it with: ' .
-            'php -r "echo base64_encode(random_bytes(32));"'
-        );
-    }
-
-    ipam_assert_random_bytes_available();
-    $newRaw = random_bytes(BACKUP_VAULT_KEY_LEN);
-    $newB64 = base64_encode($newRaw);
-
-    try {
-        ipam_config_inject_or_replace_key($configPath, 'backup_vault_key', $newB64);
-    } catch (Throwable $e) {
-        // Generic remediation message — never embed the raw key in the
-        // exception text, since it would land in error_log / UI and leak
-        // the secret protecting every stored-mode backup. Operator can
-        // generate one manually with the documented one-liner.
-        throw new RuntimeException(
-            'backup_vault_key auto-generation could not update config.php: ' .
-            $e->getMessage() . '. ' .
-            'Generate a key manually with `php -r "echo base64_encode(random_bytes(32));"` ' .
-            "and add `'backup_vault_key' => '<value>',` to config.php, then retry.",
-            0,
-            $e
-        );
-    }
-
-    // Concurrency guard: if two requests both reach the generate-and-
-    // write path simultaneously, only one rename wins persistence. The
-    // loser's in-memory $newRaw would still be used to encrypt the
-    // backup it's currently producing — and that backup would then be
-    // unreadable once the winner's key is the one persisted.
-    //
-    // Re-read the file post-rename to learn which key actually won,
-    // and adopt that as the canonical key for the rest of this request.
-    // Both racers end up using the same key — the one in config.php —
-    // so every produced backup is decryptable on restore.
-    /** @var array<string,mixed>|false $persistedCfg */
-    $persistedCfg = @include $configPath;
-    if (is_array($persistedCfg) && isset($persistedCfg['backup_vault_key'])
-        && is_string($persistedCfg['backup_vault_key'])) {
-        $persistedDecoded = base64_decode($persistedCfg['backup_vault_key'], true);
-        if (is_string($persistedDecoded) && strlen($persistedDecoded) === BACKUP_VAULT_KEY_LEN) {
-            $newRaw = $persistedDecoded;
-            $newB64 = $persistedCfg['backup_vault_key'];
-        }
-    }
-
-    if ($configPathOverride === null) {
-        global $config;
-        $config['backup_vault_key'] = $newB64;
-    }
-    $cachedRaw[$configPath] = $newRaw;
-    return $newRaw;
-}
 
 /**
  * Read-only accessor for the IPAMBKP3 vault key. Returns the 32 raw
  * bytes if config.php holds a well-formed value, NULL otherwise.
  *
- * Distinct from ipam_backup_vault_key_or_init(): this never generates,
- * never writes config.php, never throws on absent / malformed values.
+ * Read-only accessor: never generates, never writes config.php, never
+ * throws on absent / malformed values.
  * Intended for the decrypt path — autogen during a restore would mask
  * the real failure (the key that ENCRYPTED the backup is gone), and we
  * want to surface that as a clear error rather than silently produce a
@@ -4824,8 +4685,9 @@ function ipam_backup_vault_key_get_raw(): ?string
 
 /**
  * Atomic in-place rewrite of a config.php-style PHP file to set
- * `'$key' => '$valueB64'`. Used by ipam_backup_vault_key_or_init() and
- * available for any future autogen scenarios.
+ * `'$key' => '$valueB64'`. Used by ipam_bootstrap_key() (lib/vault.php)
+ * to seed the bootstrap key on first use, and available for any future
+ * autogen scenarios.
  *
  * Behaviour:
  *   - Existing single-quoted/double-quoted line for $key → replaced.

--- a/Simple-PHP-IPAM/lib/vault.php
+++ b/Simple-PHP-IPAM/lib/vault.php
@@ -42,9 +42,10 @@ const IPAM_BOOTSTRAP_KEY_LEN     = 32; // SODIUM_CRYPTO_SECRETBOX_KEYBYTES
  * deterministically read the same value (mirrors backup_vault_key v3.7+
  * lifecycle).
  *
- * Behaviour matches ipam_backup_vault_key_or_init() so a hardened install
- * with a non-writable config.php surfaces an actionable error rather than
- * silently regenerating the key on every request.
+ * Mirrors the historical auto-gen lifecycle (the deleted-in-v3.28.1
+ * ipam_backup_vault_key_or_init helper, #1176): on a hardened install
+ * with a non-writable config.php this surfaces an actionable error
+ * rather than silently regenerating the key on every request.
  */
 function ipam_bootstrap_key(): string
 {

--- a/Simple-PHP-IPAM/migrations.php
+++ b/Simple-PHP-IPAM/migrations.php
@@ -3612,8 +3612,8 @@ function ipam_migrations(): array
             // generate-and-write config.php on its first call; that is
             // intentional and matches the app_secret pattern. If the
             // config file is not writable we surface the error so the
-            // operator sees the same actionable remediation as
-            // ipam_backup_vault_key_or_init() produces.
+            // operator sees an actionable "config.php not writable"
+            // error rather than a silent regenerate-on-every-request loop.
             if (!function_exists('ipam_bootstrap_key') || !function_exists('ipam_vault_wrap')) {
                 // lib/vault.php not loaded yet — skip the migration step
                 // and let it run on a subsequent boot. This branch is

--- a/tests/BackupCryptoIpambkp3Test.php
+++ b/tests/BackupCryptoIpambkp3Test.php
@@ -158,7 +158,7 @@ class BackupCryptoIpambkp3Test extends TestCase
     private function cleanupConfigDir(string $dir): void
     {
         foreach (glob($dir . '/*') ?: [] as $f) {
-            @unlink($f);
+            @unlink($f); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test-owned tempdir
         }
         @rmdir($dir);
     }
@@ -272,108 +272,6 @@ class BackupCryptoIpambkp3Test extends TestCase
     }
 
     // -----------------------------------------------------------------------
-    // ipam_backup_vault_key_or_init — uses an isolated tempfile config so
-    // production Simple-PHP-IPAM/config.php stays untouched (the helper
-    // would otherwise REWRITE it on first call, polluting the working tree
-    // and breaking subsequent Playwright runs that depend on the
-    // bootstrap-installed test fixture).
-    // -----------------------------------------------------------------------
-
-    public function testVaultKeyHelperGeneratesAndPersistsToTempConfig(): void
-    {
-        [$dir, $path] = $this->makeConfigFile("<?php\nreturn [\n    'foo' => 'bar',\n];\n");
-        try {
-            $key = ipam_backup_vault_key_or_init($path);
-            $this->assertSame(BACKUP_VAULT_KEY_LEN, strlen($key));
-
-            // The file should now contain a backup_vault_key entry.
-            $contents = (string) file_get_contents($path);
-            $this->assertStringContainsString("'backup_vault_key'", $contents);
-
-            // Parsing back should give the same raw key.
-            /** @var array<string,mixed> $parsed */
-            $parsed = include $path;
-            $this->assertIsString($parsed['backup_vault_key']);
-            $decoded = base64_decode((string) $parsed['backup_vault_key'], true);
-            $this->assertSame($key, $decoded);
-        } finally {
-            $this->cleanupConfigDir($dir);
-        }
-    }
-
-    public function testVaultKeyHelperIdempotentWithinRequestPerPath(): void
-    {
-        [$dir, $path] = $this->makeConfigFile("<?php\nreturn [\n    'foo' => 'bar',\n];\n");
-        try {
-            $a = ipam_backup_vault_key_or_init($path);
-            $b = ipam_backup_vault_key_or_init($path);
-            $this->assertSame($a, $b);
-        } finally {
-            $this->cleanupConfigDir($dir);
-        }
-    }
-
-    public function testVaultKeyHelperReadsExistingValueFromConfigFile(): void
-    {
-        $existingRaw = random_bytes(BACKUP_VAULT_KEY_LEN);
-        $existingB64 = base64_encode($existingRaw);
-        [$dir, $path] = $this->makeConfigFile(
-            "<?php\nreturn [\n    'backup_vault_key' => '" . $existingB64 . "',\n];\n"
-        );
-        try {
-            // Override path tells the helper to ignore the $config global
-            // and read directly from the file. ipam_config_inject_or_replace_key
-            // will detect the populated key and replace it (with the same
-            // bytes if it matched). We assert the FIRST call returns the
-            // pre-existing key — meaning the regen path didn't fire because
-            // the value was already well-formed.
-            //
-            // For override-path callers this is a soft assertion: the
-            // helper does NOT re-parse the file before generating, so it
-            // generates a fresh key, writes it (replacing the existing
-            // line), and returns the new one. That's correct behaviour
-            // for a tempfile test — the production path uses $config to
-            // short-circuit before generation.
-            $key = ipam_backup_vault_key_or_init($path);
-            $this->assertSame(BACKUP_VAULT_KEY_LEN, strlen($key));
-            // Re-include and assert the file holds whatever the helper returned.
-            /** @var array<string,mixed> $parsed */
-            $parsed = include $path;
-            $decoded = base64_decode((string) $parsed['backup_vault_key'], true);
-            $this->assertSame($key, $decoded);
-        } finally {
-            $this->cleanupConfigDir($dir);
-        }
-    }
-
-    public function testVaultKeyHelperRejectsMalformedConfigValue(): void
-    {
-        global $config;
-        $original = $config['backup_vault_key'] ?? null;
-        $config['backup_vault_key'] = 'not-32-bytes-of-base64';
-        try {
-            // Static cache guards against re-entry — we can't directly trigger
-            // the malformed branch on a process where the helper has already
-            // succeeded above. Instead exercise the validation logic by
-            // directly base64_decoding in the assertion: the helper would
-            // throw if its cache were empty. This is a limitation of static
-            // caching that we accept (the production path runs once per
-            // request from a fresh process).
-            $decoded = base64_decode($config['backup_vault_key'], true);
-            $this->assertTrue(
-                $decoded === false || strlen($decoded) !== BACKUP_VAULT_KEY_LEN,
-                'sanity: malformed value would fail the helper validation'
-            );
-        } finally {
-            if ($original === null) {
-                unset($config['backup_vault_key']);
-            } else {
-                $config['backup_vault_key'] = $original;
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
     // ipam_backup_v3_pack_header / unpack — round-trip
     // -----------------------------------------------------------------------
 
@@ -428,7 +326,7 @@ class BackupCryptoIpambkp3Test extends TestCase
     {
         foreach ($paths as $p) {
             if (is_file($p)) {
-                @unlink($p);
+                @unlink($p); // nosemgrep: php.lang.security.unlink-use.unlink-use -- test-owned paths
             }
         }
     }
@@ -896,7 +794,7 @@ class BackupCryptoIpambkp3Test extends TestCase
         $enc = $src . '.enc';
         file_put_contents($src, $payload);
         backup_encrypt_stream_v3($src, $enc, BACKUP_V3_MODE_STORED, null, $vault);
-        @unlink($src);
+        @unlink($src); // nosemgrep: php.lang.security.unlink-use.unlink-use -- bin2hex(random_bytes) path
         return $enc;
     }
 

--- a/tests/VaultTest.php
+++ b/tests/VaultTest.php
@@ -6,10 +6,10 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Round-trip + tamper-detection coverage for the v3.26.0 (#1098) vault
- * helpers. The bootstrap_key auto-generation path is exercised indirectly
- * by ipam_backup_vault_key_or_init's existing tests; here we focus on the
- * new wrap/unwrap layer with an injected key so the test suite does not
- * need a writable config.php.
+ * helpers. The wrap/unwrap layer is exercised here with an injected
+ * bootstrap key so the test suite does not need a writable config.php.
+ * Auto-generation behaviour for bootstrap_key itself is covered indirectly
+ * by the integration suite during bootstrap.
  */
 final class VaultTest extends TestCase
 {


### PR DESCRIPTION
## Summary

Closes #1176.

No production caller since v3.28.0/#1164 routed encrypted-backup preflight through the read-only `ipam_backup_vault_key_get_raw()`. Delete the auto-gen-into-config.php helper (139 lines) plus its four unit tests and dangling comment refs across `lib.php`, `lib/vault.php`, and `migrations.php`.

**Kept:** `ipam_config_inject_or_replace_key()` — still used by `ipam_bootstrap_key()` in `lib/vault.php` to seed the bootstrap key on first use.

**Also annotated** three pre-existing `@unlink()` calls in `BackupCryptoIpambkp3Test.php` with `// nosemgrep` comments — semgrep started flagging them on every edit; they operate on test-owned tempfiles with paths generated via `bin2hex(random_bytes())` / `tempnam()`, not user input.

## Test plan

- [x] Full `vendor/bin/phpunit` suite green (1056 tests — baseline 1060 minus 4 deleted helper tests)
- [x] `vendor/bin/phpstan analyse` (L9) clean
- [x] `vendor/bin/phpcs` clean
- [x] `grep -rn ipam_backup_vault_key_or_init` confirms only the deliberate historical-breadcrumb docstring reference remains in `lib/vault.php`

Eighth of nine sequential PRs into \`dev\` for the v3.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)