### PR TITLE
ci+docs: activate marketing-cache-bust workflow + SSR docs

### DIFF
--- a/.github/workflows/marketing-cache-bust.yml
+++ b/.github/workflows/marketing-cache-bust.yml
@@ -14,7 +14,7 @@ jobs:
   bust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 

--- a/.github/workflows/marketing-cache-bust.yml
+++ b/.github/workflows/marketing-cache-bust.yml
@@ -1,0 +1,63 @@
+name: Marketing cache bust
+
+# When docs/*.md changes land on main, POST the changed slugs to the
+# marketing site's invalidation endpoint so the SSR cache re-fetches.
+# Companion design: docs/internal/marketing-site-ssr-decision.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/*.md'
+
+jobs:
+  bust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Compute changed doc slugs
+        id: slugs
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          before="$BEFORE_SHA"
+          # First push to main of a new branch can have a zero before-SHA;
+          # fall back to HEAD~1 in that case.
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ]; then
+            before="HEAD~1"
+          fi
+          changed=$(git diff --name-only "$before" "$AFTER_SHA" -- 'docs/*.md' \
+            | xargs -n1 -I{} basename {} .md \
+            | sort -u)
+          if [ -z "$changed" ]; then
+            echo "json=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          json=$(printf '%s\n' "$changed" | jq -R . | jq -s -c .)
+          echo "json=$json" >> "$GITHUB_OUTPUT"
+          echo "Changed slugs: $json"
+
+      - name: POST to marketing site
+        if: steps.slugs.outputs.json != '[]'
+        env:
+          SECRET: ${{ secrets.MARKETING_WEBHOOK_SECRET }}
+          SLUGS: ${{ steps.slugs.outputs.json }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SECRET:-}" ]; then
+            echo "::warning::MARKETING_WEBHOOK_SECRET not set; skipping POST"
+            exit 0
+          fi
+          # NB: docs source slugs (filename without .md) differ from marketing
+          # URL slugs in one case — install.md -> /docs/installation/. Map here.
+          mapped=$(echo "$SLUGS" | jq -c 'map(if . == "install" then "installation" else . end)')
+          curl -sS --fail-with-body -X POST https://simplephpipam.com/wp-json/sipam/v1/cache-bust \
+            -H "X-Webhook-Secret: $SECRET" \
+            -H "Content-Type: application/json" \
+            -d "{\"slugs\": $mapped}"
+          echo

--- a/docs/internal/marketing-site-ssr-decision.md
+++ b/docs/internal/marketing-site-ssr-decision.md
@@ -1,0 +1,250 @@
+# Marketing site — server-side docs rendering decision (ADR)
+
+> **Status:** Proposed (not implemented). Reserved for a focused implementation session, not a side-quest during release work.
+>
+> **Date:** 2026-05-14.
+>
+> **Scope:** `simplephpipam.com` (the WordPress marketing site). Does **not** affect the IPAM app itself.
+>
+> **Companion docs:** `docs/internal/marketing-site.md` (current procedure), this file (the future design).
+
+---
+
+## Context
+
+The marketing site at `simplephpipam.com` serves doc pages at `/docs/<slug>/` from a custom WordPress theme. The current implementation, documented in `marketing-site.md`:
+
+- The WordPress page only **exists** as a placeholder for URL routing.
+- Actual content is fetched **client-side** at runtime: `page.php` emits a `<script>` that does `fetch('https://raw.githubusercontent.com/seanmousseau/Simple-PHP-IPAM/main/docs/<slug>.md')` and renders the markdown via `marked.js`, with `Prism.js` doing syntax highlighting.
+
+This is fine for browsing humans on fast connections. It is **bad for SEO** because:
+
+1. Search-engine crawlers fetch the HTML, see an empty content shell, and have no doc text to index. The pages exist in the sitemap but rank for nothing.
+2. Social-card previews (OpenGraph, Twitter card, Slack/Discord unfurl) hit the same empty shell — no excerpt, no preview image keyed off content.
+3. Initial render is blocked on a cross-origin fetch + a second-party JS bundle parse. Lighthouse SEO score takes a hit, and Core Web Vitals (LCP in particular) are worse than necessary.
+4. AI assistants that index the public web (ChatGPT, Claude.ai web, Perplexity) see the same empty shell. As of 2026 this is non-trivial — operator-research-via-LLM is a real discovery path for self-hosted infrastructure tools.
+
+The fix is server-side rendering: render the markdown to HTML in `page.php` before the response goes out, cache the result, and emit a fully-populated page to crawlers and browsers alike.
+
+**Why this isn't shipped now:** v3.28.1 just went out at midnight after a long session. The repo's expensive failures (v2.2.1 data wipe, v3.27.8 silent-fail cron, the auto-generated-vault-key footgun chain that took three releases to fully untangle) all share a shape — "while we're here" changes made when context was thinner than it felt. This ADR locks the design while the context is fresh and reserves the implementation for a focused session.
+
+---
+
+## Decision
+
+Implement server-side markdown rendering with the following stack:
+
+### 1. Markdown renderer: `league/commonmark` (NOT Parsedown)
+
+**Choice:** `league/commonmark` v2.x via Composer.
+
+**Why not Parsedown:**
+- Last meaningful Parsedown release was 2019. Effectively unmaintained.
+- Parsedown has shipped reflected-XSS CVEs (CVE-2022-23252 and earlier) that were patched only because of community pressure, not active maintenance.
+- Parsedown's "Extra" extension for tables/footnotes is a separate unmaintained package.
+- CommonMark is the actual specification; Parsedown's heuristics drift from spec in edge cases.
+
+**Why CommonMark:**
+- Maintained by The PHP League (the people behind Flysystem, OAuth2 Server, etc.). Active monthly releases.
+- First-party `league/commonmark-ext-github-flavored-markdown` (already part of v2.x as `GithubFlavoredMarkdownConverter`) gives us tables, task lists, autolinks, strikethrough — all of which appear in `docs/*.md`.
+- AST-based design means we can write custom extensions cleanly if needed later (e.g. resolving relative links to other doc pages, or generating per-page TOC).
+- Composer-installable; standard PHP infrastructure.
+
+Picking Parsedown today would be a quick-win choice we'd revisit in 18 months, exactly the pattern this ADR is designed to avoid.
+
+### 2. Composer-managed in the theme
+
+**Choice:** add `composer.json` to the website theme. Run `composer install --no-dev --optimize-autoloader` on the deploy host (or commit the `vendor/` tree — see "Open questions" below).
+
+**Why:**
+- The theme has no `vendor/` today. Establishing the convention now means future PHP dependencies (a structured-data generator, a feed builder, anything else) land cleanly without an architectural step change.
+- The rsync deploy step in `marketing-site.md` already calls out the gotcha that `vendor/` is gitignored by default; we update that procedure to explicitly include the theme's vendor tree.
+
+**Procedure update:** the rsync line in `marketing-site.md` Deploy section becomes:
+
+```bash
+rsync -az --delete \
+  --include='vendor/' --include='vendor/**' \
+  website/ root@192.168.80.23:/usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/
+```
+
+### 3. Server-side syntax highlighting: `scrivo/highlight.php`
+
+**Choice:** `scrivo/highlight.php` v9.x (PHP port of `highlight.js`).
+
+**Why server-side:**
+- The whole point of SSR is rendered HTML reaching the crawler. Leaving code blocks as `<pre><code class="language-x">` and patching them up client-side defeats half the SEO purpose — search engines see un-highlighted, structurally-poor code blocks. Worse, they see `<pre>` content that may include `> ` shell prompts being treated as quoted text.
+- `scrivo/highlight.php` is a 1:1 port of `highlight.js`, supports 180+ languages, MIT-licensed, actively maintained.
+- Output is identical to what `highlight.js` produces, so existing Prism/highlight.js CSS in the theme works unchanged.
+- We can drop the client-side highlighter entirely once SSR rolls out — eliminates ~50 KB of JS from the doc pages.
+
+**Alternative considered:** `phpolar/php-highlight` (smaller). Rejected because the language set is narrower and we use bash, php, json, sh, yaml, dockerfile, sql, diff, ini, http, javascript across the docs — `scrivo/highlight.php` covers all of these out of the box.
+
+### 4. Webhook-driven cache invalidation (NOT TTL)
+
+**Choice:** GitHub Actions workflow on `paths: docs/**` POSTs to a custom WP REST endpoint, which deletes the affected transients.
+
+**Why webhook over TTL:**
+- TTL feels easier but creates a permanent "is the site stale right now?" question that compounds over time. A 6-hour TTL means a typo-fix doc PR is invisible to users for 6 hours, which is irritating; a 24-hour TTL is worse; a 5-minute TTL burns the cache benefit.
+- Webhook is the *right shape* and sets up cleanly for future cache-busting needs (front-page feature cards pulling from a release manifest, version-bump auto-sync, etc.).
+- Operational complexity is small: one GH Action workflow file, one WP REST endpoint, one shared secret in GitHub Secrets + WP options.
+
+**Sketch:**
+
+```yaml
+# .github/workflows/marketing-cache-bust.yml (in the IPAM repo)
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+jobs:
+  bust:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify marketing site
+        env:
+          MARKETING_WEBHOOK_SECRET: ${{ secrets.MARKETING_WEBHOOK_SECRET }}
+        run: |
+          slugs=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }} -- 'docs/*.md' | xargs -n1 basename | sed 's/\.md$//' | jq -R . | jq -s .)
+          curl -sS -X POST https://simplephpipam.com/wp-json/sipam/v1/cache-bust \
+            -H "X-Webhook-Secret: $MARKETING_WEBHOOK_SECRET" \
+            -H "Content-Type: application/json" \
+            -d "{\"slugs\": $slugs}"
+```
+
+WP endpoint (in `functions.php`):
+
+```php
+add_action('rest_api_init', function () {
+    register_rest_route('sipam/v1', '/cache-bust', [
+        'methods'             => 'POST',
+        'permission_callback' => function (WP_REST_Request $req) {
+            $secret = $req->get_header('x-webhook-secret');
+            $expected = get_option('sipam_marketing_webhook_secret', '');
+            return $secret !== '' && $expected !== '' && hash_equals($expected, $secret);
+        },
+        'callback' => function (WP_REST_Request $req) {
+            $slugs = (array) $req->get_param('slugs');
+            foreach ($slugs as $slug) {
+                if (preg_match('/^[a-z0-9-]+$/', $slug)) {
+                    delete_transient('sipam_doc_' . $slug);
+                }
+            }
+            return ['ok' => true, 'busted' => $slugs];
+        },
+    ]);
+});
+```
+
+**Fallback:** a "purge all" admin-only button in WP admin for the manual escape hatch. Operationally cheap to add and useful for "I deleted the webhook by accident" recovery.
+
+### 5. ETag-aware fetch with `wp_remote_get`
+
+**Choice:** always send `If-None-Match`. On `304 Not Modified`, refresh the transient's TTL without rebuilding the HTML. On `200`, render + cache the new ETag alongside the rendered HTML.
+
+**Why:**
+- GitHub's `raw.githubusercontent.com` honours `If-None-Match` and `If-Modified-Since`.
+- Cheap to add now while we're touching the fetch path; expensive to retrofit later when we discover we're burning rate-limit budget or seeing fetch latency we didn't anticipate.
+
+### 6. Keep the JS loader as a runtime fallback (defense in depth)
+
+**Choice:** if `wp_remote_get` returns an error (timeout, network failure, GitHub outage), `page.php` emits the existing client-side loader script instead of an empty page.
+
+**Why not "remove the old code":**
+- Marketing-site availability matters during a release announcement — exactly when GitHub is under load. A fetch failure should degrade to "JS-rendered content" not "blank page."
+- Costs ~5 lines of `<noscript>` + a feature-flag check. Negligible.
+- Sets the precedent that SSR is an optimization, not a single point of failure.
+
+**Feature flag:** `define('SIPAM_DOCS_SSR_ENABLED', true)` in `wp-config.php` (or a WP option). Lets us roll the SSR path out behind a flag and turn it off with a one-line change if something misbehaves in production.
+
+### 7. Memory MCP decision entity + procedure-doc update
+
+**Choice:** create `decision:wordpress-server-side-docs` in Memory MCP, and update `docs/internal/marketing-site.md` to point at this ADR + reflect the new procedure.
+
+**Why:**
+- The pattern of "Composer in the marketing theme" will look weird to a future contributor without the rationale. Putting it in Memory MCP and the procedure doc means the question "why is there a `vendor/` in this WordPress theme?" gets answered without spelunking through git history.
+- The phpstan-baseline-orphan lesson from v3.28.1 (`lessons-learned.md § 6.5`) was exactly this shape — a non-obvious choice that needs a written rationale. Bake that habit in now.
+
+---
+
+## Consequences
+
+### Positive
+
+- Doc pages become indexable. Expect search-engine indexing within the standard re-crawl cycle (days to weeks) once SSR is live.
+- LCP improves measurably on doc pages (no fetch-then-render delay).
+- Social-card unfurls show real content excerpts.
+- LLM-based discovery tools see real content instead of "Loading…" placeholders.
+- ~50 KB of JS removed from doc pages once the client-side renderer is no longer the primary path.
+
+### Negative
+
+- New PHP dependency surface (`league/commonmark`, `scrivo/highlight.php`, plus transitive deps). All MIT-licensed; both maintainers are reputable. Still worth a `composer audit` in CI on the website repo.
+- The marketing-site deploy procedure gets a step more complex (run `composer install` if vendor/ isn't checked in; verify the rsync includes vendor/).
+- Cache invalidation now has an external dependency (GitHub webhook reaching WP). When the webhook fails silently, content can go stale until the manual purge button is used. Mitigation: a daily cron-style purge as a safety net (low TTL on the safety-net purge, NOT on the normal cache path).
+
+### Neutral
+
+- The JS loader stays around. If a future contributor wants to fully delete it, that's a separate decision.
+
+---
+
+## Open questions (resolve at implementation start)
+
+These don't need to be resolved tonight, but the implementer should pick a stance on each before opening the PR:
+
+1. **Commit `vendor/` or run `composer install` on deploy?**
+   - Commit: deploy is one `rsync` step, no PHP needed on the deploy host. Adds ~3-5 MB to the repo.
+   - Build: smaller repo, but adds a `composer install` step to the deploy procedure and requires PHP + Composer on the deploy host (already true — the host runs WordPress).
+   - **Lean:** build (run `composer install --no-dev` on the host). The deploy host has PHP 8.4; the dep tree is small; runtime composer install is the standard convention.
+
+2. **What's the TTL on the safety-net purge?**
+   - Bare-bones answer: 24h. A doc edit that misses the webhook is at most one day stale.
+   - **Lean:** 24h, configurable via WP option.
+
+3. **Inline CSS for highlight.php or shared stylesheet?**
+   - `highlight.php` doesn't ship CSS — it emits `<span class="hljs-…">` markup that needs styling from a `highlight.js` theme stylesheet.
+   - The theme currently uses (presumably) Prism's CSS. We'd swap to a highlight.js theme stylesheet. Choosing one that matches the existing visual style is a 30-minute task.
+   - **Lean:** use the `atom-one-dark.css` highlight.js theme (closest to the current site dark aesthetic).
+
+4. **Do we generate a TOC server-side or keep that JS-side?**
+   - Currently I believe a JS post-processor builds the floating TOC. Server-side generation is straightforward with CommonMark's `HeadingPermalinkExtension` + a custom walker.
+   - **Lean:** ship SSR for content first, TOC port is a follow-up PR.
+
+5. **`raw.githubusercontent.com` rate limits?**
+   - Unauthenticated fetches are 60/hour per IP. The webhook flow guarantees we only fetch on cache miss → only on `docs/*.md` push, so 60/hour is plenty.
+   - If we ever want to refresh independently of pushes (e.g. cron warm-up), authenticated fetches go to 5000/hour. Not needed for v1.
+   - **Lean:** no auth; revisit if we ever see 429s.
+
+---
+
+## Implementation plan (sketch)
+
+1. **Spike:** new branch `feature/marketing-ssr` in the **website** repo. Add `composer.json` with the three deps. Add a `lib/docs-ssr.php` that exposes `sipam_render_doc(string $slug): ?string` (returns HTML or null on fetch failure). Unit-testable in isolation against fixtures in `lib/tests/`. ~2-3 hours.
+2. **Integrate:** wire `page.php` to call `sipam_render_doc()`; on null, fall back to existing JS loader. Feature-flag the SSR path. ~1 hour.
+3. **Cache layer:** transient get/set, ETag plumbing. ~1 hour.
+4. **Webhook:** WP REST endpoint + GH Action workflow file + shared secret setup. ~1.5 hours.
+5. **Highlight.php CSS:** swap Prism CSS for an `atom-one-dark` highlight.js theme. ~30 min.
+6. **Test:** local WP dev environment (Docker? Pre-existing harness?) — verify a known doc page renders identically to the JS-rendered version. Side-by-side diff at the HTML level. ~1.5 hours.
+7. **Deploy behind flag:** rsync + cache purge. Flip flag for `installation.md` only. Verify with `curl https://simplephpipam.com/docs/installation/ | grep -c '<h2'` returning >0. ~30 min.
+8. **Roll out:** flip flag globally. Watch Search Console + Lighthouse over the next 7 days.
+9. **Memory MCP + procedure doc:** create the decision entity, update `marketing-site.md`. ~30 min.
+
+**Total estimate:** ~8-9 hours (1 focused day with breaks).
+
+---
+
+## When to revisit this ADR
+
+- If `league/commonmark` v3 ships with a breaking API change → re-pin the dep.
+- If WordPress block themes (FSE) become relevant for this site → the rendering integration point moves and the ADR needs an addendum on where SSR hooks in under FSE.
+- If we move off WordPress entirely (Hugo / static site generator) → archive this ADR; the SSR concern goes away.
+- If we add a search feature to the docs → bring in `meilisearch` or similar; this ADR's CommonMark AST is the right input to feed it. Document the search index build path here.
+
+---
+
+## Related
+
+- `docs/internal/marketing-site.md` — current marketing-site procedure (to be updated as part of implementation).
+- `docs/internal/lessons-learned.md § 6.5` — phpstan-baseline-orphan lesson from v3.28.1 #1177; same shape of "make the non-obvious choice obvious in a written doc" pattern.
+- Memory MCP: `decision:wordpress-server-side-docs` (to be created at implementation start).

--- a/docs/internal/marketing-site-ssr-decision.md
+++ b/docs/internal/marketing-site-ssr-decision.md
@@ -1,8 +1,8 @@
 # Marketing site — server-side docs rendering decision (ADR)
 
-> **Status:** Proposed (not implemented). Reserved for a focused implementation session, not a side-quest during release work.
+> **Status:** Implemented on `feature/marketing-ssr` in the website repo (commits `3da02f5`, `8c306f0`); pending PR review + deploy to live theme. Staged on `simplephpipam-staging` theme behind cookie `sipam_theme=staging`.
 >
-> **Date:** 2026-05-14.
+> **Date:** 2026-05-14 (ADR + same-day implementation).
 >
 > **Scope:** `simplephpipam.com` (the WordPress marketing site). Does **not** affect the IPAM app itself.
 >
@@ -189,32 +189,19 @@ add_action('rest_api_init', function () {
 
 ---
 
-## Open questions (resolve at implementation start)
+## Open questions — resolved at implementation
 
-These don't need to be resolved tonight, but the implementer should pick a stance on each before opening the PR:
+1. **Commit `vendor/` or run `composer install` on deploy?** → **Commit `vendor/`.** Final repo size delta ~3-5 MB. Deploy stays single rsync (no PHP/composer step on the host — important because system `php` on deploy host lacks mbstring, only LSPHP does; running `composer install` against system PHP would risk dep-resolution drift). Sean's explicit choice over the ADR lean.
+2. **Safety-net TTL?** → **24h**, hard-coded in `SIPAM_DOC_CACHE_TTL` for now. No WP option (YAGNI — flip the constant if it ever needs to change).
+3. **Highlight CSS?** → **`atom-one-dark.css`** as planned. Fetched from cdnjs and committed at `assets/highlight-atom-one-dark.css`.
+4. **Server-side TOC?** → **Shipped in this PR.** Right-rail aside, sticky, collapses under 1100px. Built from h2/h3 with nested sublists. Heading IDs come from kramdown `{: #anchor }` when present (via `AttributesExtension`), slugified text otherwise.
+5. **GitHub raw rate limits?** → **No auth.** Webhook drives all invalidation; 60/h unauth quota has huge headroom.
 
-1. **Commit `vendor/` or run `composer install` on deploy?**
-   - Commit: deploy is one `rsync` step, no PHP needed on the deploy host. Adds ~3-5 MB to the repo.
-   - Build: smaller repo, but adds a `composer install` step to the deploy procedure and requires PHP + Composer on the deploy host (already true — the host runs WordPress).
-   - **Lean:** build (run `composer install --no-dev` on the host). The deploy host has PHP 8.4; the dep tree is small; runtime composer install is the standard convention.
+## Surprises that made it into the procedure doc
 
-2. **What's the TTL on the safety-net purge?**
-   - Bare-bones answer: 24h. A doc edit that misses the webhook is at most one day stale.
-   - **Lean:** 24h, configurable via WP option.
-
-3. **Inline CSS for highlight.php or shared stylesheet?**
-   - `highlight.php` doesn't ship CSS — it emits `<span class="hljs-…">` markup that needs styling from a `highlight.js` theme stylesheet.
-   - The theme currently uses (presumably) Prism's CSS. We'd swap to a highlight.js theme stylesheet. Choosing one that matches the existing visual style is a 30-minute task.
-   - **Lean:** use the `atom-one-dark.css` highlight.js theme (closest to the current site dark aesthetic).
-
-4. **Do we generate a TOC server-side or keep that JS-side?**
-   - Currently I believe a JS post-processor builds the floating TOC. Server-side generation is straightforward with CommonMark's `HeadingPermalinkExtension` + a custom walker.
-   - **Lean:** ship SSR for content first, TOC port is a follow-up PR.
-
-5. **`raw.githubusercontent.com` rate limits?**
-   - Unauthenticated fetches are 60/hour per IP. The webhook flow guarantees we only fetch on cache miss → only on `docs/*.md` push, so 60/hour is plenty.
-   - If we ever want to refresh independently of pushes (e.g. cron warm-up), authenticated fetches go to 5000/hour. Not needed for v1.
-   - **Lean:** no auth; revisit if we ever see 429s.
+- **`AttributesExtension` is required to consume kramdown `{: #anchor }` lines** — without it those lines render as literal `<p>` paragraphs under the heading. Slugifier was masking the regression by coincidentally producing identical ids.
+- **LiteSpeed Cache's `object-cache.php` dropin caches WP transients independently of `wp_options`.** After a renderer change, `wp transient delete` alone is insufficient. Full purge sequence (now documented in `marketing-site.md`): OPcache reset + cachedata wipe + `wp cache flush` (object cache) + `wp litespeed-purge all` (page cache + QUIC.cloud edge).
+- **System `php` on `192.168.80.23` lacks `ext-mbstring`; LSPHP 8.4 has it.** CommonMark's `RegexHelper::matchAt()` calls `mb_substr` / `mb_strcut`, so any wp-cli-driven render returns null. Keep renders in the web request path; if you ever script a warmup, target it through LSPHP not system PHP.
 
 ---
 

--- a/docs/internal/marketing-site.md
+++ b/docs/internal/marketing-site.md
@@ -6,7 +6,9 @@
 
 The marketing site is a WordPress install on OpenLiteSpeed at `root@192.168.80.23`. The theme repo is `simple-php-ipam-website` (separate from the IPAM repo) and is deployed via `rsync website/ → /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/`.
 
-Doc pages are served as WordPress pages at `/docs/<slug>/`. **The page content stored in WP is irrelevant** — `page.php` fetches the markdown live from `https://raw.githubusercontent.com/seanmousseau/Simple-PHP-IPAM/main/docs/<slug>.md` and renders it client-side via marked.js. The WP page only needs to **exist** for the URL to resolve.
+Doc pages are served as WordPress pages at `/docs/<slug>/`. As of the v3.28.2 SSR rollout, `page.php` server-side renders the markdown via `league/commonmark` (composer dep, vendor/ committed) before the response goes out — crawlers and social-card unfurls see real content, not an empty shell. The WP page still only needs to **exist** for the URL to resolve; its `post_content` is ignored by the SSR path. Markdown source is fetched live from `https://raw.githubusercontent.com/seanmousseau/Simple-PHP-IPAM/main/docs/<slug>.md` and cached in a WP transient (`sipam_doc_<slug>`, 24h TTL safety net, webhook-invalidated on every docs/*.md push to main). If the fetch/render fails the page falls back to the legacy JS-loader path.
+
+Design + rationale: [`marketing-site-ssr-decision.md`](marketing-site-ssr-decision.md).
 
 ## Per-release version bump
 
@@ -43,7 +45,11 @@ cd website/
 git add -A && git commit -m "chore(release): <message>"
 git push origin main
 cd ..
+# vendor/ is committed in the website repo (per ADR) so a single rsync ships
+# everything the SSR path needs. Include vendor/** explicitly because some
+# rsync wrappers/.cvsignore patterns would otherwise skip it.
 rsync -az --delete \
+  --include='vendor/' --include='vendor/**' \
   website/ root@192.168.80.23:/usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/
 ssh root@192.168.80.23 "chown -R nobody:nogroup /usr/local/lsws/vhosts/simplephpipam.com/html/wp-content/themes/simplephpipam/"
 ```
@@ -66,7 +72,11 @@ ssh root@192.168.80.23 "
   rm -rf /usr/local/lsws/vhosts/simplephpipam.com/cachedata/*
   # 3. Flush WP rewrite rules (required after creating new pages — without this /docs/<slug>/ returns 404)
   wp --allow-root rewrite flush
-  # 4. Purge LSCache + QUIC.cloud edge in one shot (QUIC.cloud caches pre-creation 404s)
+  # 4. Flush WP object cache (the LiteSpeed Cache plugin's object-cache.php dropin
+  #    caches the SSR sipam_doc_<slug> transients independently of wp_options;
+  #    \`wp transient delete\` alone does NOT clear them).
+  wp --allow-root cache flush
+  # 5. Purge LSCache + QUIC.cloud edge in one shot (QUIC.cloud caches pre-creation 404s)
   wp --allow-root litespeed-purge all
 "
 ```
@@ -79,6 +89,21 @@ curl -sk -o /dev/null -w '%{http_code}\n' https://simplephpipam.com/docs/<slug>/
 
 In a browser, hard-refresh is **not** enough — browser caching on this site is aggressive. Use **DevTools → Application → Storage → Clear site data** to bypass it.
 
+## Webhook cache invalidation (post-SSR)
+
+Every push to `main` that touches `docs/*.md` triggers `.github/workflows/marketing-cache-bust.yml` in the IPAM repo. The workflow POSTs the changed slugs to `https://simplephpipam.com/wp-json/sipam/v1/cache-bust` with an `X-Webhook-Secret` header validated via `hash_equals` against the WP option `sipam_marketing_webhook_secret`.
+
+Set up (one-time):
+
+```bash
+# Generate a random secret and store it on both ends.
+secret=$(openssl rand -hex 32)
+ssh root@192.168.80.23 "wp --path=/usr/local/lsws/vhosts/simplephpipam.com/html --allow-root option update sipam_marketing_webhook_secret '$secret'"
+gh -R seanmousseau/Simple-PHP-IPAM secret set MARKETING_WEBHOOK_SECRET --body "$secret"
+```
+
+If the secret is unset the workflow emits a `::warning::` and exits 0 (no-op) so doc PRs don't fail before rollout. The 24h transient TTL is the safety net for missed webhooks.
+
 ## LSCache JS bundling — useful to know
 
 LSCache combines all inline `<script>` blocks into a single external `.js` bundle (e.g. `/wp-content/litespeed/js/<hash>.js`). The doc loader's `rawUrl` is in that bundle, not the HTML, so `curl … | grep raw.github` against the page HTML will return nothing. To verify the bundle for a doc page:
@@ -90,8 +115,9 @@ curl -k -s "https://simplephpipam.com${jsurl}" | grep -oE "raw\.githubuserconten
 
 ## Pitfalls (learned the hard way)
 
-- **Jekyll frontmatter leaks visible.** Never include `---\ntitle: …\n---` in new docs. marked.js does not strip it.
-- **OPcache + cachedata + rewrite rules + LSCache** are four distinct cache layers. `wp litespeed-purge all` alone is not enough after creating a new page; you also need rewrite-flush + cachedata wipe + opcache reset.
+- **Jekyll frontmatter leaks visible.** Never include `---\ntitle: …\n---` in new docs. The SSR renderer and the JS fallback both leave it as visible text at the top of the page.
+- **OPcache + cachedata + LSCache object-cache + rewrite rules + QUIC.cloud edge** are FIVE distinct cache layers. `wp litespeed-purge all` alone is not enough after a renderer change; you also need OPcache reset, cachedata wipe, **`wp cache flush` for the SSR transient via the LSCache object-cache dropin**, and rewrite-flush (only when creating new pages). Discovered the hard way during the SSR rollout — staging served stale SSR HTML for hours after a docs-ssr.php edit because the LSCache object-cache held the old transient.
 - **QUIC.cloud caches 404s.** A page that returned 404 before creation will continue to 404 at the edge until `wp litespeed-purge all` runs (which also flushes the QUIC.cloud edge).
-- **`rsync` from working tree silently skips `vendor/`** (gitignored). Not relevant for the website theme (no vendor dir), but worth remembering — the theme is the one place we *do* deploy via rsync.
+- **`rsync` working-tree includes `vendor/`** (per ADR the theme's vendor/ is committed, not gitignored). Make sure deploy rsyncs include `--include='vendor/' --include='vendor/**'`.
 - **`page-docs.php` doc cards** are separate from `page.php` `$docs` sidebar array and `header.php` dropdown. All three must be updated when adding a new doc.
+- **SSR renderer can be disabled** via `define('SIPAM_DOCS_SSR_ENABLED', false);` in `wp-config.php`. Use as kill switch if a doc edit ever produces broken output that can't be diagnosed quickly — `page.php` falls back to the legacy JS-loader path and the site stays up.

--- a/docs/internal/marketing-site.md
+++ b/docs/internal/marketing-site.md
@@ -40,6 +40,16 @@ Wiring a new doc requires changes in **six places** plus a WordPress page. Missi
 
 ## Deploy
 
+**Step zero: verify the active theme.** The live site has both `simplephpipam` and `twentytwentyfive` installed; rsyncing to the inactive one produces zero observable change and looks like a deploy that "took silently". Confirm before deploying:
+
+```bash
+ssh root@192.168.80.23 "wp --path=/usr/local/lsws/vhosts/simplephpipam.com/html --allow-root theme list --status=active --fields=name"
+# expected: simplephpipam
+# if not, activate: wp ... theme activate simplephpipam
+```
+
+Then:
+
 ```bash
 cd website/
 git add -A && git commit -m "chore(release): <message>"


### PR DESCRIPTION
## Summary

Focused infra slice: gets the marketing-site SSR workflow + companion internal docs onto `main` so the cache-bust workflow becomes active. No app code changes.

Companion website-repo work has already shipped — `seanmousseau/simple-php-ipam-website#2` merged and rolled out earlier this evening; SSR is live at https://simplephpipam.com/docs/<slug>/.

## Commits

| Hash | Summary |
|---|---|
| `dc6bfbd` | docs(internal): ADR for marketing-site server-side docs rendering |
| `80d0bd5` | ci: marketing cache-bust workflow on docs/*.md push to main |
| `97b0077` | docs(internal): marketing-site procedure + ADR follow-through for SSR |
| `7142165` | docs(internal): require active-theme check before marketing deploy |

## What activates on merge

`.github/workflows/marketing-cache-bust.yml` will be live on `main` and registered with GitHub. Subsequent pushes to `main` with paths `docs/*.md` will POST changed slugs to `https://simplephpipam.com/wp-json/sipam/v1/cache-bust`, which clears the SSR transient cache for those slugs (proven end-to-end via probe earlier — `EXISTS` → `NONE (cleared)`).

`MARKETING_WEBHOOK_SECRET` is already set in GH Secrets; `sipam_marketing_webhook_secret` WP option is set on the live site. `hash_equals` comparison verified. Slug whitelist regex `^[a-z0-9-]+$` + `sipam_doc_md_file()` map filters reject path-traversal / unknown slugs.

## Risk

- **None on the app side** — zero PHP / schema changes.
- Workflow no-ops gracefully if the secret is ever unset (`::warning::` + exit 0).
- Internal docs only; user-facing docs untouched.

## Test plan

- [x] Workflow YAML lints (workflow file already present on `dev` — `gh workflow list` after merge will show "Marketing cache bust" registered).
- [x] WP endpoint auth: 401 on missing/wrong secret, 200 on valid (verified locally with curl + the configured secret).
- [x] Slug whitelist drops invalid entries: `{"slugs":["installation","not-a-real-slug","../../etc/passwd"]}` returned `"busted":["installation"]`.
- [x] Transient invalidation works through LSCache object-cache dropin (LSPHP probe before+after).
- [ ] Post-merge: next docs-only push to main fires the workflow successfully (will verify on first natural docs edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side rendering for docs pages to improve performance and SEO
  * Automatic marketing cache-bust workflow that notifies the site when docs change

* **Documentation**
  * Added an ADR documenting the SSR approach and trade-offs
  * Updated operational procedures for deployment, cache invalidation, and rollback/safety steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1194)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->