### PR TITLE
v3.34.0 wave 3 (part 13): Phase 2a — extract C02 + C03 + C04 to their own IIFEs (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -25,7 +25,15 @@
   }
 }());
 
-// ─── Main IIFE — concerns C02–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C02 — Theme + dismissable banners (Phase 2a, #939) ──────────────────────
+// Theme toggle (auto/light/dark) + update-banner dismiss + per-banner
+// dismissable admin notices. Helpers and DOM wire-up live together so the
+// concern is self-contained for Phase 2b move. Persists theme via
+// user_preference.php (server) AND localStorage (client seed for next page
+// load); the C01 bootstrap reads the localStorage value before paint to
+// avoid flash-of-unstyled-content. The "ipam_theme" key is the contract
+// between this concern and C01 — inlined as a literal at every site so
+// neither concern depends on the other's closure scope.
 (function(){
   function currentTheme() {
     return document.documentElement.getAttribute("data-theme") || "auto";
@@ -70,9 +78,6 @@
   }
 
   document.addEventListener("DOMContentLoaded", function() {
-    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
-    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
-
     updateThemeButton();
 
     // --- Theme toggle button ---
@@ -116,6 +121,14 @@
         localStorage.setItem("ipam_dismissed_banner_" + name, "1");
       });
     });
+  });
+}());
+
+// ─── Main IIFE — concerns C03–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
+    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
+    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
 
     // --- Site group collapse/expand ---
     document.querySelectorAll(".site-group-toggle").forEach(function(btn) {

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -124,13 +124,12 @@
   });
 }());
 
-// ─── Main IIFE — concerns C03–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C03 — Site-group collapse/expand (Phase 2a, #939) ───────────────────────
+// Sidebar sub-grouping toggle (one button per group). Open/closed state
+// persists per-group in localStorage under "ipam_sg_<key>" so the user's
+// nav layout survives across pages. Independent of every other concern.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
-    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
-    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
-
-    // --- Site group collapse/expand ---
     document.querySelectorAll(".site-group-toggle").forEach(function(btn) {
       var sgKey = btn.dataset.sgKey;
       if (sgKey && localStorage.getItem("ipam_sg_" + sgKey) === "closed") {
@@ -142,6 +141,14 @@
         if (sgKey) localStorage.setItem("ipam_sg_" + sgKey, expanded ? "closed" : "open");
       });
     });
+  });
+}());
+
+// ─── Main IIFE — concerns C04–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
+    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
+    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
 
     // --- Live Ping buttons (addresses.php) ---
     document.addEventListener("click", function(e) {

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -144,12 +144,18 @@
   });
 }());
 
-// ─── Main IIFE — concerns C04–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C04 — Live Ping + alert-recipients clear-all (Phase 2a, #939) ───────────
+// Two unrelated delegated-click handlers grouped because each is small:
+// (1) the .ping-btn handler on addresses.php that POSTs to ping_host.php
+// and renders up/down/latency in the corresponding .ping-result-<addrId>;
+// (2) the #443 [data-clear-select] handler that deselects every option in
+// a <select multiple> (no native HTML way to do this). Both are event
+// delegates rooted at document, so they activate without needing the
+// targets to exist at script-execute time. The orphan "#317 Cmd/Ctrl+N"
+// section header that previously sat between them was dropped here — the
+// actual Cmd/Ctrl+N implementation lives in C13 (command palette).
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
-    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
-    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
-
     // --- Live Ping buttons (addresses.php) ---
     document.addEventListener("click", function(e) {
       var btn = e.target.closest(".ping-btn");
@@ -189,8 +195,6 @@
         });
     });
 
-    // --- #317: Cmd/Ctrl+N opens the Add Address drawer on addresses.php ---
-
     // --- #443: clear-all button for the alert recipients multi-select ---
     // <button data-clear-select="<select-id>"> deselects every option in the
     // referenced <select multiple>. Without this, HTML offers no built-in
@@ -206,6 +210,14 @@
       Array.from(sel.options).forEach(function(o) { o.selected = false; });
       sel.dispatchEvent(new Event("change", { bubbles: true }));
     });
+  });
+}());
+
+// ─── Main IIFE — concerns C05–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
+    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
+    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
 
     // --- Auto-submit selects (data-auto-submit) ---
     document.querySelectorAll("[data-auto-submit]").forEach(function(el) {


### PR DESCRIPTION
Second Phase 2a batch in the v3.34.0 app.js modularization rollout. Builds on PR #1272 (C01 sample) by extracting three more main-IIFE concerns to their own in-file IIFEs inside \`_monolith.js\`.

## Concerns extracted

**C02 — Theme + dismissable banners** (commit \`ba311c10\`). Theme toggle (auto/light/dark) with localStorage-and-server persistence + update-banner dismiss + per-banner data-banner / data-dismiss-banner notices. Includes the helpers (\`currentTheme\`, \`applyTheme\`, \`updateThemeButton\`, \`cycleTheme\`, \`dismissUpdate\`) and their DOMContentLoaded wire-up. Shared with C01 via the \`"ipam_theme"\` localStorage key — already inlined as a literal in PR #1272.

**C03 — Site-group collapse/expand** (commit \`70daf871\`). Small standalone: one querySelectorAll + click handler. Open/closed state per-group in localStorage under \`ipam_sg_<key>\`. No helpers, no shared state with other concerns.

**C04 — Live Ping + alert-recipients clear-all** (commit \`4654a040\`). Two unrelated delegated-click handlers grouped because each is small: \`.ping-btn\` POSTs to \`ping_host.php\`; \`[data-clear-select]\` deselects every option in a \`<select multiple>\`. **Dead code removed:** the orphaned \`#317 Cmd/Ctrl+N\` section header that pointed at code which had moved to C13 (command palette).

## Pattern observations across the four extractions (C01-C04)

1. **No bundler needed.** Each concern wraps itself in \`(function(){...}())\` inside \`_monolith.js\`. The file grows by ~10 lines per concern (new section header + IIFE braces); logic doesn't change.
2. **Shared state must be made explicit.** C01/C02's \`"ipam_theme"\` was the only cross-concern coupling so far, and it had been a single shared closure-scoped \`var\`. Inlining the string literal at every site breaks the coupling without behavior change.
3. **DOMContentLoaded handlers attach independently.** Each concern can have its own \`document.addEventListener("DOMContentLoaded", ...)\`. All fire on the same DOMContentLoaded event; concern order is preserved by file emission order.
4. **Dead documentation surfaces during extraction** (the orphan \`#317\` comment in C04). Worth removing as we encounter it — leaving it would be a footgun for future contributors.

## File size

\`_monolith.js\`: 3,225 → 3,238 → 3,245 → 3,257 lines (net +32 across 3 commits). Growth is comments + IIFE wrappers; logic unchanged.

## Closes

- Nothing yet. #939 + #1047 stay open through the remaining ~14 Phase 2a concerns + Phase 2b + 3-6.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: dashboard / subnets / addresses / settings — theme toggle still works (cycle auto → light → dark → auto, persists across refresh, no FOUC)
- [ ] Manual: sidebar site-group toggle remembers open/closed state across pages
- [ ] Manual: any update banner can be dismissed and stays dismissed
- [ ] Manual: live ping button on addresses.php returns up/down/latency
- [ ] Manual: \`<select multiple>\` clear-all button on alert-recipients page works

## What's next

C05 (forms-core) is the biggest remaining concern (~320 lines including the secret-field password toggle with reveal-from-stored). Will be its own focused PR. After that, C06-C18 follow in batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)