### PR TITLE
fix(tests): Tier-C cleanups from CR PR #1179 (#1180)

### DIFF
--- a/testing/playwright/tests/custom-fields-admin.spec.ts
+++ b/testing/playwright/tests/custom-fields-admin.spec.ts
@@ -20,6 +20,7 @@ const CF_LABEL_SELECT = 'PW CF Select';
 
 let ctx: BrowserContext;
 let page: Page;
+let _lastSudoWarm = 0;
 
 test.beforeAll(async ({ browser }: { browser: Browser }) => {
   ctx = await newAuthContext(browser);
@@ -33,6 +34,7 @@ test.beforeAll(async ({ browser }: { browser: Browser }) => {
   // TTL=300s) so the form-driven CRUD tests and the fetchPost cleanup helpers
   // below don't each land on the step-up prompt.
   await warmSudoGrant(page);
+  _lastSudoWarm = Date.now();
 
   // Clean up stale test custom field defs from previous failed runs
   await page.goto('custom_fields.php');
@@ -50,6 +52,15 @@ test.beforeAll(async ({ browser }: { browser: Browser }) => {
   }, [CF_KEY_TEXT, CF_KEY_NUMBER, CF_KEY_DATE, CF_KEY_BOOL, CF_KEY_SELECT]);
   for (const id of staleIds) {
     await fetchPost(page, appUrl('custom_fields.php'), { action: 'delete', id });
+  }
+});
+
+test.beforeEach(async () => {
+  // Re-warm sudo if more than 240 s (80% of the 300 s TTL) have elapsed since
+  // the last warm, so long test suites don't hit the step-up prompt mid-run.
+  if (Date.now() - _lastSudoWarm > 240_000) {
+    await warmSudoGrant(page);
+    _lastSudoWarm = Date.now();
   }
 });
 

--- a/tests/fixtures/backup-library/generate.php
+++ b/tests/fixtures/backup-library/generate.php
@@ -40,6 +40,24 @@ declare(strict_types=1);
 require '/var/www/html/init.php';
 /** @var PDO $db */
 
+// ---------------------------------------------------------------------------
+// Write/copy helpers — fail fast on short or failed I/O.
+// ---------------------------------------------------------------------------
+function _must_write(string $path, string $contents): void {
+    $bytes = file_put_contents($path, $contents);
+    if ($bytes === false || $bytes !== strlen($contents)) {
+        fwrite(STDERR, "FATAL: short or failed write to $path\n");
+        exit(2);
+    }
+}
+
+function _must_copy(string $src, string $dst): void {
+    if (!@copy($src, $dst)) {
+        fwrite(STDERR, "FATAL: copy $src -> $dst failed\n");
+        exit(2);
+    }
+}
+
 // -- Credentials (deterministic) -------------------------------------------
 $appSecret   = str_repeat('cafef00d', 8);              // 64 hex chars
 $vaultKeyRaw = str_repeat("\xBE", 32);                  // 32 raw bytes
@@ -124,7 +142,7 @@ if ($driver === 'sqlite') {
     if (!$vacuumOk) {
         $live = '/var/www/html/data/ipam.sqlite';
         if (is_file($live)) {
-            copy($live, $l0);
+            _must_copy($live, $l0);
             $vacuumOk = is_file($l0) && filesize($l0) > 0;
         }
     }
@@ -148,7 +166,7 @@ echo "B-SQL  .sql.gz ...\n";
 $sqlGzTmp = ipam_backup_dump_to_tmp($db);  // returns a .sql.gz temp path
 $tmpFiles[] = $sqlGzTmp;
 $bsql = $A('.sql.gz');
-copy($sqlGzTmp, $bsql);
+_must_copy($sqlGzTmp, $bsql);
 $bsqlHead = match ($driver) {
     'mysql'  => 'gzip; `gunzip -c | head` -> "-- MySQL dump" / "-- MariaDB dump" (mysqldump banner)',
     'pgsql'  => 'gzip; `gunzip -c | head` -> "-- PostgreSQL database dump" (pg_dump banner)',
@@ -182,13 +200,13 @@ if ($head !== "\x1f\x8b") {
         exit(1);
     }
     $l1GzPath = $l1Tmp . '.gz';
-    file_put_contents($l1GzPath, $gz);
+    _must_write($l1GzPath, $gz);
     $tmpFiles[] = $l1GzPath;
 } else {
     echo "  (logical dump is already gzip -- good)\n";
 }
 $bl1 = $A('.ipambkl1.gz');
-copy($l1GzPath, $bl1);
+_must_copy($l1GzPath, $bl1);
 $records[] = [$bl1, 'B-L1 -- bare logical dump (`logical` type, unencrypted): gzip stream over IPAMBKL1 NDJSON',
     '(none)',
     'php Simple-PHP-IPAM/tools/decrypt-backup.php --in ' . basename($bl1) . ' --out copy.ipambkl1.gz --force   # bare: verbatim copy; `gunzip -c | head -c 9` -> "IPAMBKL1\\n"',
@@ -198,7 +216,7 @@ $records[] = [$bl1, 'B-L1 -- bare logical dump (`logical` type, unencrypted): gz
 echo "P1  .ipambkp1.enc ...\n";
 $p1 = $A('.ipambkp1.enc');
 $plain = (string) file_get_contents($sqlGzTmp);
-file_put_contents($p1, backup_encrypt($plain, $appSecret));
+_must_write($p1, backup_encrypt($plain, $appSecret));
 unset($plain);
 $records[] = [$p1, 'P1 -- IPAMBKP1 (`app_secret`, one-shot AES-256-GCM, whole file in memory). Wraps a B-SQL `.sql.gz`.',
     'app_secret = ' . $appSecret,
@@ -283,7 +301,7 @@ if ($driver === 'sqlite') {
     $m[] = '- No L0 `.sqlite` archive on this engine (see header). The `.sql.gz` here is a real `' . ($driver === 'mysql' ? 'mysqldump' : 'pg_dump') . '` dump piped through gzip, produced by `ipam_backup_dump_to_tmp()`; `gunzip -c | head` shows the engine\'s native SQL dump header.';
 }
 $m[] = '- Negative check: running a `*.enc` with the wrong `--app-secret` exits 3 (decrypt failure) and writes no partial output.';
-file_put_contents($archDir . '/MANIFEST.md', implode("\n", $m) . "\n");
+_must_write($archDir . '/MANIFEST.md', implode("\n", $m) . "\n");
 
 $cleanup();
 

--- a/tests/fixtures/decrypt-tool/run-pass1-grid.sh
+++ b/tests/fixtures/decrypt-tool/run-pass1-grid.sh
@@ -5,6 +5,33 @@
 set -o pipefail
 cd "$(dirname "$0")/../../.." || exit 1
 
+# ---------------------------------------------------------------------------
+# Portability helpers (BSD macOS vs GNU Linux)
+# ---------------------------------------------------------------------------
+file_size() {
+  wc -c <"$1" | tr -d ' '
+}
+
+_measure_rss() {
+  # Usage: _measure_rss <output_file> -- <cmd> [args...]
+  local out="$1"; shift
+  [ "$1" = "--" ] && shift
+  if /usr/bin/time -l true >/dev/null 2>&1; then
+    /usr/bin/time -l "$@" 2>"$out"
+  else
+    /usr/bin/time -v "$@" 2>"$out"
+  fi
+}
+
+_extract_rss() {
+  local f="$1"
+  if grep -q 'maximum resident set size' "$f"; then
+    awk '/maximum resident set size/ {print $1}' "$f"
+  else
+    awk '/Maximum resident set size/ {print $6 * 1024}' "$f"
+  fi
+}
+
 TOOL=(php Simple-PHP-IPAM/tools/decrypt-backup.php)
 FX=tests/fixtures/decrypt-tool
 APPS=$(grep -h '^app_secret=' "$FX/F1/credential.txt" | cut -d= -f2)
@@ -57,7 +84,7 @@ run_fixture() {
 
   # case 3: tampered byte (~mid file)
   cp "$arc" "$d/tamper.bin"
-  local sz; sz=$(stat -f%z "$d/tamper.bin")
+  local sz; sz=$(file_size "$d/tamper.bin")
   printf '\x5a' | dd of="$d/tamper.bin" bs=1 seek=$((sz/2)) count=1 conv=notrunc status=none 2>/dev/null
   rm -f "$d/t.out"
   if [ "$hascred" = 1 ] || [ "$id" = F5 ]; then
@@ -147,12 +174,12 @@ ok "C6 no machine binding (caller-supplied keys; verified by code inspection of 
 gunzip -c "$FX/F6/archive.sql.gz" > "$T/c7_f6.out"
 if cmp -s "$T/c7_f1.out" "$T/c7_f6.out" && cmp -s "$T/c7_f1.out" "$PLAIN"; then ok "C7 round-trip parity (F1 == gunzip(F6) == plaintext-source.sqlite)"; else bad "C7 round-trip parity MISMATCH"; fi
 if [ "${1:-}" = "--large" ] && [ -f /tmp/decrypt-c8-F2.enc ]; then
-  /usr/bin/time -l "${TOOL[@]}" --in /tmp/decrypt-c8-F2.enc --out "$T/c8.out" --app-secret "$APPS" >"$T/out" 2>"$T/timed"
-  RSS=$(grep 'maximum resident set size' "$T/timed" | awk '{print $1}')
+  _measure_rss "$T/timed" -- "${TOOL[@]}" --in /tmp/decrypt-c8-F2.enc --out "$T/c8.out" --app-secret "$APPS" >"$T/out"
+  RSS=$(_extract_rss "$T/timed")
   echo "  NOTE  C8 IPAMBKP2 500MB: max RSS = ${RSS:-?} bytes ($(( ${RSS:-0}/1024/1024 )) MiB)"
   if [ -n "$RSS" ] && [ "$RSS" -lt 268435456 ]; then ok "C8 RSS bounded (<256 MiB)"; else bad "C8 RSS unbounded or unmeasured"; fi
-  /usr/bin/time -l "${TOOL[@]}" --in /tmp/decrypt-c8-F5.ipambku1 --out "$T/c8b.out" >"$T/out" 2>"$T/timed"
-  RSS2=$(grep 'maximum resident set size' "$T/timed" | awk '{print $1}')
+  _measure_rss "$T/timed" -- "${TOOL[@]}" --in /tmp/decrypt-c8-F5.ipambku1 --out "$T/c8b.out" >"$T/out"
+  RSS2=$(_extract_rss "$T/timed")
   echo "  NOTE  C8 IPAMBKU1 500MB: max RSS = ${RSS2:-?} bytes ($(( ${RSS2:-0}/1024/1024 )) MiB)"
 else echo "  NOTE  C8 skipped — run with --large after 'php tests/fixtures/decrypt-tool/generate-fixtures.php --large'"; fi
 


### PR DESCRIPTION
Closes #1180.

Three contained changes flagged by CodeRabbit on PR #1179 and deliberately deferred at the time.

## Summary
- `tests/fixtures/decrypt-tool/run-pass1-grid.sh` is portable on Linux. `stat -f%z` and `time -l` were BSD-only; replaced with `file_size()` (`wc -c`) and `_measure_rss()`/`_extract_rss()` helpers that probe `/usr/bin/time -l` and fall back to `/usr/bin/time -v` on GNU. Stderr/stdout redirection at call sites is preserved exactly.
- `tests/fixtures/backup-library/generate.php` now checks every write/copy return value via `_must_write()` / `_must_copy()`. A short or failed I/O fails fast with FATAL on stderr instead of advertising a broken archive in MANIFEST.md. 6 bare statement-form call sites converted; pre-existing checked calls left untouched.
- `testing/playwright/tests/custom-fields-admin.spec.ts` re-warms sudo periodically. `beforeAll(warmSudoGrant)` stays as the initial warm; a `beforeEach` re-warms when wall-clock since last warm exceeds 240 s (80% of the 300 s sudo TTL), preventing intermittent step-up prompts mid-test on long CRUD runs.

## Test plan
- [x] PHPUnit 1092 tests, 53307 assertions: OK locally.
- [x] PHPStan analyse --memory-limit=1G: no errors.
- [x] PHPCS: clean.
- [x] Spec compliance + code-quality review subagents both approved.
- [ ] CodeRabbit + GHA gates green here.

Pre-existing PHPUnit warning + 13 deprecation notices are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)