### PR TITLE
polish(api): route early-error paths through canonical api_json() (#952 B26)

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -74,8 +74,7 @@ if (login_rate_limited($db, $clientIp, $apiMaxAttempts, $apiLockoutSeconds)) {
     http_response_code(429);
     header('Retry-After: ' . $apiLockoutSeconds);
     header('X-RateLimit-Limit: ' . $apiMaxAttempts);
-    echo json_encode(['error' => 'Too many failed API key attempts. Try again later.']);
-    exit;
+    api_json(['error' => 'Too many failed API key attempts. Try again later.']);
 }
 
 $rawKey = '';
@@ -122,8 +121,7 @@ if ($rawKey === '') {
 
 if ($rawKey === '' && $sessionApiKey === null) {
     http_response_code(401);
-    echo json_encode(['error' => 'API key required. Pass via Authorization: Bearer <key> header.']);
-    exit;
+    api_json(['error' => 'API key required. Pass via Authorization: Bearer <key> header.']);
 }
 
 if ($sessionApiKey !== null) {
@@ -138,8 +136,7 @@ if ($sessionApiKey !== null) {
     if (!$apiKey) {
         record_login_failure($db, $clientIp);
         http_response_code(401);
-        echo json_encode(['error' => 'Invalid or inactive API key.']);
-        exit;
+        api_json(['error' => 'Invalid or inactive API key.']);
     }
 
     // Successful auth — clear any accumulated failures for this IP
@@ -156,8 +153,7 @@ if ($sessionApiKey !== null) {
     if ($rateLimitRetryAfter > 0) {
         http_response_code(429);
         header('Retry-After: ' . $rateLimitRetryAfter);
-        echo json_encode(['error' => 'Rate limit exceeded. Too many requests for this API key.']);
-        exit;
+        api_json(['error' => 'Rate limit exceeded. Too many requests for this API key.']);
     }
 }
 


### PR DESCRIPTION
## Summary

B26 from the #952 umbrella. `api.php` pre-auth bailouts (rate-limit, missing key, invalid key, per-key rate-limit) emitted JSON via raw \`echo json_encode(...); exit\` instead of the canonical \`api_json()\` helper defined at L317. The wave 2 cleanup (#1268) missed these four call sites because the function is hoisted by PHP's parser — callable from earlier in the file.

| Site | Status |
|---|---|
| L77 (429 — IP rate limit) | → api_json |
| L125 (401 — API key required) | → api_json |
| L141 (401 — invalid key) | → api_json |
| L159 (429 — per-key rate limit) | → api_json |

\`api_json()\` is \`echo json_encode(\$data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); exit;\` — byte-identical for the existing ASCII-only no-slashes error responses. Single remaining raw \`echo json_encode\` in the file is the one inside \`api_json()\` itself.

## #952 status after this PR

| Item | Status |
|---|---|
| B14 — envelope=1 parsing | ✅ already addressed (`api.php:370` carries `// B14 (#952)` ref) |
| B15 — api_subnets countsSelect/Join | no hits — already cleaned |
| B16 — addrDistinctSiteCount | not dead (`addresses.php:591` consumes it) |
| B17 — audit pluralisation | open |
| B18 — users.php self-protection | ✅ already addressed (`users.php:18` carries `// B18:` ref) |
| B19 — CLI guard dedup | structurally unavoidable (must run before `init.php`; helper can't come from `lib/`) |
| B20 — oidc_callback double-cast | ✅ already addressed (`oidc_callback.php:44` carries `// B20:` ref) |
| B21 — scan_run vs cron overlap | open |
| B22 — tag/contact audit coverage | open |
| B23/B24 | not concretely specified in code_quality_review.md |
| B26 — api_json consistency | ✅ this PR |

## Test plan

- [x] \`composer ci-gate\` — PHPUnit 1518/1518, PHPStan no errors, PHPCS clean, icons audit clean
- [x] Single raw \`echo json_encode\` in api.php is the one inside \`api_json()\` itself (canonical)
- [ ] CI full matrix (especially API regression — verifies the 4 early-error responses still emit the same JSON shape + status code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)