### PR TITLE
v3.34.0 wave 3 (part 2): consolidate drawers onto IpamDrawer (closes #1243)

### DIFF
--- a/Simple-PHP-IPAM/addresses.php
+++ b/Simple-PHP-IPAM/addresses.php
@@ -574,7 +574,7 @@ ipam_skeleton_flush();
       <button class="action-pill" data-drawer-title="Add Address" data-drawer-tpl="tpl-add-address"><?= icon('plus') ?> Add Address <kbd class="kbd-hint">⌘N</kbd></button>
       <a class="action-pill" href="bulk_update.php?subnet_id=<?= (int)$selectedSubnetId ?>"><?= icon('pencil') ?> Bulk Update</a>
       <?php if ($missingInfra): ?>
-        <a class="action-pill" href="#reserve-infra" data-open-drawer="reserve-infra" data-drawer-title="Reserve Infrastructure IPs"><?= icon('shield') ?> Reserve Infra IPs</a>
+        <button type="button" class="action-pill" data-drawer-title="Reserve Infrastructure IPs" data-drawer-tpl="tpl-reserve-infra"><?= icon('shield') ?> Reserve Infra IPs</button>
       <?php endif; ?>
     <?php endif; ?>
     <?php if ($selectedSubnet && to_int($selectedSubnet['ip_version']) === 4): ?>
@@ -666,8 +666,7 @@ ipam_skeleton_flush();
 ]) ?></div>
 
 <?php if ($missingInfra && $selectedSubnet): ?>
-<div class="card mt-16 drawer-form-card" id="reserve-infra">
-  <h2>Reserve infrastructure IPs</h2>
+<div id="tpl-reserve-infra" style="display:none">
   <p class="muted">Creates reserved address records for the network and broadcast addresses (determined from the CIDR). Gateway is optional — enter an IP if this subnet has a known gateway.</p>
   <form method="post" action="addresses.php">
     <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">

--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -979,35 +979,8 @@ body.nav-open .nav-drawer-overlay{display:block}
 .status-badge.status-reserved{color:var(--warn)}
 .status-badge.status-free{color:var(--muted)}
 
-/* ---- Slide-in form drawer (#247) ---- */
-#form-drawer{
-  position:fixed;top:0;right:0;bottom:0;width:440px;max-width:95vw;
-  background:var(--card);border-left:1px solid var(--border);
-  z-index:var(--z-drawer);overflow-y:auto;padding:var(--space-10);
-  transform:translateX(100%);transition:transform .22s ease;
-  display:flex;flex-direction:column;gap:var(--space-8);
-  visibility:hidden;pointer-events:none;
-}
-#form-drawer.drawer--open{transform:translateX(0);visibility:visible;pointer-events:auto}
-.form-drawer-overlay{
-  display:none;position:fixed;inset:0;background:rgba(0,0,0,.25);z-index:var(--z-drawer-overlay);
-}
-.form-drawer-overlay.visible{display:block}
-#form-drawer .drawer-header{
-  display:flex;align-items:center;justify-content:space-between;
-  border-bottom:1px solid var(--border);padding-bottom:var(--space-6);
-}
-#form-drawer .drawer-title{margin:0;font-size:var(--font-size-6xl);font-weight:700}
-#form-drawer .drawer-close-btn{
-  background:none;border:none;cursor:pointer;font-size:1.3rem;
-  color:var(--muted);padding:var(--space-1) var(--space-3);
-}
-.drawer-form-card{display:none}
-body.drawer-ready .drawer-form-card{display:none}
-@media(max-width:600px){
-  #form-drawer{width:100vw;top:auto;height:85vh;transform:translateY(100%)}
-  #form-drawer.drawer--open{transform:translateY(0)}
-}
+/* Slide-in form-drawer (#247) was retired in v3.34.0 (#1243); all drawer
+   styles now live under IpamDrawer's `.drawer` / `#global-drawer` rules. */
 
 /* ---- Tag badges ---- */
 /* #869: background fed via the --tag-bg custom property set on the inline
@@ -1227,9 +1200,6 @@ td[data-editable].cell-saving{opacity:.5;}
 
 /* Contact typeahead: parent needs position:relative for absolute dropdown */
 .contact-typeahead-wrap{position:relative;}
-
-/* Form visible inside drawer (overrides body.drawer-ready .drawer-form-card{display:none}) */
-#form-drawer-body .drawer-form-card{display:block;}
 
 /* Utilization bar widths via data-pct attribute (replaces JS el.style.width) */
 .util-bar-fill[data-pct="0"]{width:0%}

--- a/Simple-PHP-IPAM/assets/app.js
+++ b/Simple-PHP-IPAM/assets/app.js
@@ -654,50 +654,14 @@
       });
     });
 
-    // --- Slide-in form drawer (#247) ---
-    var formDrawer = document.getElementById("form-drawer");
-    var formDrawerOverlay = document.querySelector(".form-drawer-overlay");
-    if (formDrawer) {
-      document.body.classList.add("drawer-ready");
-      function openFormDrawer(triggerId) {
-        var src = document.getElementById(triggerId);
-        if (!src) return;
-        var body = document.getElementById("form-drawer-body");
-        if (!body) return;
-        // Clear drawer body safely, then move source content in
-        while (body.firstChild) body.removeChild(body.firstChild);
-        body.appendChild(src);
-        formDrawer.classList.add("drawer--open");
-        if (formDrawerOverlay) formDrawerOverlay.classList.add("visible");
-      }
-      function closeFormDrawer() {
-        formDrawer.classList.remove("drawer--open");
-        if (formDrawerOverlay) formDrawerOverlay.classList.remove("visible");
-      }
-      if (formDrawerOverlay) formDrawerOverlay.addEventListener("click", closeFormDrawer);
-      var drawerCloseBtn = formDrawer.querySelector(".drawer-close-btn");
-      if (drawerCloseBtn) drawerCloseBtn.addEventListener("click", closeFormDrawer);
-      document.addEventListener("keydown", function(e) { if (e.key === "Escape") closeFormDrawer(); });
-      // Wire up any [data-open-drawer] triggers
-      document.querySelectorAll("[data-open-drawer]").forEach(function(trigger) {
-        trigger.addEventListener("click", function(e) {
-          e.preventDefault();
-          var titleEl = formDrawer.querySelector(".drawer-title");
-          if (titleEl && trigger.dataset.drawerTitle) titleEl.textContent = trigger.dataset.drawerTitle;
-          openFormDrawer(trigger.dataset.openDrawer);
-        });
-      });
-    }
-
     // --- "Use next IP" fill helper (data-fill-ip on addresses.php) ---
-    // The link also appears in the Add Address drawer, whose body is a
-    // bare .drawer-body (no .card / .drawer-form-card wrapper), so accept
-    // that as a scoping container too.
+    // The link can appear inside the global drawer body (Add Address /
+    // Reserve Infra IPs) or alongside a sibling card on the page.
     document.addEventListener("click", function(e) {
       var el = e.target.closest("[data-fill-ip]");
       if (!el) return;
       e.preventDefault();
-      var card = el.closest(".drawer-form-card, .card, .drawer-body");
+      var card = el.closest(".card, .drawer-body");
       if (!card) return;
       var inp = card.querySelector('input[name="ip"]');
       if (inp) { inp.value = el.dataset.fillIp; inp.focus(); }
@@ -1301,7 +1265,7 @@
     /* ---- Subnet edit drawer (#567) ---- */
     (function() {
       var editDrawer = document.getElementById("subnet-edit-drawer");
-      if (!editDrawer || !formDrawer) return;
+      if (!editDrawer) return;
 
       var siteWrap = document.getElementById("subnet-edit-site-wrap");
       var siteLocked = document.getElementById("subnet-edit-site-locked");
@@ -1398,17 +1362,7 @@
           });
         }
 
-        editDrawer.hidden = false;
-        var titleEl = formDrawer.querySelector(".drawer-title");
-        if (titleEl) titleEl.textContent = "Edit " + d.cidr;
-        var body = document.getElementById("form-drawer-body");
-        if (body) {
-          while (body.firstChild) body.removeChild(body.firstChild);
-          body.appendChild(editDrawer);
-        }
-        formDrawer.classList.add("drawer--open");
-        var overlay = document.querySelector(".form-drawer-overlay");
-        if (overlay) overlay.classList.add("visible");
+        IpamDrawer.openNode("Edit " + d.cidr, editDrawer);
       });
     }());
 
@@ -2189,6 +2143,31 @@ var IpamDrawer = (function () {
         else drawer.focus();
     }
 
+    // openNode — like open(), but accepts a DOM node and MOVES it (rather
+    // than copying innerHTML). Use when the content has JS-attached
+    // behaviour that must survive the drawer open: bound event listeners,
+    // imperatively populated values, references held in closures (e.g. the
+    // subnets edit drawer's tag select, custom-field inputs, and typeahead
+    // pickers). innerHTML cloning would lose all of that. Caller may pass
+    // either an Element or an id string. The node is set non-hidden after
+    // it lands in the drawer; previous body content is discarded.
+    function openNode(title, nodeOrId) {
+        _init();
+        var node = (typeof nodeOrId === 'string') ? document.getElementById(nodeOrId) : nodeOrId;
+        if (!node) return;
+        _lastFocus = document.activeElement;
+        while (bodyEl.firstChild) bodyEl.removeChild(bodyEl.firstChild);
+        node.hidden = false;
+        bodyEl.appendChild(node);
+        titleEl.textContent = title;
+        overlay.classList.add('is-visible');
+        drawer.classList.add('is-open');
+        drawer.setAttribute('aria-hidden', 'false');
+        var focusable = _getFocusable();
+        if (focusable.length) focusable[0].focus();
+        else drawer.focus();
+    }
+
     function close() {
         if (!drawer) return;
         drawer.classList.remove('is-open');
@@ -2199,11 +2178,11 @@ var IpamDrawer = (function () {
 
     // Event delegation — handle [data-drawer-tpl] buttons (CSP-safe, no onclick).
     // Match on data-drawer-tpl (the template-id content source), NOT on
-    // data-drawer-title: a bare data-drawer-title is just a label and is also
-    // consumed by the slide-in form-drawer (#247) for its own title. Claiming
-    // every [data-drawer-title] element opened an empty global-drawer on top of
-    // those triggers' real drawer (e.g. the "Reserve Infra IPs" pill, which is a
-    // data-open-drawer/form-drawer trigger that also carries data-drawer-title).
+    // data-drawer-title: data-drawer-title is just a label and may appear on
+    // any element. Historical note (#1243): a second slide-in form-drawer
+    // (#247) was retired in v3.34.0; before that, data-drawer-title could
+    // appear on triggers belonging to either drawer, and matching on it
+    // would have double-opened.
     document.addEventListener('click', function (e) {
         var btn = e.target.closest ? e.target.closest('[data-drawer-tpl]') : null;
         if (!btn) return;
@@ -2310,7 +2289,7 @@ var IpamDrawer = (function () {
             });
     }
 
-    return { open: open, close: close };
+    return { open: open, openNode: openNode, close: close };
 }());
 
 // Backup History drawer action handlers (#803).

--- a/Simple-PHP-IPAM/lib/presentation.php
+++ b/Simple-PHP-IPAM/lib/presentation.php
@@ -631,15 +631,10 @@ function page_footer(): void
         echo "</div></footer></div></div>"; // close footer-meta div + footer + layout-main (div) + layout-root
     }
 
-    // Slide-in form drawer container (populated by JS openFormDrawer())
-    echo "<div id='form-drawer' role='dialog' aria-modal='true' aria-labelledby='drawer-title-text'>";
-    echo "<div class='drawer-header'>";
-    echo "<span class='drawer-title' id='drawer-title-text'></span>";
-    echo "<button class='drawer-close-btn' aria-label='Close'>&times;</button>";
-    echo "</div>";
-    echo "<div id='form-drawer-body'></div>";
-    echo "</div>";
-    echo "<div class='form-drawer-overlay'></div>";
+    // Note: the slide-in form-drawer (#247) was retired in v3.34.0 (#1243).
+    // All drawer rendering now goes through IpamDrawer (`#global-drawer`,
+    // built lazily on first use by `assets/app.js`). No container is
+    // emitted server-side.
 
     echo "</body></html>";
 }

--- a/testing/playwright/tests/addresses.spec.ts
+++ b/testing/playwright/tests/addresses.spec.ts
@@ -58,26 +58,28 @@ test('addresses page loads for subnet', async () => {
   expect(title.toLowerCase()).toContain('address');
 });
 
-// Regression: the "Reserve Infra IPs" pill is a form-drawer (#247) trigger
-// (data-open-drawer) that also carries data-drawer-title. The IpamDrawer
-// global-drawer delegate used to claim every [data-drawer-title] element, so a
-// single click opened TWO drawers — an empty global-drawer on top of the real
-// form-drawer. The pill must open exactly one (the form-drawer).
-test('Reserve Infra IPs pill opens exactly one drawer', async () => {
+// Regression: in v3.33.0 and earlier, the "Reserve Infra IPs" pill triggered
+// a separate slide-in form-drawer (#247). v3.34.0 (#1243) consolidated that
+// onto IpamDrawer's #global-drawer. Before the consolidation, IpamDrawer's
+// delegate had to NOT claim [data-drawer-title] on form-drawer triggers,
+// because a single click would open TWO drawers — an empty global-drawer on
+// top of the real form-drawer. Now that there's only one drawer, the test
+// just checks the pill opens the global-drawer with the reserve-infra form
+// inside it.
+test('Reserve Infra IPs pill opens the global drawer with the reserve form', async () => {
   expect(subnetId, 'need subnet from beforeAll').not.toBeNull();
   // A freshly-created subnet has no addresses, so network/broadcast are
   // unreserved and the pill renders.
   await page.goto(`addresses.php?subnet_id=${subnetId}`);
 
-  const pill = page.locator('[data-open-drawer="reserve-infra"]');
+  const pill = page.locator('[data-drawer-tpl="tpl-reserve-infra"]');
   await expect(pill).toBeVisible();
   await pill.click();
 
-  // The slide-in form-drawer opens, carrying the real reserve-infra form.
-  await expect(page.locator('#form-drawer.drawer--open')).toHaveCount(1);
-  await expect(page.locator('#form-drawer #reserve-infra')).toHaveCount(1);
-  // ...and the global-drawer must NOT have opened (empty-drawer regression).
-  await expect(page.locator('#global-drawer.is-open')).toHaveCount(0);
+  // The global drawer opens with the reserve-infra form's fields inside.
+  await expect(page.locator('#global-drawer.is-open')).toHaveCount(1);
+  await expect(page.locator('#global-drawer-body input[name="action"][value="reserve_infra"]')).toHaveCount(1);
+  await expect(page.locator('#global-drawer-body input[name="gateway_ip"]')).toBeVisible();
 });
 
 test('create address with mac and expires_at', async () => {
@@ -282,9 +284,11 @@ test('addresses: form drawer opens on Add Address click', async () => {
 });
 
 // Regression: the "Use" link beside "Next available" had a click handler that
-// scoped its input lookup to .card / .drawer-form-card only. The add-address
-// form renders into a bare .drawer-body, so closest() returned null and the
-// link was dead. Fix widened the scope selector to include .drawer-body.
+// originally scoped its input lookup to .card only. The add-address form
+// renders into a bare .drawer-body inside the global drawer, so closest()
+// returned null and the link was dead. Fix widened the scope selector to
+// include .drawer-body (#1243 — form-drawer retirement updated this further
+// by removing the historical .drawer-form-card from the selector).
 test('addresses: Next-available "Use" link fills IP in the drawer', async () => {
   if (!subnetId) { test.skip(); return; }
   await page.goto(`addresses.php?subnet_id=${subnetId}`);


### PR DESCRIPTION
Second chunk of v3.34.0 Refactor Wave 3 (#58). Closes #1243.

Retires the slide-in form-drawer (#247) — the second drawer system that coexisted with IpamDrawer (#517) and caused the open-two-drawers regression that was patched narrowly in `f49dde5c`. Now there is one drawer.

## Summary

**Removed**:
- `lib/presentation.php`: global `#form-drawer` container + `.form-drawer-overlay` markup that emitted on every page (8 lines).
- `assets/app.js`: 35-line `data-open-drawer` event delegate + `openFormDrawer()` / `closeFormDrawer()` helpers + escape/overlay/close-button wiring + the second programmatic caller in the subnets-edit handler.
- `assets/app.css`: ~30 lines of `#form-drawer*` / `.form-drawer-overlay*` / `.drawer-form-card` / `body.drawer-ready .drawer-form-card` / `#form-drawer-body .drawer-form-card` rules and the form-drawer responsive override.

**Added**:
- `IpamDrawer.openNode(title, nodeOrId)` — moves an actual DOM node into `#global-drawer-body` (rather than copying innerHTML). Required for the subnets edit drawer because its form has JS-attached behaviour (tag pre-selection, custom-field hydration, typeahead) bound to the live node — `innerHTML` cloning would discard those listeners.

**Migrated**:
- `addresses.php` Reserve Infra IPs pill — `data-open-drawer="reserve-infra"` → `data-drawer-tpl="tpl-reserve-infra"`. Wraps the form in a hidden `<div id="tpl-reserve-infra" style="display:none">` matching existing `tpl-add-subnet` / `tpl-add-address` / `tpl-create-user` pattern.
- Subnets edit drawer (`app.js` subnet-edit-btn handler) — replaces the form-drawer DOM-move sequence with `IpamDrawer.openNode("Edit "+d.cidr, editDrawer)`.
- `[data-fill-ip]` "Use next IP" handler — scope selector drops the now-redundant `.drawer-form-card` term, keeps `.card, .drawer-body`.

**Test update**:
- `addresses.spec.ts` "Reserve Infra IPs pill" regression test rewritten to assert on `#global-drawer.is-open` + the form's actual inputs (`input[name="action"][value="reserve_infra"]`, `input[name="gateway_ip"]`) instead of the deleted `#form-drawer` selectors. Historical context preserved in the comment.

## Out of scope

- `#wh-form-drawer` in `webhooks.php` is a **third** drawer system — fully hand-rolled, single-page. Out of scope for #1243; will need its own follow-up issue if/when consolidation is wanted.

## Closes

- #1243 (consolidate the two drawer implementations)

## Diff stats

5 files changed, 63 insertions(+), 116 deletions(-) — net **-53 lines**.

## Test plan

- [ ] Local static gates passed: PHP lint, PHPStan (no errors), PHPCS (clean), PHPUnit (1517/1517), JS parses cleanly
- [ ] CI 3-driver + Playwright passes — especially the rewritten `addresses.spec.ts` "Reserve Infra IPs pill" test
- [ ] Manual: navigate to `addresses.php?subnet_id=…` for a fresh subnet, click "Reserve Infra IPs" pill, confirm: global drawer opens with title "Reserve Infrastructure IPs", form is visible, optional gateway input renders, submit creates reserved IPs
- [ ] Manual: navigate to `subnets.php`, click any subnet edit pencil, confirm: global drawer opens with title "Edit <cidr>", tag pre-selection works, custom-field values pre-populate, typeahead pickers reinit cleanly
- [ ] Manual: confirm `#form-drawer` element no longer exists in DOM (View Source on any page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)