### PR TITLE
polish(lib): drop dead parameters in housekeeping + import helpers (#949 A39)

### DIFF
--- a/Simple-PHP-IPAM/import_csv.php
+++ b/Simple-PHP-IPAM/import_csv.php
@@ -76,7 +76,7 @@ if ($step === 1 && $_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ??
     if ($upload === null || empty($upload['tmp_name']) || !is_uploaded_file(to_str($upload['tmp_name']))) {
         $err = 'No file uploaded.';
     } else {
-        $maxBytes = import_max_bytes($config);
+        $maxBytes = import_max_bytes();
         $size = to_int($upload['size'] ?? 0);
         if ($size > $maxBytes) {
             $err = 'File too large (max ' . (int)round($maxBytes / 1024 / 1024) . 'MB).';
@@ -175,7 +175,7 @@ if ($step === 1) {
         <input type="hidden" name="csrf" value="<?= e(csrf_token()) ?>">
         <input type="hidden" name="action" value="upload">
         <p><input type="file" name="csv" accept=".csv,text/csv" required></p>
-        <p class="muted">Max upload size: <?= e((string)((int)round(import_max_bytes($config)/1024/1024))) ?>MB</p>
+        <p class="muted">Max upload size: <?= e((string)((int)round(import_max_bytes()/1024/1024))) ?>MB</p>
         <p><button type="submit">Upload</button></p>
       </form>
     </div>

--- a/Simple-PHP-IPAM/init.php
+++ b/Simple-PHP-IPAM/init.php
@@ -400,7 +400,7 @@ if ($_staleConfigKeys) {
 unset($_staleConfigKeys);
 
 // Run best-effort housekeeping at most once/day (configurable)
-run_housekeeping_if_due($config, $db);
+run_housekeeping_if_due($db);
 
 // Utilization alerts — independent interval (default 1 h); no-op if alert_email is empty
 alerts_check_if_due($config, $db);

--- a/Simple-PHP-IPAM/lib.php
+++ b/Simple-PHP-IPAM/lib.php
@@ -655,14 +655,17 @@ function ipam_config_sync(string $configPath, array $loaded): array
  */
 function ipam_validate_config(array $config): array
 {
+    // A39 (#949): every check uses the same `<`-comparison ("warn when
+    // val < min" === "required: val >= min"), so the legacy operator field
+    // in each tuple was dead. Dropped.
     $warnings = [];
     $checks = [
-        ['security.session_idle_seconds',  60, '>=', 'session_idle_seconds'],
-        ['security.login_max_attempts',     1, '>=', 'login_max_attempts'],
-        ['security.login_lockout_seconds',  1, '>=', 'login_lockout_seconds'],
-        ['housekeeping.audit_log_retention_days', 0, '>=', 'audit_log_retention_days'],
+        ['security.session_idle_seconds',         60, 'session_idle_seconds'],
+        ['security.login_max_attempts',            1, 'login_max_attempts'],
+        ['security.login_lockout_seconds',         1, 'login_lockout_seconds'],
+        ['housekeeping.audit_log_retention_days',  0, 'audit_log_retention_days'],
     ];
-    foreach ($checks as [$key, $min, $op, $label]) {
+    foreach ($checks as [$key, $min, $label]) {
         $val = to_int(ipam_setting($key));
         if ($val < $min) {
             $warnings[] = "{$label} is {$val}; minimum is {$min}.";
@@ -697,10 +700,13 @@ function housekeeping_state_path(): string
 }
 
 /**
+ * A39 (#949): the legacy `$config` parameter was unused — settings are
+ * read via `ipam_setting()` since the settings-table migration in v2.6.0.
+ * Dropped here and at the two call sites in lib.php.
+ *
  * @phpstan-impure
- * @param IpamConfig $config
  */
-function housekeeping_should_run(array $config): bool
+function housekeeping_should_run(): bool
 {
     if (!(bool)ipam_setting('housekeeping.enabled')) return false;
 
@@ -1058,10 +1064,14 @@ function alerts_check_if_due(array $config, PDO $db): void
     @chmod($statePath, 0600);
 }
 
-/** @param IpamConfig $config */
-function run_housekeeping_if_due(array $config, ?PDO $db = null): void
+/**
+ * A39 (#949): the legacy `$config` parameter was unused — all settings
+ * are read via `ipam_setting()`, same as `housekeeping_should_run()`.
+ * Dropped here and at the single call site in init.php.
+ */
+function run_housekeeping_if_due(?PDO $db = null): void
 {
-    if (!housekeeping_should_run($config)) return;
+    if (!housekeeping_should_run()) return;
 
     $lockPath = __DIR__ . '/data/housekeeping.lock';
     $lock = @fopen($lockPath, 'c');
@@ -1073,7 +1083,7 @@ function run_housekeeping_if_due(array $config, ?PDO $db = null): void
     }
 
     try {
-        if (!housekeeping_should_run($config)) return;
+        if (!housekeeping_should_run()) return;
 
         $ttl = to_int(ipam_setting('housekeeping.tmp_cleanup_ttl_seconds'));
         if ($ttl < 3600) $ttl = 3600;
@@ -4407,8 +4417,12 @@ function ipv6_enumerate_first_n(PDO $db, int $subnetId, string $networkBin, int 
 
 /* ---------------- CSV import helpers ---------------- */
 
-/** @param IpamConfig $config */
-function import_max_bytes(array $config): int
+/**
+ * A39 (#949): the legacy `$config` parameter was unused — the upper-bound
+ * comes from `limits.import_csv_max_mb` via `ipam_setting()` since v2.6.0.
+ * Dropped here and at the two call sites in import_csv.php.
+ */
+function import_max_bytes(): int
 {
     $mb = to_int(ipam_setting('limits.import_csv_max_mb'));
     if ($mb < 5) $mb = 5;


### PR DESCRIPTION
## Summary

A39 from the #949 umbrella. Three internal helpers carried a vestigial `\$config` parameter that the v2.6.0 settings-table migration made unused. Bodies read every value through `ipam_setting()` since v2.6.0; the parameter contributes nothing.

| Function | Before | After |
|---|---|---|
| `housekeeping_should_run` | `(array \$config): bool` | `(): bool` |
| `run_housekeeping_if_due` | `(array \$config, ?PDO \$db = null): void` | `(?PDO \$db = null): void` |
| `import_max_bytes` | `(array \$config): int` | `(): int` |

Five call sites updated (2 in lib.php, 1 in init.php, 2 in import_csv.php).

Bonus: dropped the dead `\$op` operator field in the `housekeeping_warnings()` `\$checks` tuple at `lib.php:665`. Every check uses the same `<`-comparison, so the operator string was self-documentation the loop never read.

## #949 status after this PR

| Item | Status |
|---|---|
| A34 — format_bytes precision | open (needs spec clarity) |
| A36 — display_datetime drop | ✅ #1286 |
| A37 — redirect-stash dedup | ✅ #1286 |
| A38 — @-suppressions audit | open |
| A39 — dead unset parameters | ✅ this PR |
| A40 — string-length sentinels | mostly N/A (only 1 duplicate, captured by `_redirect_uri_is_safe()`) |
| A41 — oidc_jwks cache-write check | already implemented (lib.php:5512) |

#949 stays open until A34 + A38 are resolved.

## Test plan

- [x] `composer ci-gate` — PHPUnit 1517/1517, PHPStan no errors, PHPCS clean, icons audit clean
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)