### PR TITLE
v3.34.0 wave 3 (part 3): A-bucket carry-overs A26 + A31 (#947, #948)

### DIFF
--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -183,11 +183,11 @@ if ($_staleKeys && current_user()['role'] === 'admin'):
 <!-- KPI cards -->
 <div class="kpi-grid">
 <?php
-$pctStatus   = $kpis['pct_used'] >= 90 ? 'crit' : ($kpis['pct_used'] >= 75 ? 'warn' : 'ok');
+$pctStatus   = $kpis['pct_tracked_used'] >= 90 ? 'crit' : ($kpis['pct_tracked_used'] >= 75 ? 'warn' : 'ok');
 $alertStatus = $kpis['alerts'] > 0 ? 'crit' : 'ok';
 ipam_render('dashboard_kpi_card', ['label' => 'Subnets',     'value' => $kpis['subnets'],        'sub' => '',                                         'status' => 'ok']);
 ipam_render('dashboard_kpi_card', ['label' => 'Addresses',   'value' => $kpis['addresses'],      'sub' => '',                                         'status' => 'ok']);
-ipam_render('dashboard_kpi_card', ['label' => 'Used',        'value' => $kpis['pct_used'] . '%', 'sub' => $kpis['used'] . ' used',                   'status' => $pctStatus]);
+ipam_render('dashboard_kpi_card', ['label' => 'Used',        'value' => $kpis['pct_tracked_used'] . '%', 'sub' => $kpis['used'] . ' used',           'status' => $pctStatus]);
 ipam_render('dashboard_kpi_card', ['label' => 'Crit Alerts', 'value' => $kpis['alerts'],         'sub' => $kpis['alerts'] > 0 ? 'active alerts' : '', 'status' => $alertStatus]);
 ?>
 </div>

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -7169,6 +7169,10 @@ function ipam_passkey_dispatch_challenge(PDO $db, int $userId): bool
                 $ac->id = rtrim(strtr(base64_encode($ac->id->getBinaryString()), '+/', '-_'), '=');
             }
         }
+        // A26 (#947): MANDATORY — break the by-reference binding to the last
+        // $ac. Without this unset(), a later assignment to a variable named
+        // $ac anywhere in this function (refactor risk) would clobber the
+        // last element of $pk->allowCredentials via the still-live reference.
         unset($ac);
     }
 
@@ -7348,7 +7352,19 @@ function ipam_user_preferred_mfa(PDO $db, int $userId): ?string
 // ============================================================
 
 /**
- * @return array{subnets:int,addresses:int,used:int,pct_used:float,alerts:int}
+ * Returns dashboard summary counts for the KPI strip.
+ *
+ * `pct_tracked_used` (#948 / A31): the percentage of TRACKED address rows
+ * whose status='used' — i.e. `used / addresses`, where `addresses` is the
+ * count of rows in the addresses table, NOT the total assignable IPs across
+ * all subnets. This is an inventory-health metric (of the addresses we
+ * track, how many are claimed), not a capacity-utilisation metric. Computing
+ * true capacity utilisation would require summing `2^(32-prefix) - 2` across
+ * IPv4 subnets — which is meaningless for IPv6 — so this metric is
+ * intentionally scoped to tracked rows. The field name carries the
+ * disambiguation. Pre-v3.34.0 this was named `pct_used` and ambiguous.
+ *
+ * @return array{subnets:int,addresses:int,used:int,pct_tracked_used:float,alerts:int}
  */
 function ipam_dashboard_kpis(PDO $db): array {
     $stmtTotals = $db->query(
@@ -7371,7 +7387,7 @@ function ipam_dashboard_kpis(PDO $db): array {
         'subnets'   => $subnets,
         'addresses' => $addresses,
         'used'      => $used,
-        'pct_used'  => $addresses > 0 ? round($used / $addresses * 100, 1) : 0.0,
+        'pct_tracked_used' => $addresses > 0 ? round($used / $addresses * 100, 1) : 0.0,
         'alerts'    => is_array($alerts) ? to_int($alerts['cnt']) : 0,
     ];
 }


### PR DESCRIPTION
Third chunk of v3.34.0 Refactor Wave 3 (#58). Closes #947 + #948. **#946 deferred** to its own focused PR — see issue comment for the migration requirements.

## Summary

- **#947 (A26)** — `ipam_passkey_dispatch_challenge` adds a comment above the `unset($ac)` that follows the foreach-by-reference loop, explaining why it's mandatory (without it, a future variable named `$ac` could silently clobber the last element of `$pk->allowCredentials` via the live reference). No code change.
- **#948 (A31)** — `ipam_dashboard_kpis` renames the misleading `pct_used` array key to `pct_tracked_used`. The metric is inventory health ("of tracked addresses, what % have status='used'"), not capacity utilisation. True capacity utilisation isn't viable to compute (IPv6 subnet sizes are astronomical). Updated both consumers in `dashboard.php` and added a docblock paragraph explaining the intentional scoping. No behaviour change.

## #946 (A20) deferral

The TOTP backup-code O(N) verify needs a schema migration adding a `code_prefix` column to `totp_backup_codes`, plus a behaviour split between new rows (with prefix) and legacy rows (no prefix, fall back to O(N)). That's bigger than the other A-bucket items. Comment on #946 lays out the requirements + suggested slotting.

## Closes

- #947 (A26 — passkey by-ref unset comment)
- #948 (A31 — pct_used field semantics)

## Diff stats

2 files changed, 20 insertions(+), 4 deletions(-).

## Test plan

- [ ] Local static gates passed: PHPStan (no errors), PHPCS (clean), PHPUnit (1517/1517)
- [ ] CI 3-driver + Playwright passes
- [ ] Manual: dashboard.php shows the "Used %" card with the same value as before the rename (verify the math is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)