### PR TITLE
fix(test): use canonical testing/playwright/bootstrap-app.sh path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ These are the rules a fresh agent must hold in working memory before touching co
 4. **CSRF (`csrf_require()`) on every browser POST; `e()` on every HTML output.** `api.php` is the only CSRF-exempt surface (stateless Bearer).
 5. **`app_secret` lives in `config.php`, never the DB.** Per-tenant keys (v4+) HKDF-derive from it; vault key likewise stays out of DB.
 6. **No `git push` or PR merge without explicit per-conversation authorisation.** Previous yes does not carry forward.
-7. **Local 3-driver gate before push.** `bash testing/bootstrap-app.sh sqlite|mysql|pgsql` + Playwright all green. CI minutes are paid; don't use CI as the test runner.
+7. **Local 3-driver gate before push.** `bash testing/playwright/bootstrap-app.sh sqlite|mysql|pgsql` + Playwright all green. CI minutes are paid; don't use CI as the test runner.
 8. **No `global $config;` (or `$GLOBALS['config']`) anywhere in the tree — use the `ipam_config()` accessor (ADR-003).** `global $db` (runtime PDO handle) is still permitted. The sweep is complete (#1207 closed in v3.33.0); the ADR-004 linter (`testing/scripts/lib-module-linter.php`) now enforces this across the whole codebase, not just the extracted `lib/*.php` modules.
 
 ---
@@ -65,7 +65,7 @@ These are the rules a fresh agent must hold in working memory before touching co
 
 ```bash
 composer install                              # one-time, installs dev tools to vendor/
-bash testing/bootstrap-app.sh sqlite          # spin up dockerized app + seed for local testing
+bash testing/playwright/bootstrap-app.sh sqlite  # spin up dockerized app + seed for local testing
 vendor/bin/phpunit && vendor/bin/phpstan analyse --memory-limit=1G && vendor/bin/phpcs
 ```
 

--- a/docs/internal/coding-guide.md
+++ b/docs/internal/coding-guide.md
@@ -343,7 +343,7 @@ A PR that violates any of these gets bounced.
 6. **New runtime dependency → six-criteria justification PR per `runtime-dependency-policy.md`; update the whitelist in this doc.** Vendored frontend asset additions also update the whitelist.
 7. **Migration added → run `migration-reviewer` subagent.** Confirm the FK-safe pattern from `adding-a-migration.md`. CI runs `MigrationTest` to assert no data loss.
 8. **IP/binary code touched → run `ip-binary-auditor` subagent.** Covers `ip_bin`, `network_bin`, IP parsing, subnet math, ping/scan, DB binds for binary columns.
-9. **Local three-driver gate before push.** `bash testing/bootstrap-app.sh sqlite|mysql|pgsql` then Playwright must all pass. GH Action minutes are paid; do not use CI as your test runner.
+9. **Local three-driver gate before push.** `bash testing/playwright/bootstrap-app.sh sqlite|mysql|pgsql` then Playwright must all pass. GH Action minutes are paid; do not use CI as your test runner.
 10. **Public / cross-module function added or changed → it carries a current docblock.** See "Docblocks are not inline comments". A missing or stale contract docblock on changed surface code is a review finding.
 11. **No `git push` or PR merge without explicit per-conversation authorisation.** A previous yes does not carry forward.
 

--- a/testing/playwright/tests/vr-dashboard.setup.ts
+++ b/testing/playwright/tests/vr-dashboard.setup.ts
@@ -49,7 +49,7 @@ setup('vr-dashboard: reseed quiescent DB and save auth storage', async ({ page, 
   try {
     // Use execFileSync with an argument array (not a shell string) so there is
     // no path for shell injection, even if IPAM_DRIVER were somehow tainted.
-    execFileSync('bash', ['testing/bootstrap-app.sh', driver], {
+    execFileSync('bash', ['testing/playwright/bootstrap-app.sh', driver], {
       cwd: repoRoot,
       stdio: 'inherit',
       env: { ...process.env },

--- a/testing/scripts/phpunit-against-driver.sh
+++ b/testing/scripts/phpunit-against-driver.sh
@@ -16,7 +16,7 @@ case "$driver" in
 esac
 
 if ! docker ps --format '{{.Names}}' | grep -q "^${container}$"; then
-  echo "container $container not running. Run: bash testing/bootstrap-app.sh $driver" >&2
+  echo "container $container not running. Run: bash testing/playwright/bootstrap-app.sh $driver" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Four stragglers from v3.35.0 CR #6 (`4780b471`) that still referenced the stale `testing/bootstrap-app.sh` path. The canonical location is `testing/playwright/bootstrap-app.sh`; the legacy top-level path does not exist, so any code or doc using it fails when invoked.

Surfaced during v3.36.0 pre-flight Playwright gate: `vr-dashboard.setup.ts` shells out to `bootstrap-app.sh` from the repo root and was failing with `bash: testing/bootstrap-app.sh: No such file or directory` — cascading into the 8 `vr-dashboard-*` projects not running.

## Files

- `testing/playwright/tests/vr-dashboard.setup.ts` — the actual runtime bug
- `testing/scripts/phpunit-against-driver.sh` — operator-facing error message
- `CLAUDE.md` — hot-cache invariant #7 + quick-start snippet
- `docs/internal/coding-guide.md` — PR-time gate #9

## Test plan

- [x] `vr-dashboard-setup` Playwright project passes (1 passed in 11s) against sqlite
- [ ] Full 3-driver Playwright pass at next release-PR gate

Stem-of-v3.36.0 fix; once merged, I'll rebase the v3.36.0 #1256 branch on top and proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)