### PR TITLE
feat(css): define --space-section token + sweep card/grid gaps (#959)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -113,6 +113,13 @@
   --icon-sm: 16px;
   --icon-md: 20px;
 
+  /* Section rhythm — C7 / #959.
+     One token for the gap between adjacent cards / dashboard widgets
+     and for .grid container gaps. Set to --space-8 (16px) to match the
+     existing consensus; rebalancing section rhythm globally becomes a
+     single-token change. */
+  --space-section: var(--space-8);
+
   /* Typographic scale — ADR-007-2 migration to Open Props.
      The 15-step --font-size-* scale above is intentionally untouched
      in this PR — #953 will rewrite it as a 6-step scale, so a deep
@@ -335,7 +342,7 @@ h3{font-size:var(--text-md);font-weight:600;line-height:1.3}
   padding:var(--space-8);
   box-shadow:var(--shadow);
 }
-.card + .card{margin-top:var(--space-8)}
+.card + .card{margin-top:var(--space-section)}
 
 .table-wrap{
   overflow:auto;
@@ -404,7 +411,7 @@ tr.highlight{
 
 .grid{
   display:grid;
-  gap:var(--space-8);
+  gap:var(--space-section);
   align-items:stretch;
 }
 .grid > .card{
@@ -423,7 +430,7 @@ tr.highlight{
 /* Dashboard metric grid — always 3 columns at ≥640px, collapses to 1 at mobile (#649) */
 .metric-row{
   display:grid;
-  gap:var(--space-8);
+  gap:var(--space-section);
   grid-template-columns:repeat(3,1fr);
 }
 @media(max-width:640px){


### PR DESCRIPTION
## Summary

Closes **#959** (C7 — section spacing token). Adds `--space-section` as the single source of truth for the gap between adjacent cards and dashboard widgets; sweeps the three existing consensus call sites to consume it.

Initial value: `var(--space-8)` (16px), matching the existing consensus — **zero visual change**. The value-add is that any future section-rhythm rebalance becomes a single-token edit instead of a multi-rule sweep.

## Audit context

Surveyed every section-gap site. The 16px consensus was already present at:
- `.card + .card { margin-top: var(--space-8) }`
- `.grid { gap: var(--space-8) }`
- `.metric-row { gap: var(--space-8) }`

All three now consume `var(--space-section)`. Other layout containers using `var(--space-8)` (forms, table cells, login form, etc.) are NOT section-gap consumers — left alone.

## Touched

- `:root`: add `--space-section: var(--space-8)` (line ~109)
- `.card + .card` margin-top → `var(--space-section)` (line 332)
- `.grid` gap → `var(--space-section)` (line 401)
- `.metric-row` gap → `var(--space-section)` (line 420)

## Test plan

- [x] PHPUnit unit suite — 686/686 pass (no PHP touched)
- [x] PHPStan L9 — 0 errors
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **836 / 836 passed** (`--grep-invert="@vr-dashboard"` carving out pre-existing #1311). Zero visual regression.
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time

## Stream A progress

5 of 11 issues addressed (#1256 #1257 #957 #961 #959); 6 remaining (#953 #954 #955 #956 #958 #960).

🤖 Generated with [Claude Code](https://claude.com/claude-code)