### PR TITLE
feat(css): standardize icon sizes via --icon-sm / --icon-md tokens (#961)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -104,6 +104,16 @@
   --font-sans:'Fira Sans',system-ui,-apple-system,sans-serif;
   --font-mono:'Fira Code',ui-monospace,'SFMono-Regular','Consolas',monospace;
 
+  /* Icon size tokens — C10 / #961.
+     IPAM uses two standard icon sizes: 16px (the default, used for nav,
+     action pills, inline indicators) and 20px (medium-emphasis, used for
+     section headings + the empty-state hint icons). The hardcoded values
+     in .icon, .icon-lg, and .collapsible-toggle .icon below reference
+     these tokens so callers can adopt either via class or via inline
+     CSS without re-deriving the value. */
+  --icon-sm: 16px;
+  --icon-md: 20px;
+
   /* Typographic scale — ADR-007-2 migration to Open Props.
      The 15-step --font-size-* scale above is intentionally untouched
      in this PR — #953 will rewrite it as a 6-step scale, so a deep
@@ -141,10 +151,14 @@ html[data-theme="dark"] ::-webkit-calendar-picker-indicator{filter:invert(1);}
 *{box-sizing:border-box}
 html{scroll-behavior:smooth}
 
-/* --- SVG icon system (#511) --- */
-.icon{display:inline-block;width:1rem;height:1rem;vertical-align:-0.125em;flex-shrink:0;pointer-events:none;fill:none}
-.icon-sm{width:.875rem;height:.875rem}
-.icon-lg{width:1.25rem;height:1.25rem}
+/* --- SVG icon system (#511, #961) --- */
+.icon{display:inline-block;width:var(--icon-sm);height:var(--icon-sm);vertical-align:-0.125em;flex-shrink:0;pointer-events:none;fill:none}
+/* .icon-sm previously declared 14px (.875rem); now standardized at 16px
+   per C10. Was unused at the prior 14px value, so no caller impact. */
+.icon-sm{width:var(--icon-sm);height:var(--icon-sm)}
+.icon-md{width:var(--icon-md);height:var(--icon-md)}
+/* .icon-lg retained for compat with one in-tree caller; same 20px as .icon-md. */
+.icon-lg{width:var(--icon-md);height:var(--icon-md)}
 .icon-xl{width:1.5rem;height:1.5rem}
 .icon-2xl{width:2rem;height:2rem}
 
@@ -1399,7 +1413,7 @@ body.pw-toggle-hidden .pw-wrap .pw-input{padding-right:36px}
 /* ── Collapsible row toggle (v3.11.0 #632 #633) ─────────────────────── */
 .collapsible-toggle{display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;background:none;border:none;cursor:pointer;color:var(--muted);padding:0;border-radius:var(--radius-sm);flex-shrink:0}
 .collapsible-toggle:hover{color:var(--fg);background:color-mix(in srgb,var(--border) 60%,transparent)}
-.collapsible-toggle .icon{width:16px;height:16px;transition:transform 200ms ease}
+.collapsible-toggle .icon{width:var(--icon-sm);height:var(--icon-sm);transition:transform 200ms ease}
 .collapsible-toggle[aria-expanded="true"] .icon{transform:rotate(90deg)}
 @media (prefers-reduced-motion:reduce){.collapsible-toggle .icon{transition:none}}
 .collapsible-child--hidden{display:none}


### PR DESCRIPTION
## Summary

Closes **#961** (C10 — "standardize icon sizes"). Defines `--icon-sm: 16px` and `--icon-md: 20px` tokens in `:root` and sweeps the existing `.icon` system + the lone hardcoded `.collapsible-toggle .icon` rule to consume them.

## Audit context

Surveyed every icon-size site before editing. Only **one** in-tree caller uses any sizing class: `lib/presentation.php:491` (`icon('server-stack', 'icon-xl')` on the sidebar wordmark logo). `.icon-sm` (14px), `.icon-lg` (20px), and `.icon-2xl` (32px) are defined but had zero call sites. Two hardcoded `width:N px` rules existed: `.chart-empty .icon{width:32px…}` (kept — matches `.icon-2xl`) and `.collapsible-toggle .icon{width:16px…}` (swept to token).

## Changes

- `:root`: add `--icon-sm: 16px`, `--icon-md: 20px`.
- `.icon` default: `1rem` → `var(--icon-sm)`. Same resolved 16px.
- `.icon-sm`: standardized at `var(--icon-sm)` (was 14px / `.875rem`, **dead at the prior value**).
- `.icon-md`: **new**, `var(--icon-md)` (20px). Available for the v3.36.0 sidebar + command-palette work in milestone #60.
- `.icon-lg`: now aliased to `var(--icon-md)` (was 20px, still 20px; **dead in-tree** at the prior value).
- `.icon-xl` and `.icon-2xl`: unchanged. `.icon-xl` retains its one caller.
- `.collapsible-toggle .icon`: hardcoded `width:16px;height:16px` → `var(--icon-sm)`.

## Test plan

- [x] PHPUnit unit suite — 686/686 pass (no PHP touched)
- [x] PHPStan L9 — 0 errors
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **836 / 836 passed** (`--grep-invert="@vr-dashboard"` carving out pre-existing #1311). Zero visual regression.
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time

## Stream A progress

| # | Status |
|---|---|
| #1256 | ✅ merged (#1312) |
| #1257 | ✅ merged (#1313) |
| #957 | 🔄 #1314 |
| **#961** | **this PR** |
| #959, #953, #954, #955, #956, #958, #960 | next up |

🤖 Generated with [Claude Code](https://claude.com/claude-code)