### PR TITLE
test(modules): pin $jsModules byte-parity between page_header() and demo_gate.php (#950 B31)

### DIFF
--- a/tests/JsModulesParityTest.php
+++ b/tests/JsModulesParityTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/bootstrap.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * B31 (#950): `Simple-PHP-IPAM/lib/presentation.php` (consumed by
+ * `page_header()` on every authenticated page) and
+ * `Simple-PHP-IPAM/demo_gate.php` (its own `<head>` for the pre-login
+ * gate) each declare a `$jsModules` array. They must stay byte-identical
+ * — drift means one surface ships a different module set than the
+ * other, which the v3.34.0 frontend-modularization split (#939) was
+ * explicitly designed to prevent.
+ *
+ * Static-extracting both arrays via regex and asserting equality is a
+ * cheap drift gate. The Playwright `frontend-modules.spec.ts` already
+ * covers the page_header() side; this test pins the demo_gate.php side
+ * without needing to spin up demo_mode in a dockerized harness.
+ */
+final class JsModulesParityTest extends TestCase
+{
+    /**
+     * Read `$jsModules = [ … ];` out of $php and return the module
+     * names (each quoted string element) in order.
+     *
+     * @return list<string>
+     */
+    private function extractJsModules(string $path): array
+    {
+        $php = (string) file_get_contents($path);
+        $this->assertNotEmpty($php, "{$path} must be readable");
+
+        if (!preg_match('/\$jsModules\s*=\s*\[(.*?)\];/s', $php, $m)) {
+            $this->fail("{$path} does not contain a `\$jsModules = [ … ]` array literal");
+        }
+        $body = $m[1];
+
+        // Strip line comments so module names aren't picked out of the
+        // `// C01 — synchronous theme apply pre-paint` annotations.
+        $body = preg_replace('~//[^\n]*~', '', $body) ?? $body;
+
+        if (!preg_match_all("/'([a-z0-9-]+)'/", $body, $mm)) {
+            $this->fail("{$path} `\$jsModules` array contains no quoted module names");
+        }
+        return $mm[1];
+    }
+
+    public function testPageHeaderAndDemoGateShareTheSameModuleList(): void
+    {
+        $presentation = $this->extractJsModules(__DIR__ . '/../Simple-PHP-IPAM/lib/presentation.php');
+        $demoGate     = $this->extractJsModules(__DIR__ . '/../Simple-PHP-IPAM/demo_gate.php');
+
+        $this->assertNotEmpty($presentation, 'lib/presentation.php $jsModules must be non-empty');
+        $this->assertSame(
+            $presentation,
+            $demoGate,
+            '#950 B31: lib/presentation.php and demo_gate.php $jsModules arrays must stay byte-identical. '
+            . "Drift means the gate page ships a different module set than the authenticated surface. "
+            . 'If you added a module, register it in BOTH files.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

B31 from the #950 umbrella. The v3.34.0 frontend split (#939) introduced two parallel emit sites for the module list:

- `Simple-PHP-IPAM/lib/presentation.php` — consumed by `page_header()` on every authenticated page
- `Simple-PHP-IPAM/demo_gate.php` — its own `<head>` for the pre-login gate (does not call `page_header()`)

`testing/playwright/tests/frontend-modules.spec.ts` covers the `page_header()` side via the AUTHED_PAGES roster. `demo_gate.php` is harder to reach from Playwright because it only renders when `demo_mode.enabled = true` in the runtime config — not the default in the dockerized harness.

This PHPUnit test closes the gap: regex-extracts the `\$jsModules` array literal from both files, asserts byte-identical ordered lists. Cheap drift gate; sanity-checked locally by injecting a synthetic `'c5-sudo-replay-resume-DRIFT'` token in `demo_gate.php` and confirming the assertion fires.

## #950 status after this PR

| Item | Status |
|---|---|
| B25 — `e()`-over-escaped output audit | open |
| B26 — `api_json` vs raw `echo json_encode` | open |
| B27 — `audit.php` parse_sort accessor | open |
| B28 — `init.php` bootstrap-creep refactor | open |
| B29 — `users.php` validRoles → const | ✅ already done (USERS_VALID_ROLES) |
| B30 — `api.php` session-name fallback dup | ✅ already done (`ipam_session_name()` helper) |
| B31 — demo_gate cache-buster CI check | ✅ this PR |
| B32 — `unassigned.php` POST guard ordering | confirmed canonical, no-op |

## Test plan

- [x] `composer ci-gate` — PHPUnit 1518/1518 (+1), PHPStan no errors, PHPCS clean, icons audit clean
- [x] Synthetic-drift sanity check passes (1-token rename in `demo_gate.php` fails the test)
- [ ] CI full matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)