### PR TITLE
v3.34.0 wave 3 (part 18): Phase 2a COMPLETE — extract C14-C18b, retire main IIFE (#939)

### DIFF
--- a/Simple-PHP-IPAM/assets/modules/_monolith.js
+++ b/Simple-PHP-IPAM/assets/modules/_monolith.js
@@ -1924,7 +1924,10 @@
   });
 }());
 
-// ─── Main IIFE — C14-C18 (Phase 2a in progress, #939) ────────────────────────
+// ─── C14 — Contact picker (#563) (Phase 2a, #939) ────────────────────────────
+// Per-page contact-role grid on subnet/site forms. Rebuilds rows on form
+// reset; click delete removes a row; the rows array seeds from
+// `data-existing` JSON. Inner per-picker closure survives the wrap.
 (function(){
   document.addEventListener("DOMContentLoaded", function() {
     // --- Contact picker (v3.0.0 #563) ---
@@ -1990,7 +1993,14 @@
     });
 
   });
+}());
 
+// ─── C15 — DHCP export card on dhcp_pool.php (Phase 2a, #939) ────────────────
+// Builds an export URL from selected-subnets checkboxes for dhcpd / Kea
+// formats; preview button renders the dhcpd config inline via fetch. No
+// DOMContentLoaded needed — script defer guarantees the DOM is parsed
+// before this module runs.
+(function(){
   // DHCP export card on dhcp_pool.php
   var dhcpChecklist = document.getElementById("dhcp-export-checklist");
   if (dhcpChecklist) {
@@ -2046,7 +2056,13 @@
       });
     }
   }
+}());
 
+// ─── C15b — custom_fields.php type-select preview (Phase 2a, #939) ───────────
+// On custom_fields.php, the "Type" <select> drives both the visibility of
+// the per-type options row (only "select" shows it) and which of the
+// per-type preview widgets is shown. Page-targeted; runs once at load.
+(function(){
   // custom_fields.php — type-select → options-row + preview toggle
   var cfTypeSelect = document.getElementById("cf-type-select");
   if (cfTypeSelect) {
@@ -2063,7 +2079,14 @@
     cfTypeSelect.addEventListener("change", syncCfType);
     syncCfType();
   }
+}());
 
+// ─── C17 — TOTP verify-page toggle (Phase 2a, #939) ──────────────────────────
+// On totp_verify.php, "Use a backup code instead" link flips the form
+// between TOTP code and backup code inputs (required/disabled mirroring,
+// label swap, focus management). Not the TOTP enrollment QR — that's a
+// separate concern that already has its own standalone IIFE.
+(function(){
   // TOTP backup code toggle on totp_verify.php
   var toggleBackup = document.getElementById("toggle-backup");
   if (toggleBackup) {
@@ -2086,7 +2109,14 @@
       if (isBackup && totpInput) totpInput.focus();
     });
   }
+}());
 
+// ─── C18b — SMTP test button on settings.php (Phase 2a, #939) ────────────────
+// Single button that POSTs to smtp_test.php with the page CSRF; renders
+// status (Sent / Failed / Request failed) in #smtp-test-result. Page-
+// targeted; not the dashboard uPlot chart that's also numbered C18 in
+// the original plan — that's a separate already-standalone IIFE.
+(function(){
   // SMTP test button on settings.php
   var smtpTestBtn = document.getElementById("smtp-test-btn");
   if (smtpTestBtn) {
@@ -2109,8 +2139,11 @@
         .finally(function() { smtpTestBtn.disabled = false; });
     });
   }
+}());
 
-})();
+// ─── End of Phase 2a (C01-C18 + sub-concerns). Concerns below this line are ──
+// trailing standalone IIFEs that pre-existed Phase 2a (already self-contained)
+// and will be moved to assets/modules/<NN>-<name>.js in Phase 2b / Phase 3.
 
 // backups.php modal handlers — CSP-safe event delegation on data-action attributes
 (function () {


### PR DESCRIPTION
**Final Phase 2a PR.** Extracts the last five in-IIFE concerns and removes the now-empty main IIFE wrapper. Every concern in \`_monolith.js\` is now a standalone per-concern IIFE.

## Concerns extracted

| # | Concern | Notes |
|---|---|---|
| **C14** | Contact picker (#563) | Per-page contact-role grid on subnet/site forms; data-existing JSON seed, click-delete, form-reset rebuild |
| **C15** | DHCP export card on dhcp_pool.php | Checkbox-driven URL builder for dhcpd / Kea + inline preview fetch |
| **C15b** | custom_fields.php type-select preview | Type select drives options-row visibility + per-type preview widget |
| **C17** | TOTP verify-page toggle | totp_verify.php "Use a backup code instead" form-input flip; distinct from TOTP enrollment QR (already standalone) |
| **C18b** | SMTP test button | settings.php #smtp-test-btn POSTs to smtp_test.php, renders status; distinct from C18 uPlot chart (already standalone) |

## Main IIFE retired

The wrapper \`(function(){ ... })()\` that spanned from line 1 through the SMTP block is gone. Everything inside it now lives in its own per-concern IIFE. **The trailing standalone IIFEs that pre-existed Phase 2a** (backups.php modals, TOTP enrollment QR, uPlot chart, backup history actions, site filter strip, bulk-select bar, addresses cascade, collapsible rows, passkey verify, step-up prompt, passkey registration, settings anchor remap, destinations admin, restore confirm, remote-backups delete, verify-all bulk, skeleton-toggle, resume-card POST) continue as-is — they were already self-contained.

## Phase 2a progress: 24 of 24 ✅

Originally planned ~18 in Amendment 1; +6 discovered in C13 region = 24 actual. All extracted.

## File size

\`_monolith.js\`: 3,417 → 3,450 lines (+33). Net Phase 2a delta from the pre-extraction baseline (3,214 post Phase 1): +236 lines, all comments and IIFE wrappers. Logic unchanged.

## Next phases

| Phase | What |
|---|---|
| **2b** | Mechanical cut-and-paste move of each per-concern IIFE to its own \`assets/modules/<NN>-<name>.js\` file. Each move appends an entry to the \`$jsModules\` list in \`lib/presentation.php\` (and \`demo_gate.php\`). ~24 commits. |
| **3** | Move the trailing standalone IIFEs (already self-contained) the same way. ~14 commits. |
| **4** | Delete \`_monolith.js\`. One commit. |
| **5** | Land the test umbrella (#1047). Module-load-order spec + window.\* namespace contract + prefers-reduced-motion smoke. |
| **6** | Doc sweep: replace \`assets/app.js\` references in design-guide / coding-guide / adding-a-page. CHANGELOG entry. |

## Closes

- Nothing yet. #939 + #1047 stay open until Phase 6.

## Test plan

- [ ] CI 3-driver + Playwright passes
- [ ] Manual: contact picker on a subnet/site form — add/remove rows, reset rebuilds from data-existing
- [ ] Manual: dhcp_pool.php → select subset of subnets → export dhcpd/kea URL contains the ids; preview fetch works
- [ ] Manual: custom_fields.php → change Type select → options-row appears for "select", per-type preview swaps
- [ ] Manual: totp_verify.php → click "Use a backup code instead" → form flips between inputs
- [ ] Manual: settings.php SMTP tab → SMTP test button shows status

🤖 Generated with [Claude Code](https://claude.com/claude-code)