### PR TITLE
docs: guard-rails — invariant #22, subsystem hazards, fresh-install test, lib/ docblocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ The single-source-of-truth doc set is `docs/internal/README.md`. Use the routing
 
 ## Hot-cache invariants (read every session)
 
-These are the rules a fresh agent must hold in working memory before touching code. Full table of 21 invariants — each with the protected code location and originating incident — is in `docs/internal/design-document.md`.
+These are the rules a fresh agent must hold in working memory before touching code. Full table of 22 invariants — each with the protected code location and originating incident — is in `docs/internal/design-document.md`.
 
 1. **Binary IPs are stored at native length (4B/16B) and bound via `ipam_bind_binary()` with `PARAM_LOB`.** Anything else corrupts data on at least one engine.
 2. **`apply_migrations()` brackets every migration with `PRAGMA foreign_keys = OFF`** (set before `BEGIN`). FK-on `DROP TABLE` cascades child rows — root cause of the v2.2.1 wipe.
@@ -57,7 +57,7 @@ These are the rules a fresh agent must hold in working memory before touching co
 
 ## Current shipped version
 
-**v3.29.0** (see `Simple-PHP-IPAM/version.php`). Anything in the internal docs citing a version ≥ v4.0.0 is forward-looking design — do not apply to current code.
+**v3.30.0** (see `Simple-PHP-IPAM/version.php`). Anything in the internal docs citing a version ≥ v4.0.0 is forward-looking design — do not apply to current code.
 
 ---
 

--- a/Simple-PHP-IPAM/lib/audit.php
+++ b/Simple-PHP-IPAM/lib/audit.php
@@ -115,6 +115,16 @@ function audit(PDO $db, string $action, string $entityType, ?int $entityId, stri
     }
 }
 
+/**
+ * Convenience wrapper that records an 'export.<what>' audit_log row against
+ * the 'system' entity. Side effect: appends a row to audit_log via audit()
+ * — inherits its rethrow-inside-transaction behaviour. Return value of the
+ * underlying audit() is discarded.
+ *
+ * @param PDO    $db      Live PDO handle.
+ * @param string $what    Export verb (becomes the 'export.<what>' action).
+ * @param string $details Optional free-form detail string.
+ */
 function audit_export(PDO $db, string $what, string $details = ''): void
 {
     audit($db, "export.$what", 'system', null, $details);

--- a/Simple-PHP-IPAM/lib/auth.php
+++ b/Simple-PHP-IPAM/lib/auth.php
@@ -43,12 +43,25 @@ declare(strict_types=1);
 
 /* ---------------- CSRF ---------------- */
 
+/**
+ * Return the current session's CSRF token, or '' when none is set.
+ * Reads $_SESSION['csrf']; does not generate or mutate it.
+ */
 function csrf_token(): string
 {
     $t = $_SESSION['csrf'] ?? null;
     return is_string($t) ? $t : '';
 }
 
+/**
+ * Enforce CSRF protection on POST requests. A no-op for non-POST methods.
+ * On a missing or mismatched $_POST['csrf'] token: sends a hard 403,
+ * writes a plain-text body, and exit()s — never a redirect. Must be called
+ * on every browser POST handler before mutating state (CLAUDE.md
+ * invariant #4); api.php is the only CSRF-exempt surface.
+ *
+ * Side effects: may emit a 403 header + body and terminate the request.
+ */
 function csrf_require(): void
 {
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') return;
@@ -69,6 +82,7 @@ function csrf_require(): void
 
 /* ---------------- Auth / RBAC ---------------- */
 
+/** True when the session holds an authenticated user id. Reads $_SESSION['uid']. */
 function is_logged_in(): bool { return !empty($_SESSION['uid']); }
 
 /**
@@ -108,6 +122,18 @@ function ipam_post_login_redirect_consume(string $default = 'dashboard.php'): st
     return $uri;
 }
 
+/**
+ * Page guard: require an authenticated, non-stale session. Enforces idle
+ * timeout (security.session_idle_seconds), max password age, and pending
+ * MFA enrollment.
+ *
+ * Side effects: on any failed check, sends a `Location:` header and
+ * exit()s — to login.php (not logged in / idle timeout), to
+ * change_password.php (password expired / MFA required). On success,
+ * refreshes $_SESSION['last_active']. May stash the current REQUEST_URI
+ * for post-login redirect and may open/close a fresh session. Reads the
+ * global $db handle and ipam_setting() values.
+ */
 function require_login(): void
 {
     if (!is_logged_in()) {
@@ -178,6 +204,13 @@ function current_user(): array
     ];
 }
 
+/**
+ * Page guard: require login and an exact role match. Calls require_login()
+ * first (which may redirect + exit); then, if the session role differs
+ * from $role, sends a 403 and exit()s with 'Forbidden'.
+ *
+ * @param string $role Required role, e.g. 'admin'.
+ */
 function require_role(string $role): void
 {
     require_login();
@@ -187,6 +220,11 @@ function require_role(string $role): void
     }
 }
 
+/**
+ * Page guard: require login and a non-readonly role. Calls require_login()
+ * first (which may redirect + exit); then, if the session role is
+ * 'readonly', sends a 403 and exit()s with 'Read-only account'.
+ */
 function require_write_access(): void
 {
     require_login();
@@ -196,6 +234,21 @@ function require_write_access(): void
     }
 }
 
+/**
+ * Establish an authenticated session for a verified user.
+ *
+ * Side effects: regenerates the session id, populates $_SESSION (uid,
+ * username, role, last_active); sets $_SESSION['_abs_expires'] from
+ * session.absolute_lifetime_minutes config when that is > 0, otherwise
+ * clears it; and — when $db is supplied — loads the user's persisted theme
+ * into $_SESSION['user_theme']. The caller is responsible for verifying
+ * credentials/MFA before calling this.
+ *
+ * @param int      $uid      Authenticated user id.
+ * @param string   $username Authenticated username.
+ * @param string   $role     User role.
+ * @param PDO|null $db        Live PDO handle; when null the theme preference is skipped.
+ */
 function login_user(int $uid, string $username, string $role, ?PDO $db = null): void
 {
     session_regenerate_id(true);
@@ -218,6 +271,10 @@ function login_user(int $uid, string $username, string $role, ?PDO $db = null): 
     }
 }
 
+/**
+ * Tear down the current session. Side effects: clears $_SESSION, expires
+ * the session cookie, and calls session_destroy().
+ */
 function logout_user(): void
 {
     $_SESSION = [];
@@ -232,6 +289,18 @@ function logout_user(): void
 
 /* ---------------- Caller IP resolution ---------------- */
 
+/**
+ * Resolve the caller's IP address, honouring proxy-trust configuration.
+ *
+ * When security.proxy_trust_cidrs is set, trusts X-Forwarded-For only if
+ * REMOTE_ADDR is a listed proxy CIDR, then walks the chain right-to-left
+ * and returns the first untrusted hop (OWASP pattern). Falls back to the
+ * legacy boolean `proxy_trust` config flag (leftmost XFF, deprecated —
+ * logs a one-shot warning). Returns REMOTE_ADDR when no proxy trust is
+ * configured. Reads $_SERVER, ipam_setting() and ipam_config().
+ *
+ * @return string The resolved client IP, or '127.0.0.1' when REMOTE_ADDR is absent.
+ */
 function client_ip(): string
 {
     $remote = to_str($_SERVER['REMOTE_ADDR'] ?? '127.0.0.1');

--- a/Simple-PHP-IPAM/lib/auth_rate_limit.php
+++ b/Simple-PHP-IPAM/lib/auth_rate_limit.php
@@ -70,6 +70,16 @@ function auth_rate_limited(PDO $db, string $action, string $ip, int $maxAttempts
     return (is_array($countRow) ? to_int($countRow['c']) : 0) >= $maxAttempts;
 }
 
+/**
+ * Record one failed auth attempt for an (action, ip) pair. Side effect:
+ * INSERTs a row into login_attempts (attempted_at defaults to now in the
+ * schema). An empty $username is stored as NULL.
+ *
+ * @param PDO    $db       Live PDO handle.
+ * @param string $action   Auth action, e.g. 'login', 'forgot_password'.
+ * @param string $ip       Caller IP.
+ * @param string $username Optional username associated with the attempt.
+ */
 function record_auth_failure(PDO $db, string $action, string $ip, string $username = ''): void
 {
     $db->prepare(
@@ -81,12 +91,29 @@ function record_auth_failure(PDO $db, string $action, string $ip, string $userna
     ]);
 }
 
+/**
+ * Clear all recorded failures for an (action, ip) pair after a successful
+ * auth. Side effect: DELETEs matching rows from login_attempts.
+ *
+ * @param PDO    $db     Live PDO handle.
+ * @param string $action Auth action.
+ * @param string $ip     Caller IP.
+ */
 function clear_auth_failures(PDO $db, string $action, string $ip): void
 {
     $db->prepare("DELETE FROM login_attempts WHERE action = :a AND ip = :ip")
        ->execute([':a' => $action, ':ip' => $ip]);
 }
 
+/**
+ * action='login' wrapper around auth_rate_limited(). True when the IP has
+ * reached $maxAttempts failed logins within $windowSeconds.
+ *
+ * @param PDO    $db            Live PDO handle.
+ * @param string $ip            Caller IP.
+ * @param int    $maxAttempts   Failure threshold.
+ * @param int    $windowSeconds Sliding-window size in seconds.
+ */
 function login_rate_limited(PDO $db, string $ip, int $maxAttempts, int $windowSeconds): bool
 {
     return auth_rate_limited($db, 'login', $ip, $maxAttempts, $windowSeconds);
@@ -251,16 +278,42 @@ function prune_rate_limit_dampener(PDO $db, int $graceSeconds = 86400): void
        ->execute([':cutoff' => $cutoff]);
 }
 
+/**
+ * action='login' wrapper around record_auth_failure(). Side effect:
+ * INSERTs a login failure row into login_attempts.
+ *
+ * @param PDO    $db       Live PDO handle.
+ * @param string $ip       Caller IP.
+ * @param string $username Optional username associated with the attempt.
+ */
 function record_login_failure(PDO $db, string $ip, string $username = ''): void
 {
     record_auth_failure($db, 'login', $ip, $username);
 }
 
+/**
+ * action='login' wrapper around clear_auth_failures(). Side effect:
+ * DELETEs the IP's login failure rows from login_attempts.
+ *
+ * @param PDO    $db Live PDO handle.
+ * @param string $ip Caller IP.
+ */
 function clear_login_failures(PDO $db, string $ip): void
 {
     clear_auth_failures($db, 'login', $ip);
 }
 
+/**
+ * True when a username has reached $maxAttempts failed action='login'
+ * attempts within $windowSeconds. Scoped to action='login' so non-login
+ * failures (forgot_password, email_otp, vault_key_reveal) do not
+ * contaminate login lockout.
+ *
+ * @param PDO    $db            Live PDO handle.
+ * @param string $username      Username to check.
+ * @param int    $maxAttempts   Failure threshold.
+ * @param int    $windowSeconds Sliding-window size in seconds.
+ */
 function account_locked_out(PDO $db, string $username, int $maxAttempts, int $windowSeconds): bool
 {
     // login_attempts.attempted_at is UTC; build the cutoff in UTC (gmdate).
@@ -277,6 +330,15 @@ function account_locked_out(PDO $db, string $username, int $maxAttempts, int $wi
     return (is_array($row) ? to_int($row['c']) : 0) >= $maxAttempts;
 }
 
+/**
+ * Clear a username's action='login' lockout after a successful login.
+ * Side effect: DELETEs the username's action='login' rows from
+ * login_attempts; scoped to action='login' so forgot_password / email_otp
+ * / vault_key_reveal attempt rows survive.
+ *
+ * @param PDO    $db       Live PDO handle.
+ * @param string $username Username whose lockout to clear.
+ */
 function clear_account_lockout(PDO $db, string $username): void
 {
     // Scope to action='login' so clearing a login lockout does not wipe
@@ -285,6 +347,14 @@ function clear_account_lockout(PDO $db, string $username): void
        ->execute([':u' => $username]);
 }
 
+/**
+ * Housekeeping: drop login_attempts rows older than $windowSeconds.
+ * Side effect: DELETEs aged-out rows. Called during the lazy housekeeping
+ * sweep to bound the table size.
+ *
+ * @param PDO $db            Live PDO handle.
+ * @param int $windowSeconds Age cutoff in seconds; rows older than this are removed.
+ */
 function purge_old_login_attempts(PDO $db, int $windowSeconds): void
 {
     // login_attempts.attempted_at is UTC; build the cutoff in UTC (gmdate).
@@ -376,6 +446,14 @@ function ipam_api_key_rate_limit_check(PDO $db, string $bucketKey, int $windowSe
 
 /* ---------------- Persistent account lockout (v3.6.0, #421) ---------------- */
 
+/**
+ * Clear a user's persistent account lockout. Side effect: UPDATEs the
+ * users row, resetting failed_auth_count to 0 and nulling locked_until /
+ * lock_reason.
+ *
+ * @param PDO $db  Live PDO handle.
+ * @param int $uid User id whose lockout to clear.
+ */
 function ipam_clear_persistent_lockout(PDO $db, int $uid): void {
     $db->prepare(
         "UPDATE users SET failed_auth_count = 0, locked_until = NULL, lock_reason = NULL WHERE id = :id"

--- a/Simple-PHP-IPAM/lib/db.php
+++ b/Simple-PHP-IPAM/lib/db.php
@@ -552,6 +552,22 @@ function ipam_db_init_bootstrap_admin(PDO $db): void
     $ins->execute([':u' => to_str($u), ':h' => $hash]);
 }
 
+/**
+ * Bootstrap or self-heal the database schema on $db.
+ *
+ * On a fresh database (no users table): executes the engine-appropriate
+ * schema.*.sql file, inserts the bootstrap admin, and stamps every
+ * registered migration as applied. On an existing database: ensures the
+ * migrations table, runs pending migrations via apply_migrations(),
+ * self-heals the audit_log table, and re-seeds the bootstrap admin if the
+ * users table is empty. On SQLite, writes/honours a `.db_initialized`
+ * sentinel next to the DB file to skip the probe/migration churn on
+ * subsequent requests.
+ *
+ * Side effects: executes DDL, INSERTs, runs migrations, touches a sentinel
+ * file (SQLite). Reads $config['db_path'] via ipam_config(). The active
+ * dialect must already be selected (call after ipam_db()).
+ */
 function ipam_db_init(PDO $db): void
 {
     $driver = ipam_dialect()->driver_name();
@@ -663,6 +679,13 @@ function ipam_db_init(PDO $db): void
     }
 }
 
+/**
+ * Create the schema_migrations table if it does not exist (idempotent).
+ * Routes the autoincrement, indexed-text, and now() expressions through
+ * the active dialect so the DDL is engine-valid on every driver.
+ *
+ * Side effect: executes CREATE TABLE IF NOT EXISTS.
+ */
 function ensure_migrations_table(PDO $db): void
 {
     $d = ipam_dialect();

--- a/Simple-PHP-IPAM/lib/ip.php
+++ b/Simple-PHP-IPAM/lib/ip.php
@@ -136,6 +136,15 @@ function parse_cidr(string $cidr): ?array
     ];
 }
 
+/**
+ * Zero out the host bits of a binary IP address, returning the network
+ * address at the same byte length. Works on 4-byte (IPv4) and 16-byte
+ * (IPv6) inputs; $prefix is clamped to [0, bit-width]. Pure — no side effects.
+ *
+ * @param string $ipBin Raw binary IP (4 or 16 bytes, output of inet_pton()).
+ * @param int    $prefix CIDR prefix length.
+ * @return string        Binary network address, same length as $ipBin.
+ */
 function apply_prefix_mask(string $ipBin, int $prefix): string
 {
     $len = strlen($ipBin);
@@ -190,6 +199,16 @@ function ipam_compute_broadcast_bin(string $netBin, int $prefix): ?string
     return $out;
 }
 
+/**
+ * Compute the conventional first-usable-host gateway address (network + 1)
+ * for an IPv4 network. Returns null when $netBin is not 4 bytes (e.g. an
+ * IPv6 network) or when $prefix is outside 0..30 (no usable host range).
+ * Pure — no side effects.
+ *
+ * @param string $netBin 4-byte IPv4 network address.
+ * @param int    $prefix CIDR prefix length.
+ * @return string|null   4-byte gateway address, or null when not applicable.
+ */
 function ipam_compute_gateway_bin(string $netBin, int $prefix): ?string
 {
     if (strlen($netBin) !== 4) return null;
@@ -198,6 +217,15 @@ function ipam_compute_gateway_bin(string $netBin, int $prefix): ?string
     return ipv4_int_to_bin($int + 1);
 }
 
+/**
+ * True when $ip falls inside the network defined by $network/$prefix.
+ * Accepts IPv4 or IPv6 strings; returns false on parse error or when the
+ * IP and network are different families. Pure — no side effects.
+ *
+ * @param string $ip      IP address string to test.
+ * @param string $network Network address string.
+ * @param int    $prefix  CIDR prefix length.
+ */
 function ip_in_cidr(string $ip, string $network, int $prefix): bool
 {
     $ipBin = @inet_pton(trim($ip));
@@ -219,6 +247,13 @@ function normalize_ip(string $ip): ?array
 
 /* ---------------- IPv4 helpers ---------------- */
 
+/**
+ * Convert a 4-byte big-endian IPv4 binary address to an unsigned 32-bit
+ * integer. Pure — no side effects.
+ *
+ * @param string $bin 4-byte IPv4 address (output of inet_pton()).
+ * @return int        Unsigned 32-bit integer in the range [0, 0xFFFFFFFF].
+ */
 function ipv4_bin_to_int(string $bin): int
 {
     $unpacked = unpack('N', $bin);
@@ -226,17 +261,39 @@ function ipv4_bin_to_int(string $bin): int
     return to_int($n & 0xFFFFFFFF);
 }
 
+/**
+ * Convert a 32-bit integer to a 4-byte big-endian IPv4 binary address.
+ * The value is masked to 32 bits. Pure — no side effects.
+ *
+ * @param int $n IPv4 address as an integer.
+ * @return string 4-byte binary IPv4 address.
+ */
 function ipv4_int_to_bin(int $n): string
 {
     $n = $n & 0xFFFFFFFF;
     return pack('N', $n);
 }
 
+/**
+ * Convert a 32-bit integer IPv4 address to dotted-quad text. Returns ''
+ * if conversion fails. Pure — no side effects.
+ *
+ * @param int $n IPv4 address as an integer.
+ * @return string Dotted-quad string, e.g. '10.0.0.1', or '' on failure.
+ */
 function ipv4_int_to_text(int $n): string
 {
     return inet_ntop(ipv4_int_to_bin($n)) ?: '';
 }
 
+/**
+ * Number of assignable host addresses in an IPv4 network of the given
+ * prefix. Returns 1 for /32, 2 for /31 (RFC 3021), and total minus the
+ * network+broadcast pair otherwise. Pure — no side effects.
+ *
+ * @param int $prefix CIDR prefix length (0–32).
+ * @return int        Count of assignable hosts.
+ */
 function ipv4_assignable_count(int $prefix): int
 {
     if ($prefix >= 32) return 1;
@@ -247,12 +304,30 @@ function ipv4_assignable_count(int $prefix): int
     return ($assignable > 0) ? (int)$assignable : 0;
 }
 
+/**
+ * True when the child network is contained within the parent network at the
+ * parent's prefix length. Both binary addresses must be the same family/length.
+ * Pure — no side effects.
+ *
+ * @param string $parentNetBin Parent network binary address.
+ * @param int    $parentPrefix Parent CIDR prefix length.
+ * @param string $childNetBin  Child network binary address.
+ */
 function subnet_contains_bin(string $parentNetBin, int $parentPrefix, string $childNetBin): bool
 {
     $masked = apply_prefix_mask($childNetBin, $parentPrefix);
     return hash_equals($masked, $parentNetBin);
 }
 
+/**
+ * Compute the IPv4 broadcast address (binary) by setting all host bits.
+ * Unlike ipam_compute_broadcast_bin(), this returns a value for every
+ * prefix (e.g. the network itself for /32). Pure — no side effects.
+ *
+ * @param string $netBin 4-byte IPv4 network address.
+ * @param int    $prefix CIDR prefix length.
+ * @return string        4-byte binary broadcast address.
+ */
 function ipv4_broadcast_bin(string $netBin, int $prefix): string
 {
     $hostBits = 32 - $prefix;
@@ -266,6 +341,14 @@ function ipv4_broadcast_bin(string $netBin, int $prefix): string
     return pack('N', $b);
 }
 
+/**
+ * Compute the IPv4 broadcast address as an integer by setting all host bits
+ * of the given network integer. Pure — no side effects.
+ *
+ * @param int $networkInt IPv4 network address as an integer.
+ * @param int $prefix     CIDR prefix length.
+ * @return int            Broadcast address as an unsigned 32-bit integer.
+ */
 function ipv4_broadcast_int(int $networkInt, int $prefix): int
 {
     $hostBits = 32 - $prefix;
@@ -296,6 +379,14 @@ function ipv6_bin_increment(string $bin): string
 
 /* ---------------- CIDR helpers ---------------- */
 
+/**
+ * Convert a dotted-quad IPv4 netmask to a CIDR prefix length. Returns null
+ * when the mask is not parseable IPv4 or is not contiguous (a 1-bit appears
+ * after a 0-bit). Pure — no side effects.
+ *
+ * @param string $mask Dotted-quad netmask, e.g. '255.255.255.0'.
+ * @return int|null    Prefix length 0–32, or null on invalid/non-contiguous mask.
+ */
 function netmask_to_prefix(string $mask): ?int
 {
     $bin = @inet_pton(trim($mask));

--- a/Simple-PHP-IPAM/lib/presentation.php
+++ b/Simple-PHP-IPAM/lib/presentation.php
@@ -125,6 +125,14 @@ function icon(string $name, string $cls = ''): string
          . '</svg>';
 }
 
+/**
+ * Store a one-shot flash message in the session. Displayed and cleared by
+ * the next flash_get() call (page_header() does this). Side effect: writes
+ * $_SESSION['ipam_flash'].
+ *
+ * @param string $message Message text (rendered HTML-escaped by the consumer).
+ * @param string $type    Severity: 'success' | 'warning' | 'error' | 'danger'.
+ */
 function flash_set(string $message, string $type = 'success'): void
 {
     $_SESSION['ipam_flash'] = ['msg' => $message, 'type' => $type];
@@ -319,7 +327,23 @@ function render_install_key_banner(PDO $db, string $role): void
     }
 }
 
-/** @param array<string, mixed> $opts */
+/**
+ * Emit the full top-of-page chrome: security headers, <head>, the SVG
+ * sprite, sidebar/topbar nav, and any active admin/flash/update banners.
+ *
+ * Side effects: sends Content-Security-Policy / X-Frame-Options /
+ * X-Content-Type-Options / Referrer-Policy headers (so call before any
+ * output), echoes HTML, consumes the session flash via flash_get(), sets
+ * $GLOBALS['__ipam_no_sidebar'], and may handle the install-key dismiss
+ * POST (which can redirect + exit). Reads the global $db PDO handle and
+ * the session. Must be paired with page_footer().
+ *
+ * @param string               $title Page title (rendered after the app name).
+ * @param array<string, mixed> $opts  Optional keys: 'no_sidebar' (bool),
+ *                                     'page' (string, data-page attr),
+ *                                     'extra_script_src' / 'extra_style_src' /
+ *                                     'extra_frame_src' (string, CSP additions).
+ */
 function page_header(string $title, array $opts = []): void
 {
     // $db is the runtime PDO handle opened by init.php — not config — so it
@@ -571,6 +595,14 @@ function page_header(string $title, array $opts = []): void
     }
 }
 
+/**
+ * Emit the bottom-of-page chrome: closing layout tags, the footer with
+ * version/docs links and update badge, and the form-drawer container.
+ *
+ * Side effect: echoes HTML. Reads $GLOBALS['__ipam_no_sidebar'] (set by
+ * page_header()) to balance the layout-wrapper tags. Must follow a
+ * matching page_header() call.
+ */
 function page_footer(): void
 {
     // ADR-003: the former `global $config;` read used only by

--- a/Simple-PHP-IPAM/lib/utils.php
+++ b/Simple-PHP-IPAM/lib/utils.php
@@ -12,6 +12,15 @@ declare(strict_types=1);
  * no ipam_db() call, no IP/CIDR math, no rendering, no settings access.
  */
 
+/**
+ * HTML-escape a string for safe output in markup or attribute context.
+ * Escapes both quote styles and substitutes invalid UTF-8 sequences.
+ * Pure — no side effects. Must wrap every dynamic value echoed into HTML
+ * (CLAUDE.md invariant #4).
+ *
+ * @param string $s Raw, untrusted string.
+ * @return string   HTML-safe string.
+ */
 function e(string $s): string
 {
     return htmlspecialchars($s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
@@ -49,6 +58,14 @@ function to_str(mixed $value): string
     return '';
 }
 
+/**
+ * Format a byte count as a human-readable string (B/KB/MB/GB/TB), rounding
+ * to one decimal place above the byte unit. Returns '0 B' for non-positive
+ * input. Pure — no side effects.
+ *
+ * @param int $bytes Byte count.
+ * @return string    Formatted size, e.g. '1.5 MB'.
+ */
 function format_bytes(int $bytes): string
 {
     if ($bytes <= 0) return '0 B';
@@ -59,6 +76,17 @@ function format_bytes(int $bytes): string
     return ($i === 0 ? (string)$bytes : round($val, 1)) . ' ' . $units[$i];
 }
 
+/**
+ * Read an integer from $_GET, clamped to [$min, $max]. Returns $default when
+ * the key is absent, empty, non-scalar, or not a valid integer literal.
+ * Reads the $_GET superglobal; does not mutate it.
+ *
+ * @param string $key     $_GET key to read.
+ * @param int    $default Value returned when the key is absent or invalid.
+ * @param int    $min     Lower clamp bound.
+ * @param int    $max     Upper clamp bound.
+ * @return int            The clamped integer, or $default.
+ */
 function q_int(string $key, int $default, int $min, int $max): int
 {
     $v = $_GET[$key] ?? null;
@@ -87,11 +115,26 @@ function ipam_normalise_version(string $v): string
     return implode('.', $parts);
 }
 
+/**
+ * Encode raw bytes as unpadded base64url (RFC 4648 §5: '+/' → '-_', no '=').
+ * Pure — no side effects.
+ *
+ * @param string $bytes Raw binary input.
+ * @return string       URL-safe base64 string with no padding.
+ */
 function base64url_encode(string $bytes): string
 {
     return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
 }
 
+/**
+ * Decode an unpadded base64url string back to raw bytes. Re-adds the '='
+ * padding and translates '-_' back to '+/'. Pure — no side effects.
+ *
+ * @param string $s base64url-encoded input.
+ * @return string   Decoded raw bytes.
+ * @throws RuntimeException When $s is not valid base64url.
+ */
 function base64url_decode(string $s): string
 {
     $s = strtr($s, '-_', '+/');

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -159,6 +159,32 @@ Never:
 - Reference issue numbers as the only context — they rot. Reference commit SHAs and stable identifiers (RFC numbers, design-document invariants, version constants).
 - Write multi-paragraph comment blocks. If the WHY needs more than three lines, write a section in the appropriate doc and link to it.
 
+### Docblocks are not inline comments
+
+The "default to none" rule above is about *inline* comments. It does **not**
+apply to docblocks. A docblock on a function is its **contract** — and the
+`lib/*.php` decomposition created a large new cross-module surface that needs
+one.
+
+Write or update a docblock whenever you add or change a function that is:
+
+- exported from a `lib/*.php` module (called across module / file boundaries), or
+- a page-handler controller function (e.g. `*_handle_post()`), or
+- non-trivial in its inputs, return shape, side effects, or preconditions.
+
+State the *contract*, not the implementation: `@param` / `@return` with precise
+types (array shapes where they matter), side effects, and preconditions the
+caller must satisfy — e.g. "caller must have run `csrf_require()`", "`$cutoff`
+must be a UTC timestamp", "must run inside a transaction". A trivial private
+helper with a self-evident signature does not need one.
+
+This is enforced **opportunistically, on changed code, at PR time** (see
+"PR-time gates"): a new or modified function on the public / cross-module
+surface that lacks a current, accurate docblock is a review finding. It does
+**not** mandate a back-fill sweep of untouched code — touch a function, leave
+it better; that is how the surface gets covered without a doc-rot-prone mass
+edit.
+
 ---
 
 ## Frontend
@@ -309,7 +335,8 @@ A PR that violates any of these gets bounced.
 7. **Migration added → run `migration-reviewer` subagent.** Confirm the FK-safe pattern from `adding-a-migration.md`. CI runs `MigrationTest` to assert no data loss.
 8. **IP/binary code touched → run `ip-binary-auditor` subagent.** Covers `ip_bin`, `network_bin`, IP parsing, subnet math, ping/scan, DB binds for binary columns.
 9. **Local three-driver gate before push.** `bash testing/bootstrap-app.sh sqlite|mysql|pgsql` then Playwright must all pass. GH Action minutes are paid; do not use CI as your test runner.
-10. **No `git push` or PR merge without explicit per-conversation authorisation.** A previous yes does not carry forward.
+10. **Public / cross-module function added or changed → it carries a current docblock.** See "Docblocks are not inline comments". A missing or stale contract docblock on changed surface code is a review finding.
+11. **No `git push` or PR merge without explicit per-conversation authorisation.** A previous yes does not carry forward.
 
 ---
 

--- a/docs/internal/design-document.md
+++ b/docs/internal/design-document.md
@@ -37,8 +37,21 @@ The table below lists the rules that protect specific code locations. **Every en
 | 19 | Raw `$_GET` / `$_POST` IPs must pass through `normalize_ip()` before reaching `proc_open()` or `fsockopen()`. Semgrep rule `ipam-proc-open-safe` enforces. | `Simple-PHP-IPAM/lib.php` scanner helpers, `.semgrep/rules.yml` | IP-injection class of bugs (shell-quote escape into ping/scan argv) |
 | 20 | `addresses.mac` is free-form, `NOT NULL DEFAULT ''`. Never validate format server-side — users enter any notation (cisco, eui-48, vendor-specific). | `Simple-PHP-IPAM/schema.sql`; address-edit handlers | User-facing policy; format validators were tried twice and reverted both times |
 | 21 | No `global $config;` in extracted `lib/*.php` modules — they read config via the `ipam_config()` / `ipam_config_nested()` accessors. `global $db` (the runtime PDO handle) is still permitted. The full sweep of remaining `global $config` sites elsewhere is tracked as #1207. | `Simple-PHP-IPAM/lib/*.php`, `Simple-PHP-IPAM/lib/config.php` | ADR-003 (v3.30.0 ADR-004 wave-1 extraction) |
+| 22 | A fresh install **never runs migrations**. `ipam_db_init()` builds a new database directly from the `schema.*.sql` files, then stamps every known migration as already-applied; `apply_migrations()` runs **only** on upgrades of an existing install. **Consequence:** a migration that seeds or backfills *data* (not just DDL) will never execute on a fresh install — that data must *also* be present in the `schema.*.sql` files (or produced by PHP defaults at runtime), or fresh installs get nothing. A migration is a safe place for an *upgrade-only* data change and nowhere else. | `Simple-PHP-IPAM/lib.php` `ipam_db_init` / `apply_migrations`; `schema.*.sql` | v3.30.0 — the `setting_definitions` table was populated only by a data-seeding migration, so it was empty on every fresh install of every engine; the table was withdrawn (ADR-001 Option D) after the multi-engine gate exposed it |
 
 Cross-release rollup of lessons that did not become invariants (because they're advice, not enforceable rules at a code location) lives in `lessons-learned.md`.
+
+---
+
+## Subsystem hazards
+
+Not invariants — these are *traps*. A subsystem has **two of something**, or a name means **two things**. Misreading one of these has cost real time. Check here before assuming there is exactly one of X.
+
+- **There are two front-end drawer systems.** The slide-in *form-drawer* (`assets/app.js`, #247 — `data-open-drawer` triggers; *moves* a `.drawer-form-card` node into `#form-drawer`) and the *IpamDrawer* global-drawer (#517 — `data-drawer-tpl` / `data-drawer-url` triggers; clones a template or fetches a partial into `#global-drawer`). They coexist on the same pages and historically shared the `data-drawer-title` attribute, which let one trigger fire *both* (an empty drawer stacked on the real one). Consolidation onto one implementation is tracked as **#1243**. Until then: a drawer trigger belongs to exactly one system — never give it attributes from both.
+
+- **A settings-registry entry carries two type fields.** `ipam_setting_definitions()` enriches each entry with `storage_type` (the 4-value *storage* type — `string|int|bool|json` — how the value is encoded in the `settings` table) **and** `logical_type` (the 11-value *logical* type — `string,int,bool,json,enum,secret,url,email,timezone,cidr,datetime` — how the value is validated and rendered). They are not interchangeable: storage drives encode/decode, logical drives `ipam_setting_validate()` dispatch and the settings-form widget. The raw registry `type` key is the *storage* type. There is **no** `setting_definitions` database table — the registry is pure PHP (ADR-001 Option D).
+
+- **On the production install, the on-disk `data/ipam.sqlite` is stale and unused.** Prod runs on MySQL; the SQLite file is a leftover. Always verify migration/schema state against the live MySQL `schema_migrations`, never the disk file. (Also in `release-workflow.md` Phase 4.)
 
 ---
 

--- a/docs/superpowers/plans/2026-05-15-v3.30.0.md
+++ b/docs/superpowers/plans/2026-05-15-v3.30.0.md
@@ -1,5 +1,11 @@
 # v3.30.0 — Refactor wave 1 (lib.php decomposition + ADR-001 schema + ADR-002 prefs) — Implementation Plan
 
+> ⚠️ **ARCHIVED — STALE. Historical record only. Do NOT use this document to understand how the code works.**
+>
+> v3.30.0 shipped 2026-05-17. This plan was written up-front on 2026-05-15 and its premises diverged from reality repeatedly during execution — most notably: the `setting_definitions` DB table (designed here, then withdrawn — ADR-001 was reversed to Option D); `site_theme` (this plan and ADR-002 assumed it was a `settings` row — it was a `users.theme` column); #1122 "Bug Y" (assumed unfixed — already fixed in v3.27.2); #891 depth-limit enforcement (assumed to exist — it does not). Treat **every** factual claim here about current behaviour as unverified.
+>
+> **Authoritative sources instead:** the ADRs (`docs/internal/architecture-decisions/`), `design-document.md` (invariants + subsystem hazards), `data-dictionary.md`, and `CHANGELOG.md` `[3.30.0]`. Kept only as a record of what was planned and how it diverged — a cautionary example for future release planning.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship v3.30.0 = (a) full ADR-004 wave-1 lib.php decomposition — 12 new modules under `Simple-PHP-IPAM/lib/` (utils, ip, config, db, audit, presentation, settings, user_preferences, auth, auth_password, auth_rate_limit, auth_recaptcha); (b) ADR-001 part 1 — new `setting_definitions` schema, drop `settings.type` column, dispatch refactor (no crypto); (c) ADR-002 — new `user_preferences` table + `/api/user_preference` endpoint, site_theme migrated; (d) ADR-003 foundation — `ipam_config()` accessor in `lib/config.php`, scope-bounded to extracted modules only; (e) ADR-006 — `testing/scripts/memory-audit.sh` audit script + ADR graph entity backfill; (f) milestone #56 follow-on issues Sean called out (#917-#921, #1122; verify #1120). Full milestone #56 (19 open + ~12 new ADR-derived issues).

--- a/tests/Migration/FreshInstallSeedParityTest.php
+++ b/tests/Migration/FreshInstallSeedParityTest.php
@@ -1,0 +1,254 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\Migration;
+
+use PDO;
+
+/**
+ * FreshInstallSeedParityTest — guards design-document invariant #22.
+ *
+ * THE BUG CLASS THIS CATCHES
+ * --------------------------
+ * A fresh install **never runs migrations**. `ipam_db_init()` builds the
+ * database directly from `schema.*.sql` and then stamps every known migration
+ * as already-applied; `apply_migrations()` runs **only** when an existing
+ * install is upgraded. A migration is therefore a safe place for an
+ * *upgrade-only* data change and nowhere else.
+ *
+ * The v3.30.0 `setting_definitions` regression was exactly this: the table was
+ * created by `schema.*.sql` (so it existed on fresh installs) but populated
+ * only by a data-seeding migration. Fresh installs got the table created and
+ * empty — the seed data never arrived — while upgraded installs replayed the
+ * migration and got the rows. The general failure mode: *a migration populates
+ * a reference / seed table, but the fresh-install schema files do not carry
+ * that seed data, so fresh installs silently lack it.*
+ *
+ * WHAT THIS TEST DOES
+ * -------------------
+ *   1. Builds a **fresh-install** database the real way — `ipam_db_init()` on
+ *      an empty handle, which runs `schema.sql` and stamps migrations.
+ *   2. Builds a **migrated** database — the v2.0.0 pre-vrf baseline (see
+ *      Base::makePreVrfDb()) put through the full `apply_migrations()` chain,
+ *      i.e. the upgrade path. Row counts are captured *before* and *after*
+ *      `apply_migrations()` so the test isolates rows the migration chain
+ *      itself inserted from sample rows the baseline fixture pre-loaded.
+ *   3. For every table that a migration *populated* (post-migration count
+ *      higher than pre-migration count), FAILS if the fresh DB has zero rows —
+ *      that table carries seed / reference data on upgrades that fresh installs
+ *      never receive.
+ *
+ * THE ALLOWLIST IS THE FORCING FUNCTION
+ * -------------------------------------
+ * Some tables are *legitimately* empty on a fresh install (runtime / user data,
+ * or backfill-only targets) yet may be non-empty in the migrated baseline
+ * because the baseline fixture seeds sample rows. Those — and only those — are
+ * allowlisted below, each with a documented reason. A future migration that
+ * seeds a new reference table without also adding the data to `schema.*.sql`
+ * will fail this test until someone consciously either fixes the schema files
+ * or adds the table to the allowlist with a justification.
+ *
+ * SQLite-only by design — `ipam_db_init()` reads `schema.sql` for SQLite.
+ * Multi-engine fresh-install coverage lives in
+ * MigrationFreshInstallMultiDriverTest.
+ */
+final class FreshInstallSeedParityTest extends Base
+{
+    /**
+     * Tables that are allowed to have rows in the migrated baseline DB while
+     * being empty on a fresh install. Each entry MUST document *why* it is a
+     * legitimate exception — i.e. the table holds runtime / user / backfill
+     * data, not seed or reference data that fresh installs need.
+     *
+     * Anything NOT on this list is treated as seed / reference data: if it is
+     * populated on the upgrade path it MUST also be populated on fresh install.
+     *
+     * @var array<string, string>
+     */
+    private const ALLOWLIST = [
+        // schema_migrations is bookkeeping, not application data. A fresh
+        // install stamps every version; an upgrade INSERTs each version as the
+        // chain replays — so the migration chain "populates" it by design.
+        // It is data-engine state, never seed/reference data, and a fresh
+        // install always has it populated. Excluded on principle.
+        'schema_migrations' => 'Migration bookkeeping — populated on both paths, never seed data.',
+
+        // users is user data. apply_migrations() may INSERT a seeded admin on
+        // the upgrade path; a fresh install seeds exactly one bootstrap admin
+        // via ipam_db_init_bootstrap_admin(). Either way the row(s) are
+        // operator accounts, not reference data — fresh installs create their
+        // own, so a fresh-vs-migrated row-presence gap here is not a defect.
+        'users' => 'Bootstrap admin / operator accounts — runtime user data, fresh install seeds its own.',
+
+        // audit_log is append-only event data, not seed/reference data. Some
+        // migrations INSERT an audit row to record an upgrade-only data fixup
+        // (e.g. the alert.recipient_user_ids auto-migration emits a
+        // 'settings.auto_migrate_alert_email' row). Those rows describe an
+        // event that, by definition, only happened on an upgrade — a fresh
+        // install never had the legacy value to migrate. Zero audit rows on a
+        // fresh install is correct; the application writes them at runtime.
+        'audit_log' => 'Append-only event log — upgrade-fixup rows describe events that never occur on fresh installs.',
+
+        // settings IS populated by a seed migration on the upgrade path, yet a
+        // fresh install legitimately leaves it EMPTY. This is the subtle case
+        // and the reason the allowlist demands a justification: setting values
+        // have a PHP-defaults runtime fallback. ipam_setting() resolves any
+        // absent key from ipam_setting_definitions() ($def['default']), so an
+        // empty settings table is fully functional on a fresh install — the
+        // PHP registry is the source of truth invariant #22 explicitly allows
+        // ("...or produced by PHP defaults at runtime").
+        //
+        // CONTRAST WITH THE BUG THIS TEST GUARDS: the v3.30.0 setting_definitions
+        // table had NO such runtime fallback — code read it straight from the
+        // DB — so an empty table on a fresh install was a real defect. Such a
+        // table is NOT allowlistable in good conscience and this test would
+        // flag it. Only allowlist a migration-seeded table here if its data is
+        // genuinely reproducible at runtime without the DB rows.
+        'settings' => 'Seeded on upgrade, but ipam_setting() falls back to the PHP registry default for any absent key — empty table is functional on fresh install (invariant #22 "PHP defaults at runtime").',
+    ];
+
+    public function testFreshInstallCarriesEverySeedTableThatUpgradesGet(): void
+    {
+        $fresh = $this->buildFreshInstallDb();
+
+        // Build the migrated DB capturing row counts BEFORE and AFTER the
+        // migration chain. The "before" snapshot is the sample data the
+        // pre-vrf baseline fixture pre-loads (e.g. demo subnets/addresses);
+        // the "after" snapshot reflects what the migration chain added on top.
+        // Comparing the two isolates rows that migrations themselves INSERTed —
+        // which is exactly the seed/reference data a fresh install must also
+        // receive from schema.*.sql.
+        $migrated      = $this->makePreVrfDb();
+        $beforeCounts  = $this->tableRowCounts($migrated);
+        \apply_migrations($migrated);
+        $afterCounts   = $this->tableRowCounts($migrated);
+
+        $freshCounts = $this->tableRowCounts($fresh);
+
+        $gaps = [];
+        foreach ($afterCounts as $table => $afterRows) {
+            $beforeRows = $beforeCounts[$table] ?? 0;
+            // Only consider tables the migration chain itself populated:
+            // post-migration count strictly greater than pre-migration count.
+            // Tables the baseline fixture pre-seeded (subnets, addresses,
+            // audit_log sample rows) show no migration-driven growth and are
+            // ignored — they are fixture noise, not migration seed data.
+            if ($afterRows <= $beforeRows) {
+                continue;
+            }
+            if (array_key_exists($table, self::ALLOWLIST)) {
+                continue; // legitimately runtime/user data — documented above
+            }
+            $freshRows = $freshCounts[$table] ?? 0;
+            if ($freshRows === 0) {
+                $gaps[] = sprintf(
+                    "  - %s: migration chain inserted %d row(s), fresh-install has 0",
+                    $table,
+                    $afterRows - $beforeRows
+                );
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $gaps,
+            "Fresh-install seed-data gap (design-document invariant #22).\n"
+            . "The following tables are populated on the migrated-upgrade path "
+            . "but EMPTY on a fresh install:\n"
+            . implode("\n", $gaps) . "\n\n"
+            . "A fresh install never runs migrations — it builds from schema.*.sql "
+            . "and stamps migrations as applied. A migration that seeds a "
+            . "reference/seed table therefore never runs on fresh installs.\n"
+            . "Fix: add the seed data to schema.sql / schema.mysql.sql / "
+            . "schema.pgsql.sql (or produce it from PHP defaults at runtime). "
+            . "If the table genuinely holds runtime/user data, add it to "
+            . "FreshInstallSeedParityTest::ALLOWLIST with a documented reason."
+        );
+    }
+
+    /**
+     * Sanity guard: the comparison is only meaningful if the migrated baseline
+     * actually populates at least one seed table. If this ever drops to zero
+     * the fixture has drifted and the parity test above would pass vacuously.
+     */
+    public function testMigratedBaselineActuallyHasSeedData(): void
+    {
+        $migrated = $this->buildMigratedDb();
+        $settings = (int) $migrated
+            ->query('SELECT COUNT(*) FROM settings')
+            ->fetchColumn();
+
+        $this->assertGreaterThan(
+            0,
+            $settings,
+            "Migrated baseline has no seeded settings rows — the pre-vrf "
+            . "fixture or the settings-seed migration has drifted, and "
+            . "testFreshInstallCarriesEverySeedTableThatUpgradesGet would "
+            . "pass vacuously."
+        );
+    }
+
+    /**
+     * Build a fresh-install database the production way: an empty SQLite
+     * handle put through ipam_db_init(), which runs schema.sql and stamps
+     * every migration. This is the exact code path a brand-new deployment
+     * takes — migrations are NEVER executed.
+     */
+    private function buildFreshInstallDb(): PDO
+    {
+        $db = $this->makeDb();
+
+        $hadConfig  = array_key_exists('config', $GLOBALS);
+        $prevConfig = $GLOBALS['config'] ?? null;
+        // ipam_db_init_bootstrap_admin() reads the bootstrap admin config.
+        $GLOBALS['config'] = [
+            'proxy_trust'     => false,
+            'bootstrap_admin' => ['username' => 'admin', 'password' => 'changeme-test-123!'],
+        ];
+        try {
+            \ipam_db_init($db);
+        } finally {
+            if ($hadConfig) {
+                $GLOBALS['config'] = $prevConfig;
+            } else {
+                unset($GLOBALS['config']);
+            }
+        }
+        return $db;
+    }
+
+    /**
+     * Build a migrated database: the v2.0.0 pre-vrf baseline (Base::makePreVrfDb)
+     * put through the full apply_migrations() chain — i.e. the upgrade path an
+     * existing install takes.
+     */
+    private function buildMigratedDb(): PDO
+    {
+        $db = $this->makePreVrfDb();
+        \apply_migrations($db);
+        return $db;
+    }
+
+    /**
+     * Row count for every user table in the SQLite database, keyed by table
+     * name. Tables that fail to count (should not happen) are skipped.
+     *
+     * @return array<string, int>
+     */
+    private function tableRowCounts(PDO $db): array
+    {
+        /** @var list<string> $tables */
+        $tables = $db
+            ->query("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+            ->fetchAll(PDO::FETCH_COLUMN);
+
+        $out = [];
+        foreach ($tables as $table) {
+            $out[$table] = (int) $db
+                ->query('SELECT COUNT(*) FROM "' . str_replace('"', '', $table) . '"')
+                ->fetchColumn();
+        }
+        ksort($out);
+        return $out;
+    }
+}


### PR DESCRIPTION
Internal-quality work, **no behaviour change** — documentation, one test, and docblocks. No version bump, no bundle, no release; these ride to users with the next release.

Prompted by the v3.30.0 retrospective: several missteps came from *stale planning docs* and *non-obvious architecture*, not under-documented code. This closes the genuine gaps.

### Changes
- **`design-document.md` invariant #22** — a fresh install never runs migrations (`ipam_db_init()` builds from `schema.*.sql` and stamps them); a data-seeding migration therefore never executes on fresh installs. This is the `setting_definitions` root cause, now a load-bearing rule.
- **`design-document.md` "Subsystem hazards"** — the two drawer systems, the `storage_type` vs `logical_type` settings split, the stale prod `data/ipam.sqlite`.
- **`FreshInstallSeedParityTest`** — fresh-install vs migrated-upgrade seed-data parity; an allowlist (each entry justified) is the forcing function. The executable check that would have caught `setting_definitions`.
- **`coding-guide.md`** — "Docblocks are not inline comments": contract docblocks expected on the `lib/*.php` cross-module surface, enforced opportunistically on changed code at PR time (gate item #10).
- **~40 contract docblocks** across `lib/{utils,ip,db,audit,presentation,auth,auth_rate_limit}.php`.
- **`CLAUDE.md`** — fix stale shipped-version (v3.29.0 → v3.30.0) and invariant count.
- v3.30.0 plan doc marked **ARCHIVED/STALE**; **#908** closed as superseded by ADR-001 Option D.

### Verification
Static gate green — phpstan L9, phpcs, phpunit 1376/0, lib-module-linter. Independent review pass on the test and docblocks (both sound; 2 minor docblock imprecisions fixed). No 3-driver gate — changes are docs + docblocks + one runtime-inert test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal coding guidelines clarifying documentation requirements for exported functions.
  * Expanded design documentation with fresh install invariant and subsystem hazards section.
  * Improved function documentation across core modules.

* **Tests**
  * Added new test to verify data seeding consistency between fresh installations and migration paths.

* **Chores**
  * Updated version to v3.30.0.
  * Marked v3.30.0 plan as archived with historical reference notice.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/seanmousseau/Simple-PHP-IPAM/pull/1246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->