### PR TITLE
docs(adr): correct ADR-007 — Open Props is already loaded; close #1255

### DIFF
--- a/docs/internal/architecture-decisions/007-open-props-adoption.md
+++ b/docs/internal/architecture-decisions/007-open-props-adoption.md
@@ -1,9 +1,35 @@
 # ADR-007: Adopt Open Props as the CSS design-token base
 
-**Status:** draft
+**Status:** draft (amended 2026-05-20 — see correction below)
 **Decided:** —
 **Scope:** UX foundation milestone #59 + UX nav milestone #60. Gates the migration of `assets/app.css` from a hand-rolled token scale to Open Props as the source of truth for spacing, radii, font sizes, colors, easings, and animations. Affects every CSS variable read across `app.css` (84 KB) and every PHP view that inlines a `style=""` (≤30 sites).
 **Stamped by:** —
+
+---
+
+## ⚠️ Correction (2026-05-20)
+
+This ADR was drafted on the premise that Open Props was **not** loaded by the project. **That premise was wrong.**
+
+While doing the v3.34.0 modularization Phase 0 inspection of `lib/presentation.php`, the `<link rel='stylesheet' href='assets/vendor/open-props.min.css?v=…'>` tag was discovered at line 386, and the vendor file already exists at `Simple-PHP-IPAM/assets/vendor/open-props.min.css` (committed in `e433f134 feat(#506): design token scales + Open Props vendor`).
+
+What the original ADR §2 inventory missed: it searched `views/` + `assets/` + `lib/presentation.php` for the literal text `open-props` but the search did not reach the right line range. The vendor file + the load `<link>` have been in the tree since well before this ADR was filed.
+
+**Effect on the ADR-007 issue arc:**
+
+| # | Title | Original status | Corrected status |
+|---|---|---|---|
+| #1255 | vendor Open Props + load ahead of app.css | new work | **already done** — closed with explanation |
+| #1256 | migrate spacing + radii + font-size tokens to OP | new work | still pending |
+| #1257 | migrate neutral color tokens to OP grays | new work | still pending |
+| #1258 | adopt OP shadows + easings + animations | new work | still pending |
+| #1259 | cleanup + delete hand-rolled blocks + close #941 | new work | still pending |
+
+`assets/app.css` does NOT actually consume OP tokens today — only one stray `var(--font-size-1)` matches an OP-defined token (likely coincidence). The remaining four migration issues (#1256–#1259) are still real, still scoped correctly, and still slotted to v3.35.0 + v3.36.0.
+
+**Effect on the ADR's reasoning:** the recommendation (Option A) stands. The "vendor + drop-in" step was already done; the migrations are still the value-add. The ADR §3 "Decision drivers" section (no-build-step, milestone-#59 coupling, etc.) still applies. The ADR §5 "Implications" file list still applies (minus the new vendor file, which already exists).
+
+**No other ADR text below has been edited.** The original "Open Props is NOT loaded" language in §2 stays as-is — it is the historical record of the (incorrect) understanding at the time of drafting.
 
 ---
 

--- a/docs/internal/roadmap.md
+++ b/docs/internal/roadmap.md
@@ -301,11 +301,11 @@ Audit scope **explicitly excludes** backup/restore UX — that's `archive/backup
 
 ### 7.1 ADR-007 Open Props adoption arc (straddles v3.35.0 + v3.36.0)
 
-Captured 2026-05-20. Adopts [Open Props](https://open-props.style) as the project's CSS design-token base over two releases, paired with the natural UX work in #59 and #60.
+Captured 2026-05-20; **corrected 2026-05-20 (later same day)** — see ADR-007 amendment header. The "vendor + load" step is already done (the OP vendor file has been in the tree since `e433f134 feat(#506)` and `lib/presentation.php:386` already loads it). The remaining four issues are real and scoped correctly.
 
 | Slot | Phase | Issues | Effort |
 |---|---|---|---|
-| **v3.35.0** (#59) | **Phase 1 — Foundation:** vendor Open Props + migrate spacing/radii/font-size + neutral colors. Hand-rolled tokens kept as aliases for one-release compat. | #1255 (vendor + load), #1256 (sizing migration), #1257 (color migration) | ~3.5d |
+| **v3.35.0** (#59) | **Phase 1 — Foundation:** migrate spacing/radii/font-size + neutral colors. Hand-rolled tokens kept as aliases for one-release compat. (#1255 vendor + load is **already done** — pre-v3.34.0.) | #1256 (sizing migration), #1257 (color migration) | ~3d |
 | **v3.36.0** (#60) | **Phase 2 — Polish:** adopt OP shadows + easings + animation primitives. Delete alias block. Audit `!important`. Close #941. | #1258 (secondary tokens), #1259 (cleanup), reframed #941 (closes via #1259) | ~1.5d |
 
 **Why this slotting:**


### PR DESCRIPTION
Docs-only correction. Discovered during v3.34.0 PR #1268's Phase 0 work that the project already vendors and loads Open Props — ADR-007 was filed on the wrong premise.

## What this PR does

- **ADR-007 amendment header** (`docs/internal/architecture-decisions/007-open-props-adoption.md`) — adds a "⚠️ Correction (2026-05-20)" block at the top of the doc explaining the discovery, with a disposition table showing #1255 is already-done and the other four sub-issues (#1256-#1259) are still real and pending. The original body text is intentionally NOT edited — it stays as the historical record of the (incorrect) understanding at draft time.
- **Roadmap §7.1 update** — drops #1255 from the v3.35.0 row, trims the effort estimate (~3.5d → ~3d). The four migration issues (#1256-#1259) stay on milestones #59 and #60 unchanged.
- **#1255 closed** with a detailed comment on the issue.

## Discovery evidence

- `Simple-PHP-IPAM/assets/vendor/open-props.min.css` exists (29 KB, committed in `e433f134 feat(#506): design token scales + Open Props vendor`)
- `lib/presentation.php:386` already emits `<link rel='stylesheet' href='assets/vendor/open-props.min.css?v={$av}'>` on every page
- `assets/app.css` does NOT currently consume any OP tokens (one stray `var(--font-size-1)` matches an OP-defined token but is likely coincidence — the project's hand-rolled scale uses lettered suffixes `--font-size-2xs` through `--font-size-9xl`, not numeric)

## What does NOT change

- ADR-007's recommendation (Option A — adopt Open Props) still stands
- The four remaining migration issues (#1256/#1257/#1258/#1259) are still in scope for v3.35.0 + v3.36.0
- The original ADR body is preserved verbatim

## Closes

- #1255 (already closed in the issue itself, via the detailed comment)

## Test plan

- [ ] Read the new "⚠️ Correction" header at the top of `docs/internal/architecture-decisions/007-open-props-adoption.md` and confirm the framing is honest
- [ ] Read the roadmap §7.1 diff — confirm #1255 is dropped from v3.35.0 and the other four issues are unchanged
- [ ] Confirm #1255 is closed with the explanation comment
- [ ] No code changes; CI is informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)