### PR TITLE
v3.34.0 wave 3 (part 17): Phase 2a — extract C13 palette + 6 sub-concerns (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1657,7 +1657,11 @@
   });
 }());
 
-// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+// ─── C13f — Contact browse overlay (#562) (Phase 2a, #939) ───────────────────
+// Full-page overlay listing contacts; opens when a `[data-browse-contacts]`
+// trigger is clicked, populates via `api.php?resource=contacts`, click a
+// row to stamp the id back into the originating hidden input. Escape to
+// close. Inner IIFE survives the wrap.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     /* ---- Contact browse overlay (#562) ---- */
@@ -1796,7 +1800,12 @@
         }
       });
     }());
+  });
+}());
 
+// ─── Main IIFE — C13g + C14-C18 (Phase 2a, #939) ─────────────────────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     /* ---- Contact card popover (#561) ---- */
     (function() {
       var card = null;

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1803,7 +1803,10 @@
   });
 }());
 
-// ─── Main IIFE — C13g + C14-C18 (Phase 2a, #939) ─────────────────────────────
+// ─── C13g — Contact card popover (#561) (Phase 2a, #939) ─────────────────────
+// Hover/focus a `.contact-link` → fetches contact details via api.php and
+// renders a small popover card. Cached per contact id; hidden on Escape
+// or scroll. Inner IIFE survives the wrap.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     /* ---- Contact card popover (#561) ---- */
@@ -1918,7 +1921,12 @@
       });
       window.addEventListener("scroll", hideCard, true);
     }());
+  });
+}());
 
+// ─── Main IIFE — C14-C18 (Phase 2a in progress, #939) ────────────────────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // --- Contact picker (v3.0.0 #563) ---
     document.querySelectorAll(".contact-picker").forEach(function(picker) {
       var contacts = [];

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1425,7 +1425,12 @@
   });
 }());
 
-// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+// ─── C13d — Subnet edit drawer (#567) (Phase 2a, #939) ───────────────────────
+// Click `.subnet-edit-btn` → hydrate `#subnet-edit-drawer` from row data
+// (vlan/vrf/site/tags/custom-fields/notes) → `IpamDrawer.openNode(...)`.
+// Cross-module dependency: IpamDrawer in `20-drawer.js` loads first.
+// Inner IIFE survives the outer wrap (closure for editDrawer + site*
+// element refs).
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     /* ---- Subnet edit drawer (#567) ---- */
@@ -1531,7 +1536,12 @@
         IpamDrawer.openNode("Edit " + d.cidr, editDrawer);
       });
     }());
+  });
+}());
 
+// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     /* ---- Subnet stats async load (#565) ---- */
     (function() {
       var placeholders = document.querySelectorAll("[data-subnet-counts]");

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1539,7 +1539,11 @@
   });
 }());
 
-// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+// ─── C13e — Subnet stats async load (#565) (Phase 2a, #939) ──────────────────
+// Lazy-fills per-subnet utilization counts after page load via
+// `api.php?resource=subnet_stats` so the table renders fast and the
+// counts trickle in. Inner IIFE survives the wrap (closure scope for
+// `placeholders` and the fetched data).
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     /* ---- Subnet stats async load (#565) ---- */
@@ -1650,7 +1654,12 @@
           });
         });
     }());
+  });
+}());
 
+// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     /* ---- Contact browse overlay (#562) ---- */
     (function() {
       var overlay = null;

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1150,7 +1150,17 @@
   });
 }());
 
-// ─── Main IIFE — concerns C13–C18 (Phase 2a in progress, #939) ───────────────
+// ─── C13 — Command palette ⌘K (Phase 2a, #939) ───────────────────────────────
+// The largest single concern in _monolith.js. ⌘K opens a quick-action
+// palette with global commands (Add Subnet, Add Address, Search, navigation
+// links, theme cycle) plus a per-page item set echoed into a JSON island
+// from `ipam_command_palette_items()` in lib.php. Fuzzy filter on input,
+// arrow-key navigation, Enter activates. Recent items persist in
+// localStorage. Cross-module dependency: opens IpamDrawer via
+// `IpamDrawer.open(...)` for Add Subnet / Add Address — IpamDrawer is in
+// `20-drawer.js` which loads before this module per the documented order.
+// Cmd/Ctrl+N shortcut to open Add Address drawer on addresses.php also
+// lives in this block (was orphan-commented in C04, removed there).
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Command palette ⌘K (#516) ---
@@ -1340,7 +1350,16 @@
         }
       });
     }());
+  });
+}());
 
+// ─── Main IIFE — concerns C14–C18 + intra-palette siblings (Phase 2a, #939) ──
+// Block still contains tooltips, audit-log expand, subnet edit drawer,
+// subnet stats async load, contact browse overlay, contact card popover,
+// contact picker, DHCP export, backups modals, TOTP toggle, uPlot chart.
+// Each will move to its own per-concern IIFE in subsequent Phase 2a commits.
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     // ── Tooltips (#354) ─────────────────────────────────────────────────────
     // A single shared #ipam-tooltip div at position:fixed is used so the bubble
     // is never clipped by overflow:hidden/clip on ancestor containers.

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1404,7 +1404,9 @@
   });
 }());
 
-// ─── Main IIFE — remaining intra-palette siblings + C14-C18 (Phase 2a, #939) ─
+// ─── C13c — Audit log expand (#564) (Phase 2a, #939) ─────────────────────────
+// Click or Enter/Space on `.audit-details` toggles `--expanded` so a
+// truncated row reveals its full payload. Delegated handlers; runs once.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     /* ---- Audit log: expand truncated details (#564) ---- */
@@ -1420,7 +1422,12 @@
       e.preventDefault();
       el.classList.toggle("audit-details--expanded");
     });
+  });
+}());
 
+// ─── Main IIFE — remaining sub-concerns + C14-C18 (Phase 2a, #939) ───────────
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     /* ---- Subnet edit drawer (#567) ---- */
     (function() {
       var editDrawer = document.getElementById("subnet-edit-drawer");

--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1353,11 +1353,11 @@
   });
 }());
 
-// ─── Main IIFE — concerns C14–C18 + intra-palette siblings (Phase 2a, #939) ──
-// Block still contains tooltips, audit-log expand, subnet edit drawer,
-// subnet stats async load, contact browse overlay, contact card popover,
-// contact picker, DHCP export, backups modals, TOTP toggle, uPlot chart.
-// Each will move to its own per-concern IIFE in subsequent Phase 2a commits.
+// ─── C13b — Tooltips (#354) (Phase 2a, #939) ─────────────────────────────────
+// Single shared `#ipam-tooltip` div at position:fixed so the bubble is never
+// clipped by overflow:hidden/clip on ancestor containers. Sweeps the page
+// for `[data-tooltip]` elements and wires mouseenter/focusin show +
+// mouseleave/focusout hide. Original code already had its own inner IIFE.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // ── Tooltips (#354) ─────────────────────────────────────────────────────
@@ -1401,7 +1401,12 @@
         el.addEventListener("focusout",   hideTip);
       });
     }());
+  });
+}());
 
+// ─── Main IIFE — remaining intra-palette siblings + C14-C18 (Phase 2a, #939) ─
+(function(){
+  document.addEventListener("DOMContentLoaded", function() {
     /* ---- Audit log: expand truncated details (#564) ---- */
     document.addEventListener("click", function(e) {
       var el = e.target.closest(".audit-details");


### PR DESCRIPTION
Sixth Phase 2a batch in the v3.34.0 app.js modularization rollout. Tackles the largest single region in \`_monolith.js\` — what the original plan §2.1 inventoried as just "C13 command palette" turned out to be the palette PLUS six sibling concerns that the same comment-divider had bundled together. All 7 now have their own IIFEs.

After this lands, **19 of 24 concerns extracted** (Amendment 1 had estimated 18; +6 for the C13 discovery means 24 total Phase 2a concerns). **5 remain** before Phase 2a wraps.

## Concerns extracted (7 commits)

| # | Concern | LOC | Notes |
|---|---|---|---|
| C13 | Command palette ⌘K (#516) | ~196 | Largest concern; cross-module IpamDrawer.open consumer; ⌘N shortcut |
| C13b | Tooltips (#354) | ~40 | Shared #ipam-tooltip; data-tooltip wires mouseenter/focusin |
| C13c | Audit-log expand (#564) | ~12 | Click/Enter/Space toggles audit-details--expanded |
| C13d | Subnet edit drawer (#567) | ~102 | Hydrates row data; calls IpamDrawer.openNode |
| C13e | Subnet stats async load (#565) | ~107 | Lazy-fills [data-subnet-counts] from api.php?resource=subnet_stats |
| C13f | Contact browse overlay (#562) | ~135 | Full-page overlay; stamps id into hidden input |
| C13g | Contact card popover (#561) | ~120 | Hover/focus contact-link; cached per-id; Escape/scroll dismiss |

## Plan correction logged

Amendment 1 inventory said C13 was a single ~700-LOC concern (\`80-command-palette.js\`). Reality: 7 distinct concerns inside the same comment-divider region. Total Phase 2a commit count revised from "~18 commits" (Amendment 1) to "~24 commits".

## Phase 2a progress

| Done (19) | Remaining (5) |
|---|---|
| C01-C12, C13, C13b-g | C14 contact-picker, C15 dhcp-export, C16 backups-modals, C17 totp-toggle, C18 uplot-chart |

## File size

\`_monolith.js\`: 3,350 → 3,417 lines (+67 across 7 commits). Logic unchanged at every step.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: ⌘K opens palette on any page, fuzzy filter works, Enter activates, ⌘N opens Add Address drawer on addresses.php
- [ ] Manual: any \`[data-tooltip]\` element shows tooltip on hover/focus
- [ ] Manual: audit-log row → expand button reveals full payload
- [ ] Manual: subnets.php pencil → edit drawer opens via IpamDrawer.openNode, tags pre-selected, custom fields hydrated
- [ ] Manual: subnets.php → subnet-counts placeholders fill in after page load
- [ ] Manual: contact-browse overlay opens, click row stamps id
- [ ] Manual: hover any \`.contact-link\` → popover card appears with details

🤖 Generated with [Claude Code](https://claude.com/claude-code)