### PR TITLE
v3.34.0 wave 3 (part 16): Phase 2a — extract C11 + C12 to their own IIFEs (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1033,7 +1033,14 @@
   });
 }());
 
-// ─── Main IIFE — concerns C12–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C12 — Subnet list/map view + address inline cell edit (Phase 2a, #939) ──
+// Two interactions specific to subnets/addresses listings: (1) #255
+// subnet list-vs-map view toggle on subnets.php (state persisted as
+// `ipam_subnet_view` in localStorage); (2) #254 inline-cell editing on
+// addresses.php row cells (click → become an input, blur or Enter →
+// XHR write-back via addresses.php update_cell, Tab → advance to next
+// editable cell in same row). Grouped because both target the
+// address/subnet grids surface.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Subnet list/map view toggle (#255) ---
@@ -1140,7 +1147,12 @@
         });
       });
     });
+  });
+}());
 
+// ─── Main IIFE — concerns C13–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Command palette ⌘K (#516) ---
     (function() {
       var bg = document.getElementById("cmd-palette-bg");

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -869,7 +869,16 @@
   });
 }());
 
-// ─── Main IIFE — concerns C11–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C11 — Dashboard prefs + per-user column visibility (Phase 2a, #939) ─────
+// Per-user UI preferences shared by the dashboard and any data-col-table:
+// (1) #257 dashboard pinnable widgets — hide/show via a gear menu, state
+// persisted as `ipam_hidden_widgets` JSON array in localStorage; plus the
+// dashboard's "by-site" filter persisted as `ipam_dash_site`. (2) #256
+// per-user column visibility for any table that opts in via
+// `data-col-table="<key>"` — gear dropdown shows column toggles, state
+// persisted as `ipam_cols_<key>` JSON array. Both concerns are
+// localStorage-backed (no server round-trip) so dashboard and table
+// preferences survive across sessions on the same browser.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Dashboard pinnable widgets + site filter (#257) ---
@@ -1021,7 +1030,12 @@
       // Apply persisted hidden columns
       hidden.forEach(function(col) { setColVisible(col, false); });
     });
+  });
+}());
 
+// ─── Main IIFE — concerns C12–C18 (Phase 2a in progress, #939) ───────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Subnet list/map view toggle (#255) ---
     (function() {
       var listView = document.getElementById("subnet-list-view");


### PR DESCRIPTION
Fifth Phase 2a batch in the v3.34.0 app.js modularization rollout. Two more main-IIFE concerns extracted; after this lands, **12 of 18** main-IIFE concerns are extracted (67%).

## Concerns extracted

**C11 — Dashboard prefs + per-user column visibility** (commit \`6d41440\`). Per-user UI preferences shared by the dashboard and any data-col-table: #257 dashboard pinnable widgets (gear menu → hide/show, state in \`ipam_hidden_widgets\` localStorage) + dashboard by-site filter (\`ipam_dash_site\`) + #256 per-user column visibility (\`data-col-table=\"<key>\"\` opt-in, state in \`ipam_cols_<key>\`). Both localStorage-backed; no server round-trip.

**C12 — Subnet view + inline cell edit** (commit \`12eae87\`). #255 subnet list-vs-map view toggle on subnets.php (state \`ipam_subnet_view\`) + #254 inline cell editing on addresses.php (click → input → XHR write-back via update_cell, Tab advances).

## Phase 2a progress

**12 of 18 concerns extracted** (67%). Remaining (6):
- C13 command palette ⌘K (~700 LOC — own dedicated PR next)
- C14 contact picker
- C15 dhcp export
- C16 backups modals
- C17 totp toggle
- C18 uPlot chart

## File size

\`_monolith.js\`: 3,324 → 3,350 lines (+26 across two commits). Logic unchanged.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: dashboard.php gear menu hides/shows widgets, state survives refresh
- [ ] Manual: dashboard.php by-site filter persists
- [ ] Manual: any data-col-table table gear menu toggles column visibility, persists
- [ ] Manual: subnets.php list/map view toggle persists across page navigations
- [ ] Manual: addresses.php inline cell edit (click cell → type → blur → row updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)