### PR TITLE
v3.34.0 wave 3 (part 14): Phase 2a — extract C05 + C06 + C07 to their own IIFEs (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -213,12 +213,17 @@
   });
 }());
 
-// ─── Main IIFE — concerns C05–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C05 — Forms-core (Phase 2a, #939) ───────────────────────────────────────
+// Auto-submit on select change + the password show/hide toggle complex
+// (eye-icon button + reveal-from-stored secret fetch + OIDC step-up
+// round-trip replay marker). The pw-toggle is the bulk of this concern.
+// Uses `window.__ipamPwReplayInProgress` as a one-shot anti-loop flag
+// (window-scoped because the marker survives a page navigation through
+// step_up.php and back). The eye SVG sprites live in icons.svg as
+// icon-eye / icon-eye-slash and are wired into the markup by
+// `lib/presentation.php`'s settings_group_form partial (#942/PR-1).
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
-    // Sticky headers are handled by CSS (thead th { position:sticky; top:0 } within
-    // .table-wrap { overflow:auto; max-height:65vh }). No JS offset needed.
-
     // --- Auto-submit selects (data-auto-submit) ---
     document.querySelectorAll("[data-auto-submit]").forEach(function(el) {
       el.addEventListener("change", function() { el.form.submit(); });
@@ -403,7 +408,12 @@
         document.body.classList.add("pw-toggle-hidden");
       }
     } catch (_) { /* localStorage may be blocked; non-fatal */ }
+  });
+}());
 
+// ─── Main IIFE — concerns C06–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Confirm dialogs on forms (data-confirm on <form>) ---
     document.addEventListener("submit", function(e) {
       var form = e.target;

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -411,7 +411,13 @@
   });
 }());
 
-// ─── Main IIFE — concerns C06–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C06 — Forms-confirm-bulk (Phase 2a, #939) ───────────────────────────────
+// data-confirm dialogs on forms + buttons/inputs + non-form links;
+// data-submit-on-change auto-submit; data-stop-propagation guard;
+// loading-state class on POST submitters (#507); data-select-addrs
+// bulk-select helper; SSO-only toggle on users.php; reCAPTCHA v3
+// pre-submit token fetch. Many small CSP-safe replacements for the
+// inline-onclick / nested-checkbox patterns retired in v3.27.7.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Confirm dialogs on forms (data-confirm on <form>) ---
@@ -548,7 +554,12 @@
         });
       }
     }
+  });
+}());
 
+// ─── Main IIFE — concerns C07–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Search page: site → subnet cascade filter ---
     var filterSite = document.getElementById("filter-site");
     var filterSubnet = document.getElementById("filter-subnet");

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -557,7 +557,13 @@
   });
 }());
 
-// ─── Main IIFE — concerns C07–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C07 — Search + IP validation + wheel-hijack guard (Phase 2a, #939) ──────
+// Three small adjacent search/input concerns: (1) search-page site →
+// subnet cascade filter (hides subnet <option>s whose data-site doesn't
+// match the chosen site); (2) data-validate="ip" / "cidr" client-side
+// regex check on form submit; (3) #1133 wheel-hijack guard that
+// preventDefault()'s on a wheel event over a focused number input so
+// the page scrolls instead of the number silently counting up/down.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Search page: site → subnet cascade filter ---
@@ -626,7 +632,12 @@
         t.blur();
       }
     }, { passive: false });
+  });
+}());
 
+// ─── Main IIFE — concerns C08–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Sidebar hamburger toggle (#512) ---
     (function () {
       var sidebar = document.getElementById("sidebar");


### PR DESCRIPTION
Third Phase 2a batch in the v3.34.0 app.js modularization rollout. Three more main-IIFE concerns extracted to in-file IIFEs inside \`_monolith.js\`. After this lands, **7 of 18 main-IIFE concerns are extracted** (C01-C07); 11 remain (C08-C18) before Phase 2a wraps.

## Concerns extracted

**C05 — Forms-core** (commit \`8a2a0441\`). The biggest concern shipped so far (~184 LOC). Auto-submit on select change + the password show/hide toggle complex (eye-icon click delegate + reveal-from-stored secret POST + OIDC step-up round-trip handling + sessionStorage replay marker + per-browser opt-out). \`window.__ipamPwReplayInProgress\` is the only cross-page-load state and is already window-scoped so no extraction friction.

**C06 — Forms-confirm-bulk** (commit \`17345ecd\`). Eight small CSP-safe form-related delegates: \`data-confirm\` on form/button/link, \`data-submit-on-change\` auto-submit, \`data-stop-propagation\` guard, POST submit loading-state class (#507), \`data-select-addrs\` bulk-select helper, SSO-only toggle on users.php, reCAPTCHA v3 token fetch.

**C07 — Search + validation + wheel-hijack** (commit \`8d955d41\`). Three small adjacent input concerns: search.php site→subnet cascade filter, \`data-validate=\"ip\"/\"cidr\"\` client check, #1133 wheel-hijack guard (preventDefault on wheel over focused number inputs).

## Phase 2a progress

| Done | Remaining |
|---|---|
| C01 bootstrap, C02 theme+banners, C03 site-group, C04 ping+clear-all, **C05 forms-core, C06 forms-confirm-bulk, C07 search-validation** | C08 sidebar, C09 fill-ip-spinners, C10 typeahead, C11 dashboard-prefs, C12 subnet-addr-grids, C13 command-palette, C14 contact-picker, C15 dhcp-export, C16 backups-modals, C17 totp-toggle, C18 uplot-chart |
| **7 / 18** | **11 / 18** |

## File size trajectory

| State | Lines |
|---|---|
| Phase 0 (pre-extract) | 3,460 |
| Phase 1 (post drawer extract) | 3,214 |
| After C01 | 3,225 |
| After C02 | 3,238 |
| After C03 | 3,245 |
| After C04 | 3,257 |
| After C05 | 3,267 |
| After C06 | 3,278 |
| After C07 (this PR head) | 3,289 |

Each extraction adds ~10-15 lines (new section comment + IIFE wrapper); logic unchanged at every step.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual smoke: settings.php secret-field eye toggles reveal from stored value; step-up round-trip still works (need to test against a tenant with a configured sensitive field)
- [ ] Manual: form submit confirmations still fire on any \`data-confirm\` form
- [ ] Manual: reCAPTCHA login still works (if configured)
- [ ] Manual: search.php site filter still narrows the subnet dropdown
- [ ] Manual: focused number input + wheel scrolls the page (does NOT increment the number)

## Closes

- Nothing yet. #939 + #1047 stay open through C08-C18 + Phase 2b/3-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)