### PR TITLE
v3.34.0 wave 3 (part 6): P3 nits — const hoist, session-name dedup, oidc_jwks cache check (#949, #950, #951)

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -90,11 +90,8 @@ if ($rawKey === '') {
     $resourcePeek = strtolower(trim(to_str($_GET['resource'] ?? '')));
     $methodPeek   = strtoupper(to_str($_SERVER['REQUEST_METHOD'] ?? 'GET'));
     if ($methodPeek === 'GET' && in_array($resourcePeek, ['contacts', 'subnet_stats'], true)) {
-        $sesName = to_str($config['session_name']);
-        if ($sesName === '' || $sesName === 'IPAMSESSID') {
-            $sesName = 'IPAMSESSID_' . substr(hash('sha256', __DIR__), 0, 8);
-        }
-        session_name($sesName);
+        // B.P3 (#950): shared with init.php's bootstrap path.
+        session_name(ipam_session_name($config));
         $cookiePath = to_str($config['session_cookie_path'] ?? '');
         if ($cookiePath === '') {
             $sn = to_str($_SERVER['SCRIPT_NAME'] ?? '');

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -308,12 +308,12 @@ if (!$isHttps) {
 //
 // The default for every layer is "derive from __DIR__", which makes
 // isolation automatic on every install without requiring any config edit.
-$configuredSessionName = to_str($config['session_name']);
-if ($configuredSessionName === '' || $configuredSessionName === 'IPAMSESSID') {
-    // Default path: suffix with 8 hex chars of the install-dir hash so
-    // two installs at different filesystem paths never collide.
-    $configuredSessionName = 'IPAMSESSID_' . substr(hash('sha256', __DIR__), 0, 8);
-}
+// B.P3 (#950): the fallback logic (config_session_name === ''
+// || 'IPAMSESSID' → 'IPAMSESSID_' . hash(__DIR__)) is shared with
+// api.php's own session-bootstrap path. Helper lives in lib/auth.php
+// — keyed on the lib/ parent directory so it resolves to this same
+// install root that __DIR__ resolves to here.
+$configuredSessionName = ipam_session_name($config);
 session_name($configuredSessionName);
 
 // Derive the cookie path from the running script so an install at

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -5521,8 +5521,19 @@ function oidc_jwks(string $jwksUri, bool $forceRefresh = false): array
         throw new RuntimeException('Invalid JWKS from ' . $jwksUri);
     }
 
-    file_put_contents($cache, json_encode($d));
-    @chmod($cache, 0600);
+    // A.P3 (#949): if the cache write silently fails (full disk, permission
+    // change on tmp/, EROFS), we re-fetch the JWKS from the IdP on every
+    // subsequent request — wasteful and a soft availability hit on the
+    // OIDC login path. Surface the failure to error_log so an operator
+    // can see it without us hard-failing this request (we already have
+    // a valid in-memory $d to return).
+    $encoded = json_encode($d);
+    if ($encoded === false || @file_put_contents($cache, $encoded) === false) {
+        error_log('oidc_jwks: failed to write JWKS cache to ' . $cache
+            . ' — JWKS will be re-fetched on each request until the write succeeds');
+    } else {
+        @chmod($cache, 0600);
+    }
     return array_values((array)$d['keys']);
 }
 

--- a/Simple-PHP-IPAM/lib/auth.php
+++ b/Simple-PHP-IPAM/lib/auth.php
@@ -358,6 +358,32 @@ function client_ip(): string
 }
 
 // ============================================================
+// Session name derivation (#950 B.P3)
+// ============================================================
+
+/**
+ * Derive the session cookie name from `$config['session_name']`, falling
+ * back to a per-install-directory-hashed default when unset or set to the
+ * legacy `'IPAMSESSID'` literal. Two installs at different filesystem paths
+ * never collide.
+ *
+ * The fallback logic is identical to the bootstrap at `init.php`; this
+ * helper exists so `api.php`'s own session-bootstrap path (used for
+ * browser-session-authenticated GET endpoints when no Bearer key is
+ * supplied) can derive the same value without duplicating the logic.
+ *
+ * @param IpamConfig $config
+ */
+function ipam_session_name(array $config): string
+{
+    $name = to_str($config['session_name']);
+    if ($name === '' || $name === 'IPAMSESSID') {
+        $name = 'IPAMSESSID_' . substr(hash('sha256', dirname(__DIR__)), 0, 8);
+    }
+    return $name;
+}
+
+// ============================================================
 // Session absolute lifetime (v3.6.0, #420)
 // ============================================================
 

--- a/Simple-PHP-IPAM/users.php
+++ b/Simple-PHP-IPAM/users.php
@@ -7,6 +7,11 @@ require_role('admin');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') csrf_require();
 
+// B.P3 (#950): the role set is a fixed-shape compile-time constant. Lifting
+// it to a file-scope `const` removes the per-POST-handler re-declaration and
+// avoids re-allocating the array on every request hot path.
+const USERS_VALID_ROLES = ['admin', 'netops', 'readonly'];
+
 $errors = [];
 $msg    = '';
 $self   = current_user();
@@ -22,7 +27,6 @@ $formData = ['username' => '', 'name' => '', 'email' => '', 'role' => 'readonly'
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = to_str($_POST['action'] ?? '');
 
-    $validRoles = ['admin', 'netops', 'readonly'];
     $pwPolicy   = [
         'min_length'            => to_int(ipam_setting('password_policy.min_length')),
         'require_uppercase'     => (bool)ipam_setting('password_policy.require_uppercase'),
@@ -52,7 +56,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         if ($username === '' || !preg_match('~^[a-zA-Z0-9_.\-@]{3,64}$~', $username)) {
             $errors[] = 'Username must be 3–64 chars (letters, numbers, _ . - @).';
-        } elseif (!in_array($role, $validRoles, true)) {
+        } elseif (!in_array($role, USERS_VALID_ROLES, true)) {
             $errors[] = 'Invalid role.';
         }
         $password = '';
@@ -126,7 +130,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $role = to_str($_POST['role'] ?? '');
         if ($id === $selfId) {
             $errors[] = 'You cannot change your own role.';
-        } elseif (!in_array($role, $validRoles, true)) {
+        } elseif (!in_array($role, USERS_VALID_ROLES, true)) {
             $errors[] = 'Invalid role.';
         } else {
             // Last-active-admin guard: prevent demoting the last active admin


### PR DESCRIPTION
Sixth chunk of v3.34.0 Refactor Wave 3 (#58). Closes #949 + #950 + #951.

Investigated all 22 P3-nit sub-findings across the three umbrellas (A.P3 / B.P3 / C.P3). Three real correctness/DRY items shipped; the remaining 19 dispositioned in detail on each umbrella issue (see #949, #950, #951 comments).

## Shipped (3 items)

**B.P3 #2 — \`users.php\` validRoles to const.** Hoisted the \`['admin', 'netops', 'readonly']\` literal out of the POST-handler block and onto a file-scope \`const USERS_VALID_ROLES\`. Two call sites updated.

**B.P3 #6 — session-name fallback dedup.** \`init.php:311\` and \`api.php:93\` ran the same fallback chain. New helper \`ipam_session_name(\$config)\` in \`lib/auth.php\` (next to other session helpers). Both call sites now go through it. Hash input adjusted to \`dirname(__DIR__)\` from inside \`lib/\` so it resolves to the same Simple-PHP-IPAM/ webroot existing installs derived from \`__DIR__\` — derived names are identical, sessions survive the upgrade.

**A.P3 #5 — \`oidc_jwks()\` cache write check.** The cache write at \`oidc_jwks() L5524\` silently dropped failures, forcing IdP re-fetches every OIDC login until the cache was repaired. Added \`json_encode\` + \`file_put_contents\` return-value checks; on failure logs to error_log with the path, skips the chmod, and still returns valid in-memory keys.

## Dispositioned (19 items, no code change)

Detail on each umbrella issue — see #949 / #950 / #951 comments.

Highlights:
- A.P3 \`@\`-suppressions on file ops: triaged across 10+ sites — every one is an intentional silent-on-missing-file pattern (last-run state, locks). Not real bugs.
- A.P3 redirect-stash dedup × 6: helper \`ipam_step_up_validate_return_to\` already exists; migrating the six inline sites needs its own focused issue.
- B.P3 \`unassigned.php\` CSRF vs role-check ordering: investigated, current order is correct.
- C.P3 all three (C16/C17/C18): pure style consistency, PHPCS accepts.

## Closes

- #949 (A.P3 — A34-A42)
- #950 (B.P3 — B25-B34)
- #951 (C.P3 — C16-C18)

## Diff stats

5 files changed, 54 insertions(+), 16 deletions(-).

## Test plan

- [ ] \`composer ci-gate\` passes (PHPUnit 1517/1517, PHPStan no errors, PHPCS clean)
- [ ] CI 3-driver + Playwright passes
- [ ] Manual: log in via OIDC — verify session works (session-name helper migration unchanged); verify users.php role gates still reject invalid roles on create/update
- [ ] Manual: confirm OIDC JWKS cache file appears under tmp/ (visible side effect of write working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)