### PR TITLE
chore(release): apply CR fixes from #1296 review

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,7 @@ on:
       - 'testing/playwright/**'
       - 'testing/scripts/**'
       - '.github/workflows/playwright.yml'
+      - '.github/actions/setup-php-ipam/**'
 
 concurrency:
   group: playwright-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ as of v1.15.0. Versions prior to 1.15.0 used two-part numbering.
 
 ## [3.34.0] - 2026-05-21
 
-Refactor Wave 3 — frontend modularization. A pure code-quality release; no schema migrations, no new config keys, no new operator-facing pages. Closes 9 milestone-#58 issues plus 3 umbrellas (#949 #950 #952) with full per-item disposition. The 4 substantial deferred items are carried forward to milestone #85 (Refactor wave 4).
+Refactor Wave 3 — frontend modularization. A pure code-quality release; no schema migrations, no new config keys, no new operator-facing pages. Closes 9 milestone-#58 issues plus 3 umbrellas (#949 #950 #952) with full per-item disposition. **8 items carry forward to milestone #85 (Refactor wave 4):** 4 newly filed from the wave-3 review (#1290 #1291 #1292 #1293) and 4 pre-existing deferrals (#775 #944 #946 #1243).
 
 ### Refactor Wave 3 — frontend modularization (#58, #939, #1047)
 
@@ -2029,6 +2029,7 @@ Settings-in-database groundwork release. Introduces a new `settings` table, a ty
 - CSV exports for addresses, search results, audit log, unassigned IPs, and import reports.
 - CSV import safety: dry-run plan, row-level report, duplicate/conflict detection.
 
+[3.34.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.33.0...v3.34.0
 [3.33.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.32.0...v3.33.0
 [3.32.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.31.0...v3.32.0
 [3.31.0]: https://github.com/seanmousseau/Simple-PHP-IPAM/compare/v3.30.0...v3.31.0


### PR DESCRIPTION
Three release-PR-class fixes from CodeRabbit's review of dev→main PR #1296:

1. **Playwright workflow path filter** now includes `.github/actions/setup-php-ipam/**` so PRs changing only the composite action still trigger the Playwright gate. (Major.)
2. **CHANGELOG.md `[3.34.0]` compare-link** added at the bottom of the file. (Minor.)
3. **"4 substantial deferred items"** reworded to "4 newly filed + 4 pre-existing" — matches the actual enumeration. (Minor.)

CHANGELOG follow-up lint clean. Tarball SHA256 unchanged (repo-root files aren't in the bundle).

The remaining 13 CR comments concern pre-existing module code already reviewed at original dev merges — out of scope for the release-promotion PR. Will track those as wave-4 polish issues if/when prioritised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)