### PR TITLE
fix(restore): parse db_dsn + drop-and-recreate + fail-fast psql (#1177)

### DIFF
--- a/Simple-PHP-IPAM/lib/restore_dsn.php
+++ b/Simple-PHP-IPAM/lib/restore_dsn.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+/**
+ * restore_dsn.php — DSN parsing helper for restore.php.
+ *
+ * Extracted from restore.php so the parser is unit-testable without tripping
+ * the CLI-only guard at the top of restore.php. (#1177)
+ */
+
+if (!function_exists('ipam_restore_resolve_db_conn')) {
+    /**
+     * Resolve mysql/pgsql connection parameters for the CLI restore script.
+     * Parses $gConf['db_dsn'] (PDO-style: 'mysql:host=...;port=...;dbname=...'
+     * or 'pgsql:host=...;port=...;dbname=...') when present; falls back to the
+     * discrete db_host/db_port/db_name keys. (#1177)
+     *
+     * PDO DSN format is unquoted; ';' is a hard delimiter. The password is
+     * NOT read from the DSN; it always comes from $gConf['db_pass']. Returns
+     * an empty `driver` field when no DSN is set — informational only; both
+     * callers select the mysql/pgsql client by $driver (the SQL-engine arg
+     * to restore.php), not by this field.
+     *
+     * Unsupported DSN forms (caller signals via empty/wrong host): the
+     * `unix_socket=` key — restore.php cannot pipe `mysql -h <socket>`. The
+     * restore.php caller detects this and surfaces a clear error before
+     * proc_open.
+     *
+     * @param array<string,mixed> $gConf
+     * @return array{driver:string,host:string,port:string,dbname:string,user:string,pass:string,unix_socket:string}
+     */
+    function ipam_restore_resolve_db_conn(array $gConf): array
+    {
+        $dsn         = to_str($gConf['db_dsn'] ?? '');
+        $driver      = '';
+        $host        = '';
+        $port        = '';
+        $dbname      = '';
+        $unixSocket  = '';
+
+        if ($dsn !== '') {
+            [$driver, $rest] = array_pad(explode(':', $dsn, 2), 2, '');
+            foreach (explode(';', $rest) as $kv) {
+                [$k, $v] = array_pad(explode('=', $kv, 2), 2, '');
+                $k = trim($k);
+                $v = trim($v);
+                if ($k === 'host') {
+                    $host = $v;
+                } elseif ($k === 'port') {
+                    $port = $v;
+                } elseif ($k === 'dbname') {
+                    $dbname = $v;
+                } elseif ($k === 'unix_socket') {
+                    $unixSocket = $v;
+                }
+            }
+        }
+
+        if ($host === '') {
+            $host = to_str($gConf['db_host'] ?? '127.0.0.1');
+        }
+        if ($port === '') {
+            $port = to_str($gConf['db_port'] ?? ($driver === 'pgsql' ? '5432' : '3306'));
+        }
+        if ($dbname === '') {
+            $dbname = to_str($gConf['db_name'] ?? 'ipam');
+        }
+
+        return [
+            'driver'      => $driver,
+            'host'        => $host,
+            'port'        => $port,
+            'dbname'      => $dbname,
+            'user'        => to_str($gConf['db_user'] ?? ($driver === 'pgsql' ? 'postgres' : 'root')),
+            'pass'        => to_str($gConf['db_pass'] ?? ''),
+            'unix_socket' => $unixSocket,
+        ];
+    }
+}

--- a/Simple-PHP-IPAM/restore.php
+++ b/Simple-PHP-IPAM/restore.php
@@ -21,6 +21,7 @@ if (PHP_SAPI !== 'cli') {
 }
 
 require __DIR__ . '/init.php';
+require_once __DIR__ . '/lib/restore_dsn.php';
 /** @var \PDO $db */
 /** @var IpamConfig $config */
 
@@ -161,11 +162,20 @@ if ($driver === 'sqlite') {
         "SQLite restore from: " . basename($fromAbs) . " sha256={$sha256}");
 
 } elseif ($driver === 'mysql') {
-    $host   = to_str($gConf['db_host'] ?? '127.0.0.1');
-    $port   = to_str($gConf['db_port'] ?? '3306');
-    $dbName = to_str($gConf['db_name'] ?? 'ipam');
-    $user   = to_str($gConf['db_user'] ?? 'root');
-    $pass   = to_str($gConf['db_pass'] ?? '');
+    // #1177: honour db_dsn (PDO-style host/port/dbname) with fallback to
+    // discrete db_host/db_port/db_name keys for legacy installs.
+    $conn   = ipam_restore_resolve_db_conn($gConf);
+    if ($conn['unix_socket'] !== '') {
+        restore_die(
+            'restore.php does not support a unix_socket DSN for mysql restore. ' .
+            'Set db_host/db_port to a TCP endpoint, or run restore.php from a host with TCP access to the DB.'
+        );
+    }
+    $host   = $conn['host'];
+    $port   = $conn['port'];
+    $dbName = $conn['dbname'];
+    $user   = $conn['user'];
+    $pass   = $conn['pass'];
 
     restore_info("Target      : {$user}@{$host}:{$port}/{$dbName}");
 
@@ -175,6 +185,58 @@ if ($driver === 'sqlite') {
         exit(0);
     }
 
+    // Wipe target schema before piping the dump in. Engine-native restore
+    // onto a populated install otherwise duplicates rows for tables present
+    // in both the dump and the live DB. Runs BEFORE the cred tempfile is
+    // written so a wipe failure can't leak a 0600 password file. (#1177)
+    //
+    // Filter to BASE TABLE so views (and MariaDB sequences) are not fed to
+    // DROP TABLE — that would throw and abort the loop with FK checks
+    // disabled. Views in the IPAM DB are uncommon but legal.
+    //
+    // FK checks restoration goes through a finally so a mid-loop drop
+    // failure does not leave the session FK-disabled for the subsequent
+    // apply_migrations($db) call.
+    $droppedCount = 0;
+    $dropErr = null;
+    try {
+        $db->exec('SET FOREIGN_KEY_CHECKS = 0');
+        try {
+            $tblStmt = $db->query(
+                "SELECT TABLE_NAME FROM information_schema.TABLES " .
+                "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE = 'BASE TABLE'"
+            );
+            if ($tblStmt !== false) {
+                /** @var list<array<string,mixed>> $rows */
+                $rows = $tblStmt->fetchAll();
+                foreach ($rows as $row) {
+                    $rawTbl = $row['TABLE_NAME'] ?? $row['table_name'] ?? '';
+                    $tbl    = is_string($rawTbl) ? $rawTbl : '';
+                    if ($tbl !== '') {
+                        // MySQL identifier quoting uses backticks; double internal backticks.
+                        $db->exec('DROP TABLE IF EXISTS `' . str_replace('`', '``', $tbl) . '`');
+                        $droppedCount++;
+                    }
+                }
+            }
+        } finally {
+            try {
+                $db->exec('SET FOREIGN_KEY_CHECKS = 1');
+            } catch (Throwable) {
+                // Best-effort restoration. If we can't re-enable, the session
+                // is broken anyway and the subsequent restore/migration step
+                // will surface its own actionable error.
+            }
+        }
+        restore_info("Dropped {$droppedCount} existing tables before restore.");
+    } catch (Throwable $e) {
+        $dropErr = $e;
+    }
+    if ($dropErr !== null) {
+        restore_die('Failed to drop existing tables before restore: ' . $dropErr->getMessage());
+    }
+
+    // mysql client aborts on error by default (no -f/--force passed) — fail-fast is already in effect.
     // Resolve setting before tempnam so an ipam_setting() throw doesn't
     // leak a 0600 password file (PR #1080 CR round 2).
     $verifySsl = (bool) ipam_setting('backup.dump_ssl_verify');
@@ -275,18 +337,39 @@ if ($driver === 'sqlite') {
         "MySQL restore from: " . basename($fromAbs) . " sha256={$sha256} ({$check['verdict']})");
 
 } elseif ($driver === 'pgsql') {
-    $host   = to_str($gConf['db_host'] ?? '127.0.0.1');
-    $port   = to_str($gConf['db_port'] ?? '5432');
-    $dbName = to_str($gConf['db_name'] ?? 'ipam');
-    $user   = to_str($gConf['db_user'] ?? 'postgres');
-    $pass   = to_str($gConf['db_pass'] ?? '');
+    // #1177: honour db_dsn (PDO-style host/port/dbname) with fallback to
+    // discrete db_host/db_port/db_name keys for legacy installs.
+    $conn   = ipam_restore_resolve_db_conn($gConf);
+    if ($conn['unix_socket'] !== '') {
+        restore_die(
+            'restore.php does not support a unix_socket DSN for pgsql restore. ' .
+            'Set db_host/db_port to a TCP endpoint, or run restore.php from a host with TCP access to the DB.'
+        );
+    }
+    $host   = $conn['host'];
+    $port   = $conn['port'];
+    $dbName = $conn['dbname'];
+    $user   = $conn['user'];
+    $pass   = $conn['pass'];
 
     restore_info("Target      : {$user}@{$host}:{$port}/{$dbName}");
 
     if ($dryRun) {
-        restore_info("[DRY-RUN] Would run: psql -h {$host} -p {$port} -U {$user} {$dbName} < {$fromAbs}");
+        restore_info("[DRY-RUN] Would run: psql -v ON_ERROR_STOP=1 -h {$host} -p {$port} -U {$user} {$dbName} < {$fromAbs}");
         restore_info("Dry-run complete. No changes written.");
         exit(0);
+    }
+
+    // Wipe the public schema before piping the dump in. Engine-native restore
+    // onto a populated install otherwise duplicates rows for tables present
+    // in both the dump and the live DB. Runs BEFORE the cred tempfile is
+    // written so a wipe failure can't leak a 0600 password file. (#1177)
+    try {
+        $db->exec('DROP SCHEMA public CASCADE');
+        $db->exec('CREATE SCHEMA public');
+        restore_info('Dropped public schema before restore.');
+    } catch (Throwable $dropErr) {
+        restore_die('Failed to wipe public schema before restore: ' . $dropErr->getMessage());
     }
 
     // Route the password through a 0600 PGPASSFILE so it never appears in
@@ -294,7 +377,9 @@ if ($driver === 'sqlite') {
     // carrying a *path*, not the secret — libpq's documented pattern for
     // non-interactive scripts. The file is unlinked in the finally block below.
     $credFile = ipam_backup_write_pgpass_file($pass);
-    $cmd = ['psql', '-h', $host, '-p', $port, '-U', $user, $dbName];
+    // -v ON_ERROR_STOP=1: abort psql on first SQL error rather than ploughing
+    // through subsequent statements onto a partially-populated DB. (#1177)
+    $cmd = ['psql', '-v', 'ON_ERROR_STOP=1', '-h', $host, '-p', $port, '-U', $user, $dbName];
     $env = getenv() ?: [];
     // Strip any inherited DB password env vars before merging in PGPASSFILE
     // so the parent shell can't leak a secret into the child even though

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -116,6 +116,18 @@ The backup is left in place after a successful upgrade. You can remove it manual
 
 ## Version-specific upgrade notes
 
+### v3.28.1
+
+**Engine-native restore now wipes target schema before replay.** `restore.php`'s mysql and pgsql branches drop all user tables (mysql, BASE TABLE filtered) / drop the `public` schema (pgsql) before piping the dump in. This fixes a long-standing bug where restoring a `database`-type dump onto a populated install duplicated rows. Run as `--yes` confirmation as before — no new flag.
+
+> **Postgres extension caveat.** `DROP SCHEMA public CASCADE` removes any extensions installed into the `public` schema (e.g. `pgcrypto`, `pg_trgm`, `citext`, `uuid-ossp`). A `pg_dump` taken with defaults re-emits the `CREATE EXTENSION` statements and the restore puts them back. A `--data-only` dump (or any dump that omits extensions) will leave the restored DB without them. If you use Postgres extensions outside what the IPAM schema migrations create, dump with extensions included.
+>
+> **Mid-restore failure semantics.** A failed pipe between wipe and replay leaves the target DB empty. Recovery path is "re-run with a known-good dump" — restore.php does not snapshot the pre-wipe state on the mysql/pgsql paths (only the SQLite path makes a safety copy).
+
+**`restore.php` now honours `db_dsn`.** mysql/pgsql restores parse the PDO-style `db_dsn` connection string (host/port/dbname) the rest of the app already uses. Legacy installs that set discrete `db_host`/`db_port`/`db_name` keys continue to work. **Limitation:** restore.php cannot pipe `mysql`/`psql` through a Unix-domain socket; a `db_dsn` containing `unix_socket=...` aborts with a clear error pointing the operator at the discrete TCP keys. (#1177)
+
+**psql fail-fast.** `restore.php` invokes psql with `-v ON_ERROR_STOP=1` so a mid-restore error aborts cleanly instead of ploughing through subsequent statements onto a partially-populated DB. (#1177)
+
 ### v3.28.0
 
 DR + security stabilization release. One schema migration (`3.28.0-state-tables`, runs automatically — adds two small internal tables, no operator action) and one **behavior change** worth knowing about: the legacy `app_secret`-based backup-encryption *write* path was removed.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,36 +301,6 @@ parameters:
 			path: Simple-PHP-IPAM/restore.php
 
 		-
-			message: '#^Offset ''db_host'' on array\{db_path\: string, session_name\: string, proxy_trust\: bool, app_name\: string, timezone\?\: string, base_url\?\: string\|null, bootstrap_admin\: array\{username\: string, password\: string\}, session_idle_seconds\: int, \.\.\.\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
-			path: Simple-PHP-IPAM/restore.php
-
-		-
-			message: '#^Offset ''db_name'' on array\{db_path\: string, session_name\: string, proxy_trust\: bool, app_name\: string, timezone\?\: string, base_url\?\: string\|null, bootstrap_admin\: array\{username\: string, password\: string\}, session_idle_seconds\: int, \.\.\.\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
-			path: Simple-PHP-IPAM/restore.php
-
-		-
-			message: '#^Offset ''db_pass'' on array\{db_path\: string, session_name\: string, proxy_trust\: bool, app_name\: string, timezone\?\: string, base_url\?\: string\|null, bootstrap_admin\: array\{username\: string, password\: string\}, session_idle_seconds\: int, \.\.\.\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
-			path: Simple-PHP-IPAM/restore.php
-
-		-
-			message: '#^Offset ''db_port'' on array\{db_path\: string, session_name\: string, proxy_trust\: bool, app_name\: string, timezone\?\: string, base_url\?\: string\|null, bootstrap_admin\: array\{username\: string, password\: string\}, session_idle_seconds\: int, \.\.\.\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
-			path: Simple-PHP-IPAM/restore.php
-
-		-
-			message: '#^Offset ''db_user'' on array\{db_path\: string, session_name\: string, proxy_trust\: bool, app_name\: string, timezone\?\: string, base_url\?\: string\|null, bootstrap_admin\: array\{username\: string, password\: string\}, session_idle_seconds\: int, \.\.\.\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 2
-			path: Simple-PHP-IPAM/restore.php
-
-		-
 			message: '#^Parameter \#1 \$from of function copy expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/RestoreDsnTest.php
+++ b/tests/RestoreDsnTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib.php'; // for to_str()
+require_once __DIR__ . '/../Simple-PHP-IPAM/lib/restore_dsn.php';
+
+final class RestoreDsnTest extends TestCase
+{
+    public function testParsesMysqlDsn(): void
+    {
+        $conn = ipam_restore_resolve_db_conn([
+            'db_dsn'  => 'mysql:host=db.internal;port=3307;dbname=ipam_prod',
+            'db_user' => 'ipam',
+            'db_pass' => 'p',
+        ]);
+        $this->assertSame('mysql', $conn['driver']);
+        $this->assertSame('db.internal', $conn['host']);
+        $this->assertSame('3307', $conn['port']);
+        $this->assertSame('ipam_prod', $conn['dbname']);
+        $this->assertSame('ipam', $conn['user']);
+        $this->assertSame('p', $conn['pass']);
+    }
+
+    public function testParsesPgsqlDsn(): void
+    {
+        $conn = ipam_restore_resolve_db_conn([
+            'db_dsn'  => 'pgsql:host=pg.internal;port=5433;dbname=ipam',
+            'db_user' => 'ipam',
+            'db_pass' => 'p',
+        ]);
+        $this->assertSame('pgsql', $conn['driver']);
+        $this->assertSame('pg.internal', $conn['host']);
+        $this->assertSame('5433', $conn['port']);
+        $this->assertSame('ipam', $conn['dbname']);
+    }
+
+    public function testFallsBackToDiscreteKeysWhenNoDsn(): void
+    {
+        $conn = ipam_restore_resolve_db_conn([
+            'db_host' => '10.0.0.5',
+            'db_port' => '3306',
+            'db_name' => 'ipam',
+            'db_user' => 'root',
+            'db_pass' => '',
+        ]);
+        $this->assertSame('10.0.0.5', $conn['host']);
+        $this->assertSame('3306', $conn['port']);
+        $this->assertSame('ipam', $conn['dbname']);
+        $this->assertSame('root', $conn['user']);
+    }
+
+    public function testDefaultsWhenEverythingMissing(): void
+    {
+        $conn = ipam_restore_resolve_db_conn([]);
+        $this->assertSame('127.0.0.1', $conn['host']);
+        $this->assertSame('3306', $conn['port']); // mysql default since no driver hint
+        $this->assertSame('ipam', $conn['dbname']);
+        $this->assertSame('', $conn['unix_socket']);
+    }
+
+    public function testExtractsUnixSocketDsn(): void
+    {
+        // restore.php cannot pipe mysql/psql through a unix socket; the
+        // parser must surface the value so the caller can detect and abort
+        // with a clear error rather than silently fall back to TCP.
+        $conn = ipam_restore_resolve_db_conn([
+            'db_dsn' => 'mysql:unix_socket=/var/run/mysqld/mysqld.sock;dbname=ipam',
+        ]);
+        $this->assertSame('/var/run/mysqld/mysqld.sock', $conn['unix_socket']);
+        $this->assertSame('ipam', $conn['dbname']);
+    }
+
+    public function testExtraDsnKeysAreIgnored(): void
+    {
+        // Forward-compat: unknown keys (charset, sslmode, ...) must not break
+        // host/port/dbname extraction.
+        $conn = ipam_restore_resolve_db_conn([
+            'db_dsn' => 'mysql:host=db;port=3306;dbname=ipam;charset=utf8mb4;sslmode=require',
+        ]);
+        $this->assertSame('db', $conn['host']);
+        $this->assertSame('3306', $conn['port']);
+        $this->assertSame('ipam', $conn['dbname']);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1177.

Three connected fixes to `restore.php`'s engine-native restore branches (mysql + pgsql), gated together since they share the resolver helper:

### 1. Honour `db_dsn`

mysql/pgsql restores now parse the PDO-style `db_dsn` connection string the rest of the app already uses (`mysql:host=...;port=...;dbname=...` / `pgsql:...`). Legacy installs that set discrete `db_host`/`db_port`/`db_name` keys continue to work. Helper extracted to `Simple-PHP-IPAM/lib/restore_dsn.php` so it's unit-testable without tripping the CLI-only guard at the top of `restore.php`.

**Limitation:** `restore.php` cannot pipe `mysql`/`psql` through a Unix-domain socket; a `db_dsn` containing `unix_socket=...` aborts with a clear error pointing the operator at the discrete TCP keys.

### 2. Drop-and-recreate target schema before replay

`database`-type dump restored onto a populated install previously **duplicated rows** for tables present in both the dump and the live DB. Now wipes target first:

- **mysql:** `DROP TABLE IF EXISTS` per table from `information_schema.TABLES WHERE TABLE_TYPE = 'BASE TABLE'` (filters views/MariaDB sequences), wrapped in `FOREIGN_KEY_CHECKS = 0/1` bracket with try/finally so a mid-loop failure can't leave the session FK-disabled for subsequent `apply_migrations(\$db)`.
- **pgsql:** `DROP SCHEMA public CASCADE; CREATE SCHEMA public;`.

Both pre-steps run **before** the cred tempfile is written so a wipe failure can't leak a 0600 password file. Both skipped under `--dry-run`.

> **Postgres extension caveat documented in `docs/upgrading.md`:** `DROP SCHEMA public CASCADE` removes extensions installed into `public` (`pgcrypto`, `pg_trgm`, etc.). A `pg_dump` taken with defaults re-emits `CREATE EXTENSION`; a `--data-only` dump will not.

### 3. psql fail-fast

`psql` invocation gets `-v ON_ERROR_STOP=1` so a mid-restore error aborts cleanly. mysql client default is already fail-on-error (no `-f`/`--force` passed); confirmed inline.

### Tests

6 cases in `tests/RestoreDsnTest.php`: parses mysql DSN, parses pgsql DSN, falls back to discrete keys, defaults when everything missing, extracts unix_socket DSN, ignores extra DSN keys.

## Test plan

- [x] `vendor/bin/phpunit --filter RestoreDsn` (6 new tests pass)
- [x] Full `vendor/bin/phpunit` suite green (1066 total)
- [x] `vendor/bin/phpstan analyse Simple-PHP-IPAM/restore.php Simple-PHP-IPAM/lib/restore_dsn.php` (L9) clean
- [x] `vendor/bin/phpcs` clean
- [ ] Manual smoke (operator-side, post-merge): `php Simple-PHP-IPAM/restore.php --from=<dump.sql.gz> --dry-run` on a mysql/pgsql install

**Ninth and final** of nine sequential PRs into \`dev\` for the v3.28.1 release. After this merges, Phase 2 of the release-workflow begins (docs audit, version bump, CHANGELOG, README, bundle build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)