### PR TITLE
polish(lib): redirect-stash dedup + drop dead display_datetime (#949 A36+A37)

### DIFF
--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -377,7 +377,7 @@ $db = ipam_db($config);
 ipam_db_init($db);
 
 // Now that settings are available, apply the admin-configured timezone. All DB
-// timestamps are stored as UTC; display_datetime() in lib.php converts them
+// timestamps are stored as UTC; ipam_format_datetime() in lib.php converts them
 // for UI output using the effective timezone set here.
 $tz = to_str(ipam_setting('branding.timezone'));
 if ($tz === '' || !@date_default_timezone_set($tz)) {

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -31,22 +31,6 @@ require_once __DIR__ . '/lib/csv_import.php'; // CSV-import wizard logic (ADR-00
 /* ---------------- Timestamp display ---------------- */
 
 /**
- * Convert a UTC SQLite timestamp string to the configured timezone for display.
- *
- * All timestamps are stored as UTC ('YYYY-MM-DD HH:MM:SS'). This helper converts
- * them to the timezone configured in config.php['timezone'] (default 'UTC').
- * Apply to every timestamp echo in the UI rather than using the raw DB value.
- *
- * @param  string $utcStr  UTC datetime string from the database, or empty string.
- * @param  string $format  PHP date() format string. Defaults to 'Y-m-d H:i:s'.
- * @return string          Formatted datetime in the configured timezone, or '' if input is empty.
- */
-function display_datetime(string $utcStr, string $format = 'Y-m-d H:i:s'): string
-{
-    return ipam_format_datetime($utcStr, $format);
-}
-
-/**
  * Resolve the effective display timezone for a user.
  *
  * Fallback chain: per-user users.timezone → branding.timezone setting → PHP default → UTC.

--- a/Simple-PHP-IPAM/lib/auth.php
+++ b/Simple-PHP-IPAM/lib/auth.php
@@ -86,40 +86,47 @@ function csrf_require(): void
 function is_logged_in(): bool { return !empty($_SESSION['uid']); }
 
 /**
+ * True when `$uri` is a safe same-origin relative path: starts with a single
+ * `/`, no embedded newlines (header-injection), no parent-directory
+ * traversal, no backslashes (some browsers canonicalise `\` → `/`, which
+ * would let `/\evil.com` become `//evil.com` post-normalisation), and
+ * within the 1024-byte budget. Shared by stash and consume so the two
+ * paths can never drift.
+ *
+ * Internal — call ipam_post_login_redirect_stash()/consume() instead.
+ */
+function _redirect_uri_is_safe(string $uri): bool
+{
+    if ($uri === '' || $uri[0] !== '/' || str_starts_with($uri, '//')) return false;
+    if (preg_match('/[\r\n]/', $uri))                                   return false;
+    if (str_contains($uri, '..'))                                       return false;
+    if (str_contains($uri, '\\'))                                       return false;
+    if (strlen($uri) > 1024)                                            return false;
+    return true;
+}
+
+/**
  * Stash a same-origin request URI in the session so the user can be
  * redirected back to it after they finish logging in (including any MFA
- * detour). Only safe relative paths are accepted — schemes, hosts, embedded
- * newlines, and parent-directory traversal are all rejected to prevent
- * open-redirect and header-injection.
+ * detour). Only safe relative paths are accepted — see _redirect_uri_is_safe().
  */
 function ipam_post_login_redirect_stash(string $uri): void
 {
-    if ($uri === '' || $uri[0] !== '/' || str_starts_with($uri, '//')) return;
-    if (preg_match('/[\r\n]/', $uri)) return;
-    if (str_contains($uri, '..')) return;
-    // Reject backslashes — some browsers canonicalise them to forward slashes,
-    // which would let "/\evil.com" become "//evil.com" after normalisation.
-    if (str_contains($uri, '\\')) return;
-    if (strlen($uri) > 1024) return;
+    if (!_redirect_uri_is_safe($uri)) return;
     $_SESSION['post_login_redirect'] = $uri;
 }
 
 /**
  * Pull and clear the stashed post-login URI. Returns $default if nothing is
- * stashed or the stashed value fails revalidation (defence in depth — same
- * checks as stash, in case the session was tampered with).
+ * stashed or the stashed value fails revalidation (defence in depth — the
+ * same _redirect_uri_is_safe() gate runs again here in case the session was
+ * tampered with).
  */
 function ipam_post_login_redirect_consume(string $default = 'dashboard.php'): string
 {
     $uri = to_str($_SESSION['post_login_redirect'] ?? '');
     unset($_SESSION['post_login_redirect']);
-    if ($uri === '' || $uri[0] !== '/' || str_starts_with($uri, '//')) return $default;
-    if (preg_match('/[\r\n]/', $uri)) return $default;
-    if (str_contains($uri, '..')) return $default;
-    // Reject backslashes — see note in ipam_post_login_redirect_stash().
-    if (str_contains($uri, '\\')) return $default;
-    if (strlen($uri) > 1024) return $default;
-    return $uri;
+    return _redirect_uri_is_safe($uri) ? $uri : $default;
 }
 
 /**

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -408,12 +408,12 @@ class UtilTest extends TestCase
     }
 
     // -----------------------------------------------------------------------
-    // display_datetime()
+    // ipam_format_datetime()
     // -----------------------------------------------------------------------
 
     protected function setUp(): void
     {
-        // Ensure $GLOBALS['config'] is available (display_datetime reads it).
+        // Ensure $GLOBALS['config'] is available (ipam_format_datetime reads it).
         if (!isset($GLOBALS['config'])) {
             $GLOBALS['config'] = [];
         }
@@ -422,13 +422,13 @@ class UtilTest extends TestCase
     public function testDisplayDatetimeEmptyStringReturnsEmpty(): void
     {
         ipam_setting_cache_set('branding.timezone', 'UTC', null);
-        $this->assertSame('', display_datetime(''));
+        $this->assertSame('', ipam_format_datetime(''));
     }
 
     public function testDisplayDatetimeUtcPassthrough(): void
     {
         ipam_setting_cache_set('branding.timezone', 'UTC', null);
-        $this->assertSame('2024-06-15 10:30:00', display_datetime('2024-06-15 10:30:00'));
+        $this->assertSame('2024-06-15 10:30:00', ipam_format_datetime('2024-06-15 10:30:00', 'Y-m-d H:i:s'));
     }
 
     public function testDisplayDatetimeConvertsToTokyoTime(): void
@@ -436,7 +436,7 @@ class UtilTest extends TestCase
         // Asia/Tokyo = UTC+9, no DST — unambiguous conversion.
         // 03:00 UTC → 12:00 JST
         ipam_setting_cache_set('branding.timezone', 'Asia/Tokyo', null);
-        $this->assertSame('2024-01-15 12:00:00', display_datetime('2024-01-15 03:00:00'));
+        $this->assertSame('2024-01-15 12:00:00', ipam_format_datetime('2024-01-15 03:00:00', 'Y-m-d H:i:s'));
     }
 
     public function testDisplayDatetimeConvertsToNegativeOffset(): void
@@ -444,33 +444,33 @@ class UtilTest extends TestCase
         // America/New_York in January = EST (UTC-5).
         // 17:00 UTC → 12:00 EST
         ipam_setting_cache_set('branding.timezone', 'America/New_York', null);
-        $this->assertSame('2024-01-15 12:00:00', display_datetime('2024-01-15 17:00:00'));
+        $this->assertSame('2024-01-15 12:00:00', ipam_format_datetime('2024-01-15 17:00:00', 'Y-m-d H:i:s'));
     }
 
     public function testDisplayDatetimeCustomFormat(): void
     {
         ipam_setting_cache_set('branding.timezone', 'UTC', null);
-        $this->assertSame('15/06/2024', display_datetime('2024-06-15 10:30:00', 'd/m/Y'));
+        $this->assertSame('15/06/2024', ipam_format_datetime('2024-06-15 10:30:00', 'd/m/Y'));
     }
 
     public function testDisplayDatetimeFallsBackOnInvalidInput(): void
     {
         ipam_setting_cache_set('branding.timezone', 'UTC', null);
         // Invalid datetime — should return the raw input rather than throwing.
-        $this->assertSame('not-a-date', display_datetime('not-a-date'));
+        $this->assertSame('not-a-date', ipam_format_datetime('not-a-date'));
     }
 
     public function testDisplayDatetimeEmptyTimezoneDefaultsToUtc(): void
     {
         ipam_setting_cache_set('branding.timezone', '', null);
-        $this->assertSame('2024-06-15 10:30:00', display_datetime('2024-06-15 10:30:00'));
+        $this->assertSame('2024-06-15 10:30:00', ipam_format_datetime('2024-06-15 10:30:00', 'Y-m-d H:i:s'));
     }
 
     public function testDisplayDatetimeMidnightBoundary(): void
     {
         // UTC+9: 2024-01-16 00:00:00 JST = 2024-01-15 15:00:00 UTC
         ipam_setting_cache_set('branding.timezone', 'Asia/Tokyo', null);
-        $this->assertSame('2024-01-16 00:00:00', display_datetime('2024-01-15 15:00:00'));
+        $this->assertSame('2024-01-16 00:00:00', ipam_format_datetime('2024-01-15 15:00:00', 'Y-m-d H:i:s'));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two A.P3 nits from milestone #58 #949 umbrella. Both safe, tiny, and isolated.

- **A36** — drop dead `display_datetime()` wrapper in `lib.php`. Zero callers across the source tree; was a 4-line passthrough to `ipam_format_datetime()`. The 8 TZ-conversion tests in `tests/UtilTest.php` (Tokyo, NY, midnight boundary, empty-TZ fallback) now call `ipam_format_datetime()` directly with the explicit `'Y-m-d H:i:s'` format (the canonical helper defaults to `'Y-m-d H:i T'`) — preserves the unique surface that `FormatDatetimeTest.php` doesn't reach.
- **A37** — extract `_redirect_uri_is_safe()` private helper in `lib/auth.php`. `ipam_post_login_redirect_stash()` and `…_consume()` had byte-identical 5-line validation gates (single leading `/`, no `//`, no `\r\n`, no `..`, no `\`, ≤1024 bytes). They now share one rule list; can never drift.

While reviewing the umbrella, also verified that **A41** (`oidc_jwks` cache-write success check) is already implemented at `lib.php:5512` — the code already detects `file_put_contents` failure and `error_log`s with a clear "JWKS will be re-fetched until the write succeeds" message.

## Items still open in #949

- A34 — format_bytes precision (needs spec clarity: per-unit decimals vs relative precision)
- A38 — `@`-suppression audit
- A39 — dead unset parameters
- A40 — string-length sentinels (1024, 2048, 200) → centralised constants

Will land in follow-up PRs as the scope of each becomes concrete. #949 stays open until they're done.

## Test plan

- [x] `composer ci-gate` — PHPUnit 1517/1517, PHPStan no errors, PHPCS clean, icons audit clean
- [x] Renamed datetime tests 8/8 (Tokyo/NY/midnight/empty-TZ all green with explicit `'Y-m-d H:i:s'` format)
- [ ] CI full matrix (PHP QA × 4 + Playwright × 4 + semgrep + .htaccess × 2 + MailHog + API regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)