### PR TITLE
v3.34.0 wave 3 (part 12): Phase 2a sample — extract C01 bootstrap (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1,22 +1,32 @@
+// ─── C01 — Bootstrap (Phase 2a, #939) ────────────────────────────────────────
+// Synchronous init that must run BEFORE DOMContentLoaded — applies the saved
+// theme to <html data-theme=...> before first paint to avoid flash-of-unstyled.
+// Has no DOM-event dependencies, so it lives outside any DOMContentLoaded
+// handler. The "ipam_theme" localStorage key is the contract between this
+// concern and C02 (theme/banners) — kept as a string literal at every site
+// rather than a shared variable, so the concerns are independently extractable
+// in Phase 2b.
 (function(){
   // Remove skeleton loader if present (CSP-safe, no inline script)
   var skel = document.getElementById("skeleton-shell");
   if (skel) skel.remove();
 
-  var key = "ipam_theme";
   // Seed localStorage from server-side theme meta tag (CSP-safe, replaces inline script)
   var metaTheme = document.querySelector("meta[name='ipam-server-theme']");
   if (metaTheme) {
     var serverTheme = metaTheme.getAttribute("content");
     if (serverTheme === "light" || serverTheme === "dark") {
-      localStorage.setItem(key, serverTheme);
+      localStorage.setItem("ipam_theme", serverTheme);
     }
   }
-  var saved = localStorage.getItem(key);
+  var saved = localStorage.getItem("ipam_theme");
   if (saved === "light" || saved === "dark") {
     document.documentElement.setAttribute("data-theme", saved);
   }
+}());
 
+// ─── Main IIFE — concerns C02–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
   function currentTheme() {
     return document.documentElement.getAttribute("data-theme") || "auto";
   }
@@ -24,10 +34,10 @@
   function applyTheme(t) {
     if (t === "auto") {
       document.documentElement.removeAttribute("data-theme");
-      localStorage.removeItem(key);
+      localStorage.removeItem("ipam_theme");
     } else {
       document.documentElement.setAttribute("data-theme", t);
-      localStorage.setItem(key, t);
+      localStorage.setItem("ipam_theme", t);
     }
     var csrfMeta = document.querySelector("meta[name='ipam-csrf']");
     var csrfTok = csrfMeta ? csrfMeta.getAttribute("content") || "" : "";


### PR DESCRIPTION
Validates the Phase 2a per-concern IIFE restructure pattern (decided 2026-05-20 in PR #1271) using C01 (bootstrap) as the smallest, most independent concern.

## What this PR does

- Wraps the bootstrap block (skeleton-loader removal + theme seed from \`localStorage\` / meta-tag) in its own IIFE at the top of \`_monolith.js\`, OUTSIDE the main IIFE.
- Inlines the \`"ipam_theme"\` localStorage key at all 4 read/write sites (was \`var key = "ipam_theme"\` shared between C01 and C02 via the main IIFE's closure scope).
- C02–C18 still live inside a second IIFE beneath C01. Each subsequent concern shrinks the main IIFE in the same shape.

## Why ship C01 alone

Per the plan amendment (PR #1270) and the "✅ Decided" line in PR #1271, the recommendation was "Run one Phase 2a sample commit to validate the per-concern restructure pattern, then batch the remaining ~17." This PR is that sample. Once approved, the next PR batches C02-C18.

## Coupling broken

Before: \`var key = "ipam_theme"\` declared at the top of the main IIFE, used from both C01 (bootstrap read) AND C02 (theme helpers \`applyTheme\`, \`cycleTheme\`).

After: the literal \`"ipam_theme"\` is inlined at every site. C01 and C02 no longer share closure-scoped state — they're independently extractable.

This matches the Phase 2a rule from the plan amendment: "Shared helpers (used by ≥2 concerns) hoist to a new \`window.IpamUtils.*\` top-level; otherwise inline. **Do NOT keep silent closure-scope coupling.**"

## File size delta

\`_monolith.js\`: 3,214 → 3,225 lines (+11). The added lines are the new section-divider comment headers and the inner IIFE braces; no logic change.

## Gates

\`composer ci-gate\` passes (PHPUnit 1517/1517, PHPStan no errors, PHPCS clean, icons audit clean). JS parse-check on the trimmed monolith passes. No behavior change visible to the user.

## Closes

- Nothing. #939 + #1047 stay open through the remaining Phases 2a/2b/3-6.

## Diff stats

1 file changed, 15 insertions(+), 5 deletions(-).

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: load any page in light + dark mode, refresh — no flash-of-unstyled-content (the C01 IIFE applies the saved theme before first paint, same as before)
- [ ] Manual: View source on any page — confirm two \`<script defer>\` tags (\`20-drawer.js\` then \`_monolith.js\`) AND that opening \`_monolith.js\` shows the new \`// ─── C01 — Bootstrap\` header at the top followed by the second IIFE for the remaining concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)