### PR TITLE
v3.34.0 wave 3 (part 1): icons.svg audit + dead-code removal (closes #940, #942)

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -158,6 +158,10 @@ jobs:
         if: always()
         run: php testing/scripts/migration-linter.php
 
+      - name: icons.svg audit (#942)
+        if: always()
+        run: php tools/audit-icons-svg.php
+
       # ----- MySQL slot only: test_api.sh against php -S backed by MySQL -----
       #
       # Runs the full ~150-assertion API regression suite against a fresh

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -2462,33 +2462,6 @@ var IpamDrawer = (function () {
     }
 }());
 
-// IpamVirtualTable — utility for future viewport-based row rendering
-function IpamVirtualTable(containerId, rows, rowHeight, renderRow) {
-    var container = document.getElementById(containerId);
-    if (!container) return;
-    var scroller = container.querySelector(".vt-scroll");
-    var tbody = container.querySelector("tbody");
-    if (!scroller || !tbody) return;
-
-    var OVERSCAN = 5;
-    scroller.style.height = (rows.length * rowHeight) + "px";
-
-    function render() {
-        var scrollTop = container.scrollTop;
-        var clientHeight = container.clientHeight;
-        var start = Math.max(0, Math.floor(scrollTop / rowHeight) - OVERSCAN);
-        var end = Math.min(rows.length, Math.ceil((scrollTop + clientHeight) / rowHeight) + OVERSCAN);
-        tbody.style.transform = "translateY(" + (start * rowHeight) + "px)";
-        while (tbody.firstChild) tbody.removeChild(tbody.firstChild);
-        for (var i = start; i < end; i++) {
-            tbody.appendChild(renderRow(rows[i], i));
-        }
-    }
-
-    container.addEventListener("scroll", render, { passive: true });
-    render();
-}
-
 // ─── Site filter strip (#629) ─────────────────────────────────────────────────
 // Pill-based client-side filter for subnets.php.
 // Filter state is stored in sessionStorage so a page reload restores the last

--- a/Simple-PHP-IPAM/assets/icons.svg
+++ b/Simple-PHP-IPAM/assets/icons.svg
@@ -20,9 +20,6 @@
   <symbol id="icon-chevron-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <path d="m19.5 8.25-7.5 7.5-7.5-7.5"/>
   </symbol>
-  <symbol id="icon-user-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
-  </symbol>
   <symbol id="icon-key" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <path d="M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 0 1 21.75 8.25Z"/>
   </symbol>
@@ -106,9 +103,6 @@
   </symbol>
   <symbol id="icon-health" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <path d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/>
-  </symbol>
-  <symbol id="icon-backup" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="m20.25 7.5-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z"/>
   </symbol>
   <symbol id="icon-database" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
     <path d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 2.625c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125m16.5 5.625c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125"/>

--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -395,7 +395,7 @@ if (current_user()['role'] === 'admin'):
     }
 ?>
 <div class="card" data-widget="backups" style="margin-top:1.25rem">
-  <div class="card-header"><h2><?= icon('archive-box') ?> Backups</h2></div>
+  <div class="card-header"><h2><?= icon('server-stack') ?> Backups</h2></div>
   <?php if ($bdCount === 0): ?>
     <p class="muted">No backup destinations configured yet.</p>
     <a href="backup_admin.php?tab=destinations" class="action-pill">Configure backups</a>

--- a/Simple-PHP-IPAM/views/settings_group_form.php
+++ b/Simple-PHP-IPAM/views/settings_group_form.php
@@ -211,8 +211,8 @@ $groupLabel = to_str($groupMeta['label'] ?? $groupKey);
                         data-pw-toggle-for="<?= e($inputId) ?>"
                         <?php if ($isSet): ?>data-pw-reveal-key="<?= e($key) ?>" data-pw-reveal-csrf="<?= e(csrf_token()) ?>"<?php endif; ?>
                         aria-label="Show password" aria-pressed="false">
-                  <svg class="pw-eye pw-eye--open" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-                  <svg class="pw-eye pw-eye--closed" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17.94 17.94A10.94 10.94 0 0 1 12 20c-7 0-11-8-11-8a19.77 19.77 0 0 1 5.06-5.94"/><path d="M9.9 4.24A10.94 10.94 0 0 1 12 4c7 0 11 8 11 8a19.77 19.77 0 0 1-3.17 4.19"/><path d="M14.12 14.12A3 3 0 1 1 9.88 9.88"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                  <?= icon('eye', 'pw-eye pw-eye--open') ?>
+                  <?= icon('eye-slash', 'pw-eye pw-eye--closed') ?>
                 </button>
               </span>
               <span class="badge badge-<?= e($statusCls) ?> settings-row__badge"><?= e($statusText) ?></span>

--- a/tools/audit-icons-allowlist.txt
+++ b/tools/audit-icons-allowlist.txt
@@ -1,0 +1,31 @@
+# tools/audit-icons-allowlist.txt
+#
+# Symbols defined in Simple-PHP-IPAM/assets/icons.svg that don't yet have
+# callers but are kept on purpose because they're staged for an upcoming
+# UX milestone. Without this allowlist, tools/audit-icons-svg.php would fail
+# CI for these.
+#
+# One symbol per line, including the `icon-` prefix. Blank lines and lines
+# starting with `#` are ignored.
+#
+# When a symbol on this list gets its first caller, remove it from here in
+# the same PR — the audit will pass either way, but keeping the allowlist
+# tight is the point.
+
+# Theme toggle redesign — UX nav milestone #60 (suggested v3.36.0).
+# Both states needed; current theme toggle uses icon-theme as a placeholder.
+icon-moon
+icon-sun
+
+# Notification UI — UX polish milestone #62 (post-v4.0.0).
+icon-bell
+
+# Success-state primitive — UX foundation milestone #59 (suggested v3.35.0).
+# Badge primitive (#1188) will use this for inline success indicators.
+icon-check
+
+# Backup destinations: cloud / database / desktop icons for destination
+# type display. Staged for backup-admin UX work in UX cleanup milestone #63.
+icon-cloud
+icon-computer-desktop
+icon-database

--- a/tools/audit-icons-svg.php
+++ b/tools/audit-icons-svg.php
@@ -1,0 +1,187 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * audit-icons-svg.php — verify every <symbol id="icon-…"> in assets/icons.svg
+ * has at least one referencing call site, and that every site that references
+ * an icon points at a symbol that exists.
+ *
+ * Closes findings:
+ *   - D14 (#942): audit assets/icons.svg for dead symbols
+ *
+ * Why this exists. icons.svg is a 22 KB sprite shipped to every page in the
+ * <head>. Symbols that have no callers are pure dead weight — but historically
+ * have accumulated as features got renamed, redesigned, or never wired up at
+ * all. This script surfaces both kinds of drift: unused symbols (waste) and
+ * missing symbols (broken UI). It runs in CI; the gate is a non-zero exit code
+ * if either condition is true (configurable via the env vars below for the
+ * one-off migration where the sweep is happening).
+ *
+ * Reference patterns scanned:
+ *   - `icon('name', …)` / `icon("name", …)` PHP helper calls (lib/presentation.php)
+ *   - `<use href="#icon-name">` literal references (in PHP, JS, CSS)
+ *   - `xlink:href="#icon-name"` legacy form
+ *
+ * Allowlist:
+ *   tools/audit-icons-allowlist.txt — one symbol per line (icon-…), supports
+ *   `# comments` and blank lines. Symbols on the allowlist are reported as
+ *   notes ("staged for upcoming work") instead of failures. Use sparingly —
+ *   the allowlist exists for icons we deliberately ship ahead of their first
+ *   caller because we know they're coming in an upcoming UX milestone.
+ *
+ * Environment variables:
+ *   AUDIT_ICONS_ALLOW_UNUSED — if "1", unused non-allowlisted symbols are
+ *                              warnings, not failures. For one-off migrations.
+ *
+ * Exit codes:
+ *   0 — clean (or unused-only and AUDIT_ICONS_ALLOW_UNUSED=1)
+ *   1 — symbols referenced but not defined (would break UI)
+ *   2 — symbols defined but unreferenced and AUDIT_ICONS_ALLOW_UNUSED unset
+ *
+ * Usage:
+ *   php tools/audit-icons-svg.php             # full audit, fails on either drift
+ *   AUDIT_ICONS_ALLOW_UNUSED=1 php tools/audit-icons-svg.php   # report only
+ */
+
+$repoRoot      = dirname(__DIR__);
+$svgPath       = $repoRoot . '/Simple-PHP-IPAM/assets/icons.svg';
+$allowlistPath = $repoRoot . '/tools/audit-icons-allowlist.txt';
+
+$allowlist = [];
+if (is_file($allowlistPath)) {
+    foreach (file($allowlistPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') continue;
+        $allowlist[$line] = true;
+    }
+}
+
+if (!is_file($svgPath)) {
+    fwrite(STDERR, "ERROR: icons.svg not found at {$svgPath}\n");
+    exit(1);
+}
+
+$svg = (string) file_get_contents($svgPath);
+
+// Defined symbols: <symbol id="icon-…"> or <symbol id="icon-…"/>.
+$defined = [];
+if (preg_match_all('/<symbol\s+[^>]*\bid="(icon-[a-z0-9_-]+)"/i', $svg, $m)) {
+    $defined = array_values(array_unique($m[1]));
+    sort($defined);
+}
+
+// Search roots for callers. Stay within the app — never the vendor/ or
+// node_modules/ trees.
+// IMPORTANT: page entry-points (users.php, sites.php, addresses.php, …) live
+// at the top level of Simple-PHP-IPAM/, NOT under views/. Scanning the whole
+// Simple-PHP-IPAM/ subtree and pruning vendor/node_modules. Skipping the
+// Simple-PHP-IPAM/assets/vendor/ tree — third-party CSS may legitimately
+// contain unrelated `icon-*` class names that aren't sprite references.
+$searchRoots = [
+    $repoRoot . '/Simple-PHP-IPAM',
+];
+$excludeDirs = [
+    $repoRoot . '/Simple-PHP-IPAM/assets/vendor',
+    $repoRoot . '/Simple-PHP-IPAM/assets/fonts',
+];
+
+$used = [];
+$iterFiles = function (string $root) use ($excludeDirs, $svgPath): \Generator {
+    if (is_file($root)) {
+        yield $root;
+        return;
+    }
+    if (!is_dir($root)) {
+        return;
+    }
+    $rii = new \RecursiveIteratorIterator(
+        new \RecursiveCallbackFilterIterator(
+            new \RecursiveDirectoryIterator($root, \RecursiveDirectoryIterator::SKIP_DOTS),
+            function ($current) use ($excludeDirs) {
+                if (!$current->isDir()) return true;
+                foreach ($excludeDirs as $ex) {
+                    if (rtrim($current->getPathname(), '/') === rtrim($ex, '/')) return false;
+                }
+                return true;
+            }
+        )
+    );
+    foreach ($rii as $f) {
+        if (!$f->isFile()) continue;
+        $ext = strtolower($f->getExtension());
+        if ($f->getPathname() === $svgPath) continue;
+        if (!in_array($ext, ['php', 'js', 'css', 'html', 'svg'], true)) continue;
+        yield $f->getPathname();
+    }
+};
+
+foreach ($searchRoots as $root) {
+    foreach ($iterFiles($root) as $file) {
+        $content = (string) file_get_contents($file);
+
+        // icon('name') / icon("name") — bare-name PHP helper.
+        if (preg_match_all('/\bicon\(\s*[\'"]([a-z0-9_-]+)[\'"]/', $content, $m)) {
+            foreach ($m[1] as $name) {
+                $used['icon-' . $name] = true;
+            }
+        }
+
+        // <use href="#icon-name"> or xlink:href="#icon-name".
+        if (preg_match_all('/(?:xlink:)?href=[\'"]#?(icon-[a-z0-9_-]+)/', $content, $m)) {
+            foreach ($m[1] as $name) {
+                $used[$name] = true;
+            }
+        }
+    }
+}
+
+$usedList = array_keys($used);
+sort($usedList);
+
+$unusedAll = array_values(array_diff($defined, $usedList));
+$missing   = array_values(array_diff($usedList, $defined));
+$unusedAllowed = array_values(array_filter($unusedAll, fn($s) => isset($allowlist[$s])));
+$unusedReal    = array_values(array_filter($unusedAll, fn($s) => !isset($allowlist[$s])));
+sort($unusedAllowed);
+sort($unusedReal);
+sort($missing);
+
+echo "=== icons.svg audit ===\n";
+echo 'defined symbols: ' . count($defined) . "\n";
+echo 'used references: ' . count($usedList) . "\n";
+echo 'unused (defined, no caller): ' . count($unusedReal) . "\n";
+echo 'allowlisted (defined, staged for upcoming): ' . count($unusedAllowed) . "\n";
+echo 'missing (called, not defined): ' . count($missing) . "\n";
+
+if ($unusedAllowed) {
+    echo "\n--- allowlisted (staged for upcoming work) ---\n";
+    foreach ($unusedAllowed as $s) echo "  {$s}\n";
+}
+
+if ($unusedReal) {
+    echo "\n--- unused symbols (candidates for removal) ---\n";
+    foreach ($unusedReal as $s) echo "  {$s}\n";
+}
+
+if ($missing) {
+    echo "\n--- MISSING symbols (UI will be broken) ---\n";
+    foreach ($missing as $s) echo "  {$s}\n";
+}
+
+if ($missing) {
+    fwrite(STDERR, "\nFAIL: " . count($missing) . " icon reference(s) point at symbols not defined in icons.svg\n");
+    exit(1);
+}
+
+if ($unusedReal) {
+    $allow = getenv('AUDIT_ICONS_ALLOW_UNUSED');
+    if ($allow === '1') {
+        echo "\nWARN: " . count($unusedReal) . " unused symbol(s) — allowed because AUDIT_ICONS_ALLOW_UNUSED=1.\n";
+        exit(0);
+    }
+    fwrite(STDERR, "\nFAIL: " . count($unusedReal) . " unused symbol(s) — delete them from icons.svg, add them to tools/audit-icons-allowlist.txt, or set AUDIT_ICONS_ALLOW_UNUSED=1 during a migration.\n");
+    exit(2);
+}
+
+echo "\nclean.\n";
+exit(0);


### PR DESCRIPTION
First chunk of v3.34.0 Refactor Wave 3 (#58). Closes two issues + fixes a real bug surfaced by the audit; the bigger app.js modularization (#939) and drawer consolidation (#1243) follow in subsequent PRs.

## Summary

- **Adds `tools/audit-icons-svg.php`** — scans `icons.svg` for `<symbol id="icon-*">` entries and the codebase for `icon('name')` PHP helper calls + `<use href="#icon-name">` sprite references. Exits non-zero if a referenced symbol is undefined (broken UI) or a defined symbol has no caller (dead weight). Allowlist file (`tools/audit-icons-allowlist.txt`) covers symbols deliberately shipped ahead of their first caller. Wired into `php-qa.yml`.
- **Fixes a real UI bug** — `dashboard.php:398` called `icon('archive-box')` which the sprite never defined, so the Backups card on the dashboard rendered an empty 16×16 box. Swapped to `icon('server-stack')` to match the sidebar's Backup & Restore entry.
- **Sprite consistency** — `settings_group_form.php` password show/hide toggle was rendering inline SVG path data for the eye icons instead of using the project's `icon()` helper like everywhere else. Converted to `icon('eye', 'pw-eye pw-eye--open')` / `icon('eye-slash', 'pw-eye pw-eye--closed')`. CSS toggle (`.pw-toggle[aria-pressed="true"]`) keeps working because class hooks survive via the helper's `$cls` parameter.
- **Dead-code removal** — deletes `icon-backup` + `icon-user-circle` symbols from `icons.svg` (both replaced years ago; zero callers). Deletes `IpamVirtualTable` function from `app.js` (zero callers; closes #940).
- **icons.svg size**: 22,445 → 21,632 bytes (-813 shipped to every page).

## Closes

- #942 (D14 — audit assets/icons.svg for dead symbols)
- #940 (D5 — wire up or delete IpamVirtualTable)

## Still to do for milestone #58

- #939 — split `assets/app.js` into per-concern modules (anchor — own PR)
- #1047 — test umbrella for app.js modularization (lands with #939)
- #1243 — consolidate the two drawer implementations
- #946, #947, #948 — A.P3 carry-overs
- #952 — `api.php` P2 polish
- #949, #950, #951 — A.P3 / B.P3 / C.P3 nit umbrellas
- #943, #944, #945 — build/CI items
- #775 — dashboard VR restoration

## Notes

- Issue #941 (the original "reconcile CSS variables with Open Props") was found to be filed on a wrong premise (OP not actually loaded). Captured in ADR-007 (PR #1260) and reframed to milestone #60. **#941 is no longer in this milestone's scope.**
- The 7 allowlisted icons (`bell`, `check`, `cloud`, `computer-desktop`, `database`, `moon`, `sun`) are deliberately staged for UX foundation (#59), UX nav (#60), UX polish (#62), and UX cleanup (#63) work — comments in the allowlist file document the intended target milestone for each.

## Test plan

- [ ] Local static gate passed: PHPUnit (1517/1517), PHPStan (no errors), PHPCS (clean), icon audit (clean)
- [ ] CI 3-driver (sqlite/mysql/mariadb/pgsql) + Playwright passes
- [ ] Manual: dashboard.php Backups card renders the server-stack icon (no empty box)
- [ ] Manual: settings.php sensitive field eye toggle still works (show/hide, reveal-from-stored on first click, clear on hide)
- [ ] Manual: icon audit script in CI fails if a random symbol is added with no caller and not allowlisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)