### PR TITLE
refactor(css): reconcile :root tokens with Open Props — closeout (#957)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -41,7 +41,7 @@
      scales match exactly (rem-based, identical px at the default 16px
      root font-size). Tokens with no OP equivalent keep their px literal.
      OP source: assets/vendor/open-props.min.css. */
-  --space-0:0;
+  /* --space-0 (0) removed in #957 — zero references. */
   --space-1:2px;             /* no OP match — smallest OP size is --size-1 (4px) */
   --space-2:var(--size-1);   /* OP: 0.25rem = 4px */
   --space-3:6px;             /* no OP match */
@@ -56,11 +56,10 @@
   --space-12:var(--size-8);  /* OP: 3rem = 48px */
   --space-13:60px;           /* no OP match */
 
-  --z-base:1;
+  /* z-index registry — #957 removed --z-base (0 refs) and --z-drawer-overlay (0 refs). */
   --z-sticky:2;
   --z-topbar:50;
   --z-overlay:100;
-  --z-drawer-overlay:179;
   --z-drawer:180;
   --z-nav-overlay:199;
   --z-nav-drawer:200;
@@ -98,7 +97,7 @@
   --font-size-6xl:1.15rem;
   --font-size-7xl:1.35rem;
   --font-size-8xl:1.6rem;
-  --font-size-9xl:1.9rem;
+  /* --font-size-9xl (1.9rem) removed in #957 — zero references. */
 
   --focus-ring:0 0 0 2px var(--bg), 0 0 0 4px var(--link);
   --font-sans:'Fira Sans',system-ui,-apple-system,sans-serif;

--- a/docs/internal/design-guide.md
+++ b/docs/internal/design-guide.md
@@ -12,27 +12,32 @@ Vanilla CSS in `assets/app.css` (~3000 lines, CSS custom properties for theming)
 
 ---
 
-## Theme system
+## Design tokens
 
-Theme is controlled by `html[data-theme]` with three values: `auto` (default), `light`, `dark`. `auto` defers to `prefers-color-scheme`. The setting is persisted per user in `users.theme` and re-applied on login via `login_user()`.
+Per **ADR-007** (`docs/internal/architecture-decisions/007-open-props-adoption.md`), `assets/app.css` consumes [Open Props](https://open-props.style) as the underlying token base, layered with IPAM-specific brand values where the OP scale doesn't fit a compact admin UI.
 
-CSS uses custom properties exclusively for theme-able values. The full palette:
+**Token surface (`:root` in `app.css`):**
 
-| Variable | Light | Dark | Use |
-|---|---|---|---|
-| `--bg` | page background | | Outermost surface |
-| `--fg` | foreground text | | Default text |
-| `--muted` | secondary text | | Helper text, timestamps |
-| `--border` | divider lines | | All borders |
-| `--card` | elevated surface | | Cards, modals, sidebar |
-| `--danger` | red | | Destructive actions, errors |
-| `--success` | green | | Success states, confirmations |
-| `--warn` | amber | | Warning callouts |
-| `--link` | accent | | Links, primary actions |
-| `--btn` / `--btnfg` | button bg / fg | | Default button |
-| `--badge-bg` | badge fill | | Badges |
+| Layer | Tokens | Source |
+|---|---|---|
+| Color (light + dark) | `--bg`, `--fg`, `--muted`, `--border`, `--border-strong`, `--card`, `--card-2`, `--link`, `--danger`, `--success`, `--warn`, `--btn`, `--btnfg`, `--btn-secondary`, `--btn-secondary-fg`, `--brand`, `--badge-bg`, `--input-bg`, `--nav-bg`, `--shadow` (composed from `--shadow-near` + `--shadow-far`) | **Brand-defined.** Each token uses CSS `light-dark(<light>, <dark>)`; the chosen scheme is pinned by `html[data-theme="light|dark"] { color-scheme: ... }`. Closest OP gray noted in comment for reference; IPAM keeps its cool-toned neutrals as brand identity. |
+| Spacing | `--space-1` … `--space-13` | **6 alias OP** `--size-{1,2,3,4,5,8}` where values match exactly (4 / 8 / 16 / 20 / 24 / 48 px). The remaining 7 (2 / 6 / 10 / 12 / 14 / 40 / 60 px) have no OP equivalent and stay as px literals. |
+| Radius | `--radius-xs` … `--radius-4xl`, `--radius-pill` | **2 alias OP** `--radius-3` and `--radius-round` (16 px and full pill). The other 7 have no OP equivalent. |
+| Typography (15-step) | `--font-size-2xs` … `--font-size-8xl` | **Untouched** — owned by #953 (6-step type-scale rewrite). |
+| Typography (semantic) | `--text-xs` … `--text-2xl` | **3 alias OP** `--font-size-{1,3,4}` (`--text-md`, `--text-xl`, `--text-2xl`). |
+| Z-index | `--z-sticky`, `--z-topbar`, `--z-overlay`, `--z-drawer`, `--z-nav-overlay`, `--z-nav-drawer`, `--z-dropdown`, `--z-col-vis`, `--z-spinner`, `--z-toast`, `--z-page-overlay` | **Brand registry.** Each layer has exactly one z value; do not introduce ad-hoc z-indices. |
+| Misc | `--focus-ring`, `--font-sans`, `--font-mono` | Brand-defined. |
 
-**Never hardcode a colour.** Use a variable. If the colour you need doesn't exist, add a variable; don't bypass.
+**Theme controls.** `html[data-theme]` takes three values: `auto` (default — defers to `prefers-color-scheme`), `light`, `dark`. The setting is persisted per user in `users.theme` and re-applied on login via `login_user()`. With ADR-007-3 in place, `light` and `dark` toggles set `color-scheme` on the `html` element; `auto` leaves it as `light dark` so `light-dark()` resolves against the OS preference.
+
+**Adding a new token.**
+
+- Color: add a `light-dark()` declaration on `:root`; do not add new `[data-theme=dark]` override blocks.
+- Spacing / radius: if the value exists in Open Props, alias it (`var(--size-N)` or `var(--radius-N)`); otherwise add a px literal with a `/* no OP match */` comment.
+- Never hardcode a colour in a rule. Use a token. If the token you need doesn't exist, add it; don't bypass.
+- Typography: do not extend `--font-size-*` until #953 lands.
+
+**Browser support.** `light-dark()` requires Chrome 123+ (Mar 2024) / Safari 17.5 (May 2024) / Firefox 120 (Nov 2023). The project assumes modern evergreen browsers (already used: `:has()`, `:focus-visible`, `:where()`).
 
 ---
 


### PR DESCRIPTION
## Summary

Closeout PR for **#957** ("reconcile `:root` tokens with Open Props"). After #1312 (ADR-007-2 sizing) and #1313 (ADR-007-3 dark-mode consolidation) landed, the OP base is fully integrated where it can be. This PR audits the remaining tokens, deletes dead ones, and documents the post-migration token system.

## Audit findings

`grep -E "var\(<token>[,)]"` across `Simple-PHP-IPAM/**/*.{css,php,html}`:

- **80 tokens declared in `:root` before this PR; 4 had zero references** → deleted.
- **Tokens that COULD alias OP but don't: zero.** Every non-aliased `--space-*` / `--radius-*` is a px value with no exact OP equivalent (verified against OP `--size-1..8` and `--radius-1..6`).
- Color tokens stay brand-defined per ADR-007-3 conservative scope (IPAM neutrals are cool-toned by intent).
- The 15-step `--font-size-*` scale is intentionally left for #953.

## Deletions

| Token | Refs | Note |
|---|---|---|
| `--space-0` | 0 | 0px placeholder; no consumers |
| `--font-size-9xl` (1.9rem) | 0 | top of the to-be-rewritten 15-step scale |
| `--z-base` (1) | 0 | implicit z=auto suffices |
| `--z-drawer-overlay` (179) | 0 | the drawer overlay uses `--z-drawer` directly |

## Documentation

Rewrote the "Theme system" section in `docs/internal/design-guide.md` into a comprehensive **"Design tokens"** section:

- Token surface table by layer (color / spacing / radius / typography / z-index / misc) with source-of-truth annotations
- Theme-control mechanism (now `light-dark()`-based per ADR-007-3)
- "Adding a new token" contract — when to alias OP, when to add a px literal, when to add a `light-dark()` declaration
- `light-dark()` browser-support floor (Chrome 123+ / Safari 17.5 / Firefox 120)

## Test plan

- [x] PHPUnit unit suite — 686/686 pass (no PHP touched)
- [x] PHPStan L9 — 0 errors
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **835 / 835 passed** (`--grep-invert="@vr-dashboard"` to carve out pre-existing #1311). Zero visual regression.
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time

## Stream A status after merge

| # | Status |
|---|---|
| #1256 | merged (#1312) |
| #1257 | merged (#1313) |
| **#957** | **this PR** |
| #961, #959, #953, #954, #955, #956, #958, #960 | next up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)