### PR TITLE
v3.34.0 wave 3 (part 4): composite setup-php action + composer scripts (#943, #945)

### DIFF
--- a/.github/actions/setup-php-ipam/action.yml
+++ b/.github/actions/setup-php-ipam/action.yml
@@ -1,0 +1,54 @@
+name: 'Set up PHP for Simple PHP IPAM'
+description: >-
+  Composite action wrapping shivammathur/setup-php with the project's pinned
+  SHA, plus optional Composer cache setup. Used by php-qa.yml and
+  playwright.yml so the SHA pin lives in one place (#943).
+
+inputs:
+  extensions:
+    description: >-
+      Comma-separated PHP extensions to enable. Required — pass the engine
+      drivers your job actually needs (e.g. `pdo_sqlite, mbstring, openssl`
+      for sqlite-only jobs; `pdo_sqlite, pdo_mysql, pdo_pgsql, mbstring,
+      openssl` for the full php-qa matrix).
+    required: true
+  composer-cache:
+    description: >-
+      Set to "true" (default) to also set up the Composer cache for the job.
+      Set to "false" when the job does not run `composer install` (e.g. the
+      Docker-image-build slot in playwright.yml that only needs the php
+      binary on the host for tooling, not vendor/).
+    required: false
+    default: 'true'
+  php-version:
+    description: 'PHP version to install. Default 8.2 — the project floor.'
+    required: false
+    default: '8.2'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup PHP (shivammathur/setup-php)
+      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.extensions }}
+        coverage: none
+
+    # ----- Composer cache (#411) -----
+    # Keyed on composer.lock so a no-dep PR doesn't bust the cache. Saves
+    # ~20–30s per job and compounds across matrix slots.
+    - name: Get Composer cache directory
+      if: inputs.composer-cache == 'true'
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache Composer dependencies
+      if: inputs.composer-cache == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ inputs.php-version }}-composer-

--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -93,28 +93,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      - name: Setup PHP + Composer cache (composite action #943)
+        uses: ./.github/actions/setup-php-ipam
         with:
-          php-version: '8.2'
           extensions: pdo_sqlite, pdo_mysql, pdo_pgsql, mbstring, openssl
-          coverage: none
-
-      # ----- Composer cache (#411) -----
-      # Keyed on composer.lock so a no-dep PR doesn't bust the cache. Saves
-      # ~20–30s per job and compounds across matrix slots once MySQL and
-      # Postgres land.
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-8.2-composer-
 
       - name: Validate composer.json
         run: composer validate --strict

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -267,24 +267,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: testing/playwright/package-lock.json
 
-      - name: Setup PHP + Composer
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      - name: Setup PHP + Composer cache (composite action #943)
+        uses: ./.github/actions/setup-php-ipam
         with:
-          php-version: '8.2'
           extensions: pdo_sqlite, mbstring, openssl
-          coverage: none
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Composer dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-8.2-composer-
 
       - name: Install runtime Composer dependencies
         run: composer install --no-dev --no-progress --quiet
@@ -363,12 +349,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      - name: Setup PHP (composite action #943, no Composer cache)
+        uses: ./.github/actions/setup-php-ipam
         with:
-          php-version: '8.2'
           extensions: pdo_sqlite, mbstring, openssl
-          coverage: none
+          composer-cache: 'false'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,30 @@
         ],
         "post-update-cmd": [
             "bash testing/scripts/check-composer-lock-drift.sh"
+        ],
+        "test": "phpunit",
+        "phpstan": "phpstan analyse --memory-limit=1G",
+        "phpcs": "phpcs",
+        "phpcbf": "phpcbf",
+        "audit-icons": "php tools/audit-icons-svg.php",
+        "lint": [
+            "@phpstan",
+            "@phpcs",
+            "@audit-icons"
+        ],
+        "ci-gate": [
+            "@test",
+            "@lint"
         ]
+    },
+    "scripts-descriptions": {
+        "test": "Run the PHPUnit test suite.",
+        "phpstan": "Static analysis at the project-configured level (currently L9).",
+        "phpcs": "PSR-12 style check with project exclusions (see phpcs.xml.dist).",
+        "phpcbf": "Auto-fix PSR-12 style violations where safe.",
+        "audit-icons": "Verify icons.svg sprite has no dead symbols or missing references (#942).",
+        "lint": "Run all static-quality gates: phpstan + phpcs + audit-icons.",
+        "ci-gate": "Full local CI gate: PHPUnit + lint. Run before pushing. Does not include the dockerized 3-driver bootstrap (see testing/bootstrap-app.sh)."
     },
     "config": {
         "platform": {


### PR DESCRIPTION
Fourth chunk of v3.34.0 Refactor Wave 3 (#58). Closes #943 + #945. **#944 deferred** to its own focused PR (171-file classification work).

## Summary

**#943 (D19) — composite GitHub Action.** New `.github/actions/setup-php-ipam/action.yml` wraps the `shivammathur/setup-php` SHA pin + Composer cache scaffolding. Three call sites updated:

| Site | Extensions | composer-cache |
|---|---|---|
| `php-qa.yml` | `pdo_sqlite, pdo_mysql, pdo_pgsql, mbstring, openssl` | on |
| `playwright.yml` (matrix slot) | `pdo_sqlite, mbstring, openssl` | on |
| `playwright.yml` (Docker-build slot) | `pdo_sqlite, mbstring, openssl` | **off** (host doesn't need vendor/) |

Single source of truth for the action SHA pin. Future Dependabot bumps on `shivammathur/setup-php` now touch one file (`action.yml`).

**#945 (D21) — composer scripts block.** Added user-facing aliases:

- `composer test` — PHPUnit
- `composer phpstan` — PHPStan L9 with `--memory-limit=1G`
- `composer phpcs` / `composer phpcbf` — PSR-12 check / auto-fix
- `composer audit-icons` — the new icon audit (#942)
- `composer lint` — phpstan + phpcs + audit-icons
- `composer ci-gate` — test + lint (full local gate before push)

Plus `scripts-descriptions` so `composer list` documents each alias. Existing `post-install-cmd` / `post-update-cmd` hooks preserved.

## #944 deferral

Splitting `phpunit.xml` Unit vs Integration requires classifying the 171 flat test files (no current directory structure separates them). Better paired with #1047 (wave-3 test umbrella) or done as its own focused PR. Issue comment lays out requirements.

## Diff stats

4 files changed, 84 insertions(+), 40 deletions(-) — composite action is ~60 lines, workflow reductions are ~30 lines. Roughly even net, but single-source-of-truth.

## Closes

- #943 (D19 — composite GitHub Action for PHP setup)
- #945 (D21 — composer.json scripts block)

## Test plan

- [ ] Local: `composer ci-gate` runs PHPUnit + PHPStan + PHPCS + audit-icons cleanly
- [ ] CI: php-qa.yml matrix (sqlite/mysql/mariadb/pgsql) still green using the composite action
- [ ] CI: playwright.yml matrix still green using the composite action
- [ ] Manual: `composer list | grep -E "test|lint|phpstan|audit-icons"` shows the new aliases with their descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)