### PR TITLE
v3.34.0 wave 3 (part 15): Phase 2a — extract C08 + C09 + C10 to their own IIFEs (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -737,7 +737,16 @@
   });
 }());
 
-// ─── Main IIFE — concerns C09–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C09 — Fill-IP helper + import/restore spinners (Phase 2a, #939) ─────────
+// Three small interaction helpers grouped because they each provide
+// progress / fill-in affordances around a single click or submit:
+// (1) data-fill-ip clicks copy a next-available IP into a sibling
+// input[name=ip] inside a .card or .drawer-body; (2) the import-form
+// submit overlays a generic spinner; (3) #1135 restore-apply spinner
+// overlays a spinner AND escalates its message at 5 s and 20 s so the
+// operator knows the page hasn't frozen during a long synchronous
+// restore. All three are page-targeted (specific data-* / id), no
+// shared state with any other concern.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- "Use next IP" fill helper (data-fill-ip on addresses.php) ---
@@ -794,7 +803,12 @@
         }, 20000);
       });
     }
+  });
+}());
 
+// \u2500\u2500\u2500 Main IIFE \u2014 concerns C10\u2013C18 (Phase 2a in progress, #939) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Contact typeahead (data-contact-typeahead) ---
     document.querySelectorAll("[data-contact-typeahead]").forEach(function(input) {
       var hiddenInput = input.parentElement.querySelector("input[name=owner_contact_id]");

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -635,7 +635,14 @@
   });
 }());
 
-// ─── Main IIFE — concerns C08–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C08 — Sidebar + inline status toggle (Phase 2a, #939) ───────────────────
+// Two unrelated concerns grouped because both rebind a visible navigation
+// surface: (1) #512 sidebar hamburger toggle (mobile slide-in with overlay,
+// keyboard escape, aria-hidden state synced to viewport width); (2) #252
+// inline status toggle (click a status-badge to cycle used → reserved →
+// free → used with an XHR write-back via addresses.php update_status).
+// The sidebar dispatches `ipam:sidebar-toggle` so chart resizers can
+// re-measure after the slide animation settles.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Sidebar hamburger toggle (#512) ---
@@ -727,7 +734,12 @@
           .catch(function(){ badge.classList.remove("status-updating"); });
       });
     });
+  });
+}());
 
+// ─── Main IIFE — concerns C09–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- "Use next IP" fill helper (data-fill-ip on addresses.php) ---
     // The link can appear inside the global drawer body (Add Address /
     // Reserve Infra IPs) or alongside a sibling card on the page.

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -806,7 +806,11 @@
   });
 }());
 
-// \u2500\u2500\u2500 Main IIFE \u2014 concerns C10\u2013C18 (Phase 2a in progress, #939) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+// \u2500\u2500\u2500 C10 \u2014 Contact typeahead (Phase 2a, #939) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+// data-contact-typeahead wires a `<input>` to the contacts API with a 250 ms
+// debounce; query renders suggestions in a sibling <ul>, click stamps the
+// chosen contact's id into the hidden owner_contact_id field. Escape /
+// blur clears suggestions. Self-contained per-input closure.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Contact typeahead (data-contact-typeahead) ---
@@ -862,7 +866,12 @@
         if (e.key === "Escape") { clearSuggestions(); }
       });
     });
+  });
+}());
 
+// ─── Main IIFE — concerns C11–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Dashboard pinnable widgets + site filter (#257) ---
     (function() {
       var HIDDEN_KEY = "ipam_hidden_widgets";


### PR DESCRIPTION
Fourth Phase 2a batch in the v3.34.0 app.js modularization rollout. Three more main-IIFE concerns extracted to in-file IIFEs inside \`_monolith.js\`. After this lands, **10 of 18 main-IIFE concerns are extracted** (C01-C10); 8 remain (C11-C18) before Phase 2a wraps.

## Concerns extracted

**C08 — Sidebar + inline status toggle** (commit \`a4bfadb\`). Two unrelated UI-rebinding concerns grouped: #512 sidebar hamburger toggle (mobile slide-in with overlay, keyboard escape, aria-hidden, dispatches \`ipam:sidebar-toggle\` for chart resize sync) + #252 inline status toggle (click status-badge → cycle used → reserved → free → used with XHR write-back to update_status).

**C09 — Fill-IP helper + import/restore spinners** (commit \`fe16bbb\`). Three progress / fill-in helpers: data-fill-ip click (copy IP into sibling input[name=ip] inside .card or .drawer-body), import-form generic spinner, #1135 restore-apply spinner with escalating 5s/20s status messages.

**C10 — Contact typeahead** (commit \`e563ff7\`). data-contact-typeahead with 250ms debounce, API-fed suggestions, mousedown to stamp contact id into hidden owner_contact_id. Self-contained per-input closure.

## Phase 2a progress

**10 of 18 main-IIFE concerns extracted** (C01-C10). Remaining (8): C11 dashboard-prefs, C12 subnet-addr-grids, C13 command-palette (biggest), C14 contact-picker, C15 dhcp-export, C16 backups-modals, C17 totp-toggle, C18 uplot-chart.

## File size trajectory

\`_monolith.js\` grew from 3,289 (start of this branch) to 3,324 (+35 lines from three concern wrappers + section headers). Logic unchanged at every commit.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: mobile-width browser → hamburger button opens/closes sidebar with overlay
- [ ] Manual: addresses.php → click status-badge cycles status with XHR write-back
- [ ] Manual: subnets.php "Use next IP" link populates IP field in drawer
- [ ] Manual: import a small CSV → spinner overlay appears during upload
- [ ] Manual: any input with data-contact-typeahead → fetches suggestions on 2+ chars typed

🤖 Generated with [Claude Code](https://claude.com/claude-code)