### PR TITLE
test(vr): restore dashboard VR with dedicated mutation-isolated project (#775)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ Thumbs.db
 # Playwright test artifacts
 test-results/
 .playwright-mcp/
+# vr-dashboard setup writes session cookies here — never commit
+testing/playwright/tests/vr-dashboard.storage.json
 
 # Session/scratch files
 .remember/

--- a/docs/internal/test-suites.md
+++ b/docs/internal/test-suites.md
@@ -319,25 +319,62 @@ Pick a fresh `NN` outside that set (`10.92`, `10.94`, `10.95`, …) for any new 
 
 The `deleteSubnet()` fixture in `testing/playwright/fixtures/ipam.ts` is now a bounded loop (defence-in-depth against orphan rows when `UNIQUE(cidr, vrf_id)` doesn't dedupe NULL `vrf_id` per SQL standard), but the loop is not a substitute for unique-CIDR-per-spec — the loop only handles the same spec's own orphans, not cross-spec races.
 
-### Dashboard is excluded from visual-regression — manual smoke check during release gate
+### Dashboard visual-regression — mutation-isolated dedicated project (#775, v3.35.0)
 
-`tests/visual-regression.spec.ts` no longer captures `dashboard.php`. Every widget on the dashboard reflects live DB state — security-warning banner (config / app_secret / HTTPS state), Top IPv4 Subnets by Usage (live address counts), Addresses by Site (per-site totals), Expiring Addresses (lease-date sensitive), Recent Activity (audit_log timestamps + ordering). Under the parallel Playwright harness, dozens of workers mutate the shared SQLite DB concurrently with the dashboard capture, so every widget renders differently between baseline-snapshot and re-run. Masking individual widgets via Playwright `mask` failed (variable widget heights leak diff pixels into the surrounding layout); DOM-removal via `page.evaluate` only solved one of five volatile sources. Restoring dashboard VR coverage requires a mutation-isolated capture path (separate worker pool with its own DB, or a serial pre-mutation capture step) — tracked as a v3.20.0 follow-up.
+`dashboard.php` is back in `tests/visual-regression.spec.ts` as of v3.35.0, captured by a set of dedicated Playwright projects (`vr-dashboard-1440`, `vr-dashboard-1024`, `vr-dashboard-768`, `vr-dashboard-375`) that run serially against a freshly-seeded DB.
 
-**Manual smoke check during every release gate.** Because the dashboard is a high-traffic page that can break in obvious ways (broken widget, broken theme, layout collapse on small viewports), the AI agent driving the release gate MUST manually verify it. Procedure:
+**Why a dedicated project is required.** Every dashboard widget reflects live DB state — security-warning banner (config / app_secret / HTTPS state), Top IPv4 Subnets by Usage (live address counts), Addresses by Site (per-site totals), Expiring Addresses (lease-date sensitive), Recent Activity (audit_log timestamps + ordering). Under the shared DB the main E2E suite mutates these values, making VR non-deterministic. The v3.19.0 attempt to mask or DOM-remove individual widgets failed because widget heights vary, leaking diff pixels into the surrounding layout.
+
+**How the isolation works.**
+
+1. `vr-dashboard-setup` is declared as a Playwright project dependency of all four `vr-dashboard-*` capture projects. Playwright fires all declared dependencies before running any dependent project.
+2. The setup step (`tests/vr-dashboard.setup.ts`) calls `bootstrap-app.sh <driver>` to reseed the DB to its canonical demo state, then logs in as admin and writes `tests/vr-dashboard.storage.json` (session cookies).
+3. Each `vr-dashboard-*` capture project injects the stored session via `storageState` in its `use{}` block, navigates to `dashboard.php` in a known-quiet DB, and captures the screenshot.
+4. Standard `vr-*` projects carry `grepInvert: /@vr-dashboard/` so they never run the dashboard test; `vr-dashboard-*` projects carry `grep: /@vr-dashboard/` so they run only the dashboard test. The tag appears in the test title (`dashboard — light @vr-dashboard`).
+
+**Running the dashboard VR projects manually:**
+
+```bash
+bash testing/bootstrap-app.sh sqlite   # or mysql / pgsql
+cd testing/playwright
+IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test visual-regression --project=vr-dashboard-setup \
+                                        --project=vr-dashboard-1440 \
+                                        --project=vr-dashboard-1024 \
+                                        --project=vr-dashboard-768  \
+                                        --project=vr-dashboard-375
+```
+
+To capture new baselines after an intentional UI change:
+
+```bash
+# Same command with --update-snapshots
+IPAM_BASE_URL=https://127.0.0.1:8443 IPAM_ADMIN_USER=demo IPAM_ADMIN_PASS=demo \
+  npx playwright test visual-regression --project=vr-dashboard-setup \
+                                        --project=vr-dashboard-1440 \
+                                        --project=vr-dashboard-1024 \
+                                        --project=vr-dashboard-768  \
+                                        --project=vr-dashboard-375  \
+                                        --update-snapshots
+git add testing/playwright/tests/visual-regression.spec.ts-snapshots/dashboard*.png
+git commit -m "test(vr): refresh dashboard baselines"
+```
+
+**Manual smoke check — backup procedure (keep until two stable release cycles).**
+
+The automated coverage above is new as of v3.35.0. Until two release cycles confirm it is reliable, the manual check documented in v3.19.0 remains as a backup and is NOT a gate violation to skip once the automated run is green. If the automated `vr-dashboard-*` projects fail for a non-obvious reason during a release gate, fall back to the manual procedure:
 
 1. After `bootstrap-app.sh sqlite` is up, use the Playwright MCP to navigate to `https://127.0.0.1:8443/dashboard.php` (after logging in as `demo`/`demo`) at viewport widths 1440, 1024, 768, and 375.
 2. At each viewport, take a screenshot via `browser_take_screenshot` and **read it** (multimodal — the agent has visual access to PNGs).
 3. Check for: missing widgets (top-subnets, by-site, expiring-addresses, recent-activity, metrics row), broken layout (overflow, collapsed columns, off-canvas elements), broken theme switch (light vs dark — toggle via the data-theme attribute), zero-data states (empty tables should show a graceful empty state, not a broken table head).
 4. If anything looks wrong, treat it as a release-blocking failure and surface to the user before pushing.
-5. Repeat the same pass for the **mysql** and **pgsql** drivers — dashboard rendering differences across engines are the most common visible regressions.
-
-Skipping this manual check during a release run is a gate violation. The check is fast (~30 seconds per driver) and catches the failure mode that automated VR was supposed to but cannot reliably cover under parallelism.
+5. Repeat the same pass for the **mysql** and **pgsql** drivers.
 
 ### Visual-regression baselines are platform-suffixed and need refreshing on intentional UI/seed changes
 
 `testing/playwright/tests/visual-regression.spec.ts-snapshots/` holds per-platform PNG baselines (`*-darwin.png`, `*-linux.png`). Filenames include the host OS because Chromium's text shaping and AA differ between CoreText (macOS) and HarfBuzz+FreeType (Linux Docker), producing low-amplitude pixel diffs even when the bundled `@font-face` woff2s render identically.
 
-CI's `playwright.yml` job runs in Linux Docker, so it only validates and refreshes `*-linux.png` baselines. **Darwin baselines drift over time** — every release that grows `demo_seed.php` (more rows on the captured pages) or restructures a captured page will eventually push the rendered page taller than the committed darwin baseline, and a local-mac VR run shows a cluster of visual-regression failures with the signature: `Expected an image WIDTHpx by Hpx, received WIDTHpx by H'px` where `H' < H`, on `subnets-*` / `addresses-*` / `search-*` across the 4 viewports. (Dashboard is excluded from automated VR — see the section above.)
+CI's `playwright.yml` job runs in Linux Docker, so it only validates and refreshes `*-linux.png` baselines. **Darwin baselines drift over time** — every release that grows `demo_seed.php` (more rows on the captured pages) or restructures a captured page will eventually push the rendered page taller than the committed darwin baseline, and a local-mac VR run shows a cluster of visual-regression failures with the signature: `Expected an image WIDTHpx by Hpx, received WIDTHpx by H'px` where `H' < H`, on `subnets-*` / `addresses-*` / `search-*` / `dashboard-*` across the 4 viewports.
 
 **This is not a regression.** It is platform-suffixed baseline maintenance debt.
 

--- a/testing/playwright/playwright.config.ts
+++ b/testing/playwright/playwright.config.ts
@@ -54,12 +54,20 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      testIgnore: /visual-regression/,
+      testIgnore: /visual-regression|vr-dashboard/,
       use: { ...devices['Desktop Chrome'] },
     },
+
+    // ── Standard VR projects (non-dashboard pages) ───────────────────────────
+    // These run against whatever DB state the main suite left behind.
+    // Dashboard tests carry the @vr-dashboard tag and are excluded via
+    // grepInvert so they are only captured by the mutation-isolated
+    // vr-dashboard-* projects below.
     {
       name: 'vr-1440',
       testMatch: /visual-regression/,
+      testIgnore: /vr-dashboard/,
+      grepInvert: /@vr-dashboard/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1440, height: 900 },
@@ -69,6 +77,8 @@ export default defineConfig({
     {
       name: 'vr-1024',
       testMatch: /visual-regression/,
+      testIgnore: /vr-dashboard/,
+      grepInvert: /@vr-dashboard/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 1024, height: 768 },
@@ -78,6 +88,8 @@ export default defineConfig({
     {
       name: 'vr-768',
       testMatch: /visual-regression/,
+      testIgnore: /vr-dashboard/,
+      grepInvert: /@vr-dashboard/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 768, height: 1024 },
@@ -87,10 +99,84 @@ export default defineConfig({
     {
       name: 'vr-375',
       testMatch: /visual-regression/,
+      testIgnore: /vr-dashboard/,
+      grepInvert: /@vr-dashboard/,
       use: {
         ...devices['Desktop Chrome'],
         viewport: { width: 375, height: 812 },
         deviceScaleFactor: 1,
+      },
+    },
+
+    // ── Dashboard VR projects (mutation-isolated, #775) ──────────────────────
+    // These run serially against a freshly-seeded DB so dashboard widgets
+    // (top-subnets, by-site, expiring-addresses, recent-activity) capture
+    // deterministic, known-quiet state. The setup project re-bootstraps the
+    // app container before any screenshot is taken.
+    //
+    // Playwright fires project dependencies in declaration order. Declare the
+    // setup project first so its DB reseed completes before any vr-dashboard-*
+    // capture begins.
+    {
+      name: 'vr-dashboard-setup',
+      testMatch: /vr-dashboard\.setup/,
+      fullyParallel: false,
+      workers: 1,
+    },
+    {
+      name: 'vr-dashboard-1440',
+      testMatch: /visual-regression/,
+      fullyParallel: false,
+      workers: 1,
+      dependencies: ['vr-dashboard-setup'],
+      grep: /@vr-dashboard/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+        deviceScaleFactor: 1,
+        storageState: 'tests/vr-dashboard.storage.json',
+      },
+    },
+    {
+      name: 'vr-dashboard-1024',
+      testMatch: /visual-regression/,
+      fullyParallel: false,
+      workers: 1,
+      dependencies: ['vr-dashboard-setup'],
+      grep: /@vr-dashboard/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1024, height: 768 },
+        deviceScaleFactor: 1,
+        storageState: 'tests/vr-dashboard.storage.json',
+      },
+    },
+    {
+      name: 'vr-dashboard-768',
+      testMatch: /visual-regression/,
+      fullyParallel: false,
+      workers: 1,
+      dependencies: ['vr-dashboard-setup'],
+      grep: /@vr-dashboard/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 768, height: 1024 },
+        deviceScaleFactor: 1,
+        storageState: 'tests/vr-dashboard.storage.json',
+      },
+    },
+    {
+      name: 'vr-dashboard-375',
+      testMatch: /visual-regression/,
+      fullyParallel: false,
+      workers: 1,
+      dependencies: ['vr-dashboard-setup'],
+      grep: /@vr-dashboard/,
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 375, height: 812 },
+        deviceScaleFactor: 1,
+        storageState: 'tests/vr-dashboard.storage.json',
       },
     },
   ],

--- a/testing/playwright/tests/visual-regression.spec.ts
+++ b/testing/playwright/tests/visual-regression.spec.ts
@@ -23,15 +23,12 @@ interface VRPage {
   name: string;
   path: string;
   skipAuth?: boolean;
+  /** Optional Playwright grep tag (e.g. '@vr-dashboard'). When set the test
+   *  title includes this tag so a project's `grep` option can select or
+   *  de-select it without touching any other project's test list. */
+  tag?: string;
 }
 
-// Dashboard intentionally excluded — every widget on it (security-warning
-// banner, top-subnets, by-site, expiring-addresses, recent-activity) reflects
-// live DB state that mutates under parallel test workers, making VR coverage
-// fundamentally unstable in this harness. Tracked as a v3.20.0 follow-up to
-// restore coverage with a mutation-isolated capture path. Until then,
-// dashboard rendering changes are a manual smoke-test item during release prep.
-//
 // `subnets` was VR-covered v3.26.0–v3.31.0 but is excluded again as of
 // v3.32.0 (#1251). When #1206 re-enabled the vr-* projects in CI it surfaced
 // that the CI job runs the vr-* step AFTER the main E2E suite, in the same
@@ -39,7 +36,7 @@ interface VRPage {
 // so the suite-created rows make the page ~600 px taller than a clean-seed
 // baseline (`Expected 1440x3024, received 1440x3626`) — a structural height
 // mismatch, not a rendering drift. Restoring coverage needs the same
-// mutation-isolated capture path tracked for the dashboard (#1251).
+// mutation-isolated capture path tracked for the dashboard.
 // `search` stays covered — its default view does not grow with suite rows.
 //
 // Backup & Restore tabs (#1040, v3.21.0):
@@ -49,12 +46,22 @@ interface VRPage {
 //     the dashboard: they render destination/schedule/history rows that
 //     other tests create and tear down. Re-evaluate once the dashboard
 //     mutation-isolation work lands.
+//
+// Dashboard (#775, v3.35.0):
+//   Restored with a mutation-isolated capture path. The `@vr-dashboard` tag
+//   routes this page to the `vr-dashboard-*` projects in playwright.config.ts,
+//   which declare a `vr-dashboard-setup` dependency that re-bootstraps the app
+//   against a freshly-seeded DB before any screenshot is taken. The standard
+//   `vr-*` projects exclude tagged tests (grep inverse), so the dashboard is
+//   never captured against a mutated DB.
 const PAGES: VRPage[] = [
   { name: 'addresses', path: 'addresses.php' },
   { name: 'search',    path: 'search.php' },
   { name: 'login', path: 'login.php', skipAuth: true },
   { name: 'backup-admin-notifications', path: 'backup_admin.php?tab=notifications' },
   { name: 'backup-admin-restore', path: 'backup_admin.php?tab=restore' },
+  // Dashboard: mutation-isolated via dedicated vr-dashboard-* projects (#775).
+  { name: 'dashboard', path: 'dashboard.php', tag: '@vr-dashboard' },
 ];
 
 const THEMES = ['light', 'dark'] as const;
@@ -79,7 +86,16 @@ test.describe('visual regression baseline', () => {
 
   for (const theme of THEMES) {
     for (const pg of PAGES) {
-      test(`${pg.name} — ${theme}`, async ({ page }) => {
+      // Include the page's grep tag (if any) in the test title so Playwright
+      // project-level `grep` options can select or exclude it. For example,
+      // vr-dashboard-* projects pass `grep: /@vr-dashboard/` to capture only
+      // the dashboard, while standard vr-* projects pass
+      // `grepInvert: /@vr-dashboard/` to skip it — all without modifying PAGES.
+      const title = pg.tag
+        ? `${pg.name} — ${theme} ${pg.tag}`
+        : `${pg.name} — ${theme}`;
+
+      test(title, async ({ page }) => {
         test.setTimeout(30_000);
 
         // Suppress animations for deterministic screenshots
@@ -88,7 +104,13 @@ test.describe('visual regression baseline', () => {
         if (pg.skipAuth) {
           await page.goto(pg.path);
         } else {
-          await login(page, ADMIN_USER, ADMIN_PASS);
+          // vr-dashboard-* projects inject storageState at the project level
+          // (playwright.config.ts), so the browser context is already
+          // authenticated. For non-dashboard pages the context is fresh and
+          // we log in here as before.
+          if (!pg.tag) {
+            await login(page, ADMIN_USER, ADMIN_PASS);
+          }
           await page.goto(pg.path);
         }
 

--- a/testing/playwright/tests/vr-dashboard.setup.ts
+++ b/testing/playwright/tests/vr-dashboard.setup.ts
@@ -1,0 +1,69 @@
+/**
+ * Setup step for the vr-dashboard Playwright project (#775).
+ *
+ * Runs serially before the vr-dashboard-* projects via Playwright project
+ * dependencies. Responsibilities:
+ *   1. Re-bootstrap the app against a freshly seeded SQLite DB so every
+ *      dashboard widget shows known-quiet data (no suite-mutated rows).
+ *   2. Log in as admin and persist the storage state so the vr-dashboard-*
+ *      projects can reuse the authenticated session without a fresh login.
+ *
+ * The storage-state file is written to the same `tests/` directory as this
+ * file and is gitignored (it contains session cookies — not committed).
+ *
+ * NOTE: bootstrap-app.sh is invoked with cwd set to the repo root so the
+ * script's internal `./` paths resolve correctly. The IPAM_BASE_URL env var
+ * must be set in the environment (or .env) before running this project;
+ * the default http://localhost:8080 almost certainly does not match the
+ * containerized port (8443).
+ */
+import { test as setup } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+import { login, ADMIN_USER, ADMIN_PASS } from '../fixtures/ipam';
+
+// Where we persist the authenticated session for the vr-dashboard projects.
+export const VR_DASHBOARD_STORAGE = path.join(__dirname, 'vr-dashboard.storage.json');
+
+// Allowlist of valid driver names. bootstrap-app.sh accepts only these values.
+const ALLOWED_DRIVERS = ['sqlite', 'mysql', 'pgsql'] as const;
+type Driver = typeof ALLOWED_DRIVERS[number];
+
+function resolveDriver(): Driver {
+  const raw = (process.env.IPAM_DRIVER ?? 'sqlite').toLowerCase();
+  if ((ALLOWED_DRIVERS as readonly string[]).includes(raw)) return raw as Driver;
+  throw new Error(
+    `vr-dashboard setup: IPAM_DRIVER="${raw}" is not a recognised driver. ` +
+    `Allowed values: ${ALLOWED_DRIVERS.join(', ')}.`,
+  );
+}
+
+setup('vr-dashboard: reseed quiescent DB and save auth storage', async ({ page, context }) => {
+  // Give this step enough time for bootstrap-app.sh (Docker pull + DB seed).
+  setup.setTimeout(300_000);
+
+  // Re-bootstrap: spins up (or recycles) the test container with a fresh
+  // demo_seed.php run so the DB contains only canonical seed rows.
+  const driver = resolveDriver();
+  const repoRoot = path.resolve(__dirname, '../../..');
+  try {
+    // Use execFileSync with an argument array (not a shell string) so there is
+    // no path for shell injection, even if IPAM_DRIVER were somehow tainted.
+    execFileSync('bash', ['testing/bootstrap-app.sh', driver], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: { ...process.env },
+    });
+  } catch (err) {
+    throw new Error(
+      `vr-dashboard setup: bootstrap-app.sh failed for driver=${driver}. ` +
+      `Ensure Docker is running and IPAM_BASE_URL is set correctly. ` +
+      `Original error: ${(err as Error).message}`,
+    );
+  }
+
+  // Log in and persist session cookies / localStorage so vr-dashboard-*
+  // tests reuse the warm session without repeating the login round-trip.
+  await login(page, ADMIN_USER, ADMIN_PASS);
+  await context.storageState({ path: VR_DASHBOARD_STORAGE });
+});


### PR DESCRIPTION
## Summary

Closes #775.

\`dashboard.php\` was excluded from \`tests/visual-regression.spec.ts\` in v3.19.0 because it's non-deterministic under parallel mutating workers (live subnet usage, audit log, expiring leases, etc.). Three prior attempts on feat/v3.19.0 — masking, CSP-blocked style injection, and per-element \`page.evaluate(remove)\` — all failed. This PR restores coverage via the Playwright project-dependency model.

### Design

**Approach 1 (dedicated project + setup dependency).** A new \`vr-dashboard-setup\` project runs first, fresh-bootstraps the DB via \`bootstrap-app.sh\`, logs in once, and writes a storage state file. Four \`vr-dashboard-{1440,1024,768,375}\` projects then consume that storage state, run \`workers: 1, fullyParallel: false\`, and capture the dashboard. All existing \`vr-*\` projects gain a \`grepInvert: /@vr-dashboard/\` so they skip the dashboard test. The existing harness is already serial globally (\`workers: 1, fullyParallel: false\`), so a \`globalSetup\` hook offered no isolation advantage — project dependencies are the documented Playwright pattern for exactly this problem.

### Changes

- \`testing/playwright/tests/vr-dashboard.setup.ts\` (new) — runs the bootstrap script via \`execFileSync\` (array form, no shell-injection surface), logs in with credentials from env, writes \`tests/vr-dashboard.storage.json\`.
- \`testing/playwright/playwright.config.ts\` — adds the 5 new projects (setup + 4 viewports), gates the existing \`vr-*\` projects with \`grepInvert\`.
- \`testing/playwright/tests/visual-regression.spec.ts\` — extends \`VRPage\` with optional \`tag\`; dashboard entry added to \`PAGES\` with \`@vr-dashboard\`; test loop respects the tag.
- \`docs/internal/test-suites.md\` — "Dashboard is excluded" section replaced; manual smoke-check kept as backup per the issue's "two-release-cycle" wording.
- \`.gitignore\` — \`testing/playwright/tests/vr-dashboard.storage.json\` excluded from version control.

### What CI must verify (the acceptance criteria require it)

1. **Baseline capture.** No baseline PNGs were committed locally — capturing them requires Docker, which isn't running in the dev environment. After this PR opens, CI's first \`vr-dashboard-*\` projects will fail with "missing baseline." Re-run that one job with \`--update-snapshots\` (the existing CI pattern, see how baselines were captured for other VR projects) and commit the resulting \`dashboard-light.png\` / \`dashboard-dark.png\` files (8 files: 4 viewports × 2 themes, platform-suffixed \`-linux.png\`).
2. **Three consecutive full-suite runs all green** — the issue's hard requirement. Run the gate three times after baselines land and confirm stability.
3. **\`storageState\` path resolution.** Setup writes to \`testing/playwright/tests/vr-dashboard.storage.json\`; Playwright resolves the \`storageState\` config string relative to the config file directory. The two paths line up — verify on CI that the file exists after the setup project completes, before capture projects start.
4. **\`bootstrap-app.sh\` inside the setup test.** If the main suite container is already up by the time setup runs, \`bootstrap-app.sh\`'s reseed must be idempotent. Review \`playwright.yml\` job ordering.

### Out of scope for this PR

- TypeScript-only changes; no PHP touched.
- Manual smoke-check stays in docs as backup until two stable release cycles confirm the harness.

## Test plan

- [x] \`npx tsc --noEmit\` on testing/playwright/ → clean
- [ ] CI Playwright matrix: vr-dashboard-setup completes
- [ ] CI Playwright matrix: vr-dashboard-{1440,1024,768,375} green after baseline-capture
- [ ] Three consecutive full-suite runs on a single driver — all green
- [ ] Other vr-* projects unchanged (\`grepInvert\` properly excludes dashboard from them)

## Commit

| Hash | Message |
|---|---|
| \`385f11db\` | test(vr): restore dashboard VR with dedicated mutation-isolated project |

🤖 Generated with [Claude Code](https://claude.com/claude-code)