### PR TITLE
fix(ui): em-dash empty-cell fallback in bulk_update + dhcp_pool tables (#960)

### DIFF
--- a/Simple-PHP-IPAM/bulk_update.php
+++ b/Simple-PHP-IPAM/bulk_update.php
@@ -512,10 +512,10 @@ page_header('Bulk Update');
         <tr class="muted opacity-70">
           <td><input class="addrbox" type="checkbox" name="unconf_ips[]" value="<?= e($uip) ?>" data-unconf="1"></td>
           <td><?= e($uip) ?></td>
-          <td></td>
-          <td></td>
+          <td class="muted">—</td>
+          <td class="muted">—</td>
           <td><span class="muted"><em>free (unconfigured)</em></span></td>
-          <td></td>
+          <td class="muted">—</td>
           <td class="muted">—</td>
         </tr>
       <?php endforeach; ?>

--- a/Simple-PHP-IPAM/dhcp_pool.php
+++ b/Simple-PHP-IPAM/dhcp_pool.php
@@ -460,7 +460,7 @@ page_header('DHCP Pools');
               </form>
             </td>
             <?php else: ?>
-            <td></td>
+            <td class="muted">—</td>
             <?php endif; ?>
           </tr>
           <?php endif; ?>


### PR DESCRIPTION
## Summary

Closes **#960** (C9 — standardize empty-cell fallback to `—`). 4 bare `<td></td>` cells remained after the v3.30.0–v3.35.0 refactor waves had swept the rest of the codebase: 3 in `bulk_update.php` (the "unconfigured IPs" rows) and 1 in `dhcp_pool.php` (when the user lacks delete permission).

Both files now render `<td class="muted">—</td>`, matching the convention already in use at `bulk_update.php:519`, `address_history.php`, `addresses.php`, `aggregates.php`, `api_keys.php`, `audit.php`, and other list pages.

## Touched

- `Simple-PHP-IPAM/bulk_update.php` — lines 515, 516, 518 (3 cells in the unconfigured-IPs row)
- `Simple-PHP-IPAM/dhcp_pool.php` — line 463 (no-delete-permission else branch)

## Test plan

- [x] `php -l` on both edited files — clean
- [x] PHPUnit unit suite — 686/686 pass
- [x] PHPStan L9 — 0 errors
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **836 / 836 passed** (excluding pre-existing #1311 via grep-invert)
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time

## Stream A progress

6 of 11 done (#1256 #1257 #957 #961 #959 #960); 5 remaining (#953 #954 #955 #956 #958).

🤖 Generated with [Claude Code](https://claude.com/claude-code)