### PR TITLE
fix(css): override hover underline + visited color on sidebar brand link (#958)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -1443,6 +1443,13 @@ body.pw-toggle-hidden .pw-wrap .pw-input{padding-right:36px}
 .sidebar{width:var(--sidebar-width,220px);background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;position:fixed;top:0;bottom:0;left:0;z-index:100;overflow-y:auto;transition:transform 200ms ease}
 .sidebar-logo{display:flex;align-items:center;gap:.5rem;padding:1rem .75rem;border-bottom:1px solid var(--border);min-height:3.5rem}
 .sidebar-logo-link{font-weight:700;font-size:var(--text-lg,1.125rem);color:var(--fg);text-decoration:none;display:flex;align-items:center;gap:.5rem;flex:1}
+/* S9 + C6 / #958 — override the global a:hover{text-decoration:underline} and
+   default :visited color on the sidebar brand link in both themes. Without
+   these the brand link picks up an underline on hover and the OS-default
+   visited color, which looks broken (especially in dark mode). */
+.sidebar-logo-link:hover,
+.sidebar-logo-link:focus{text-decoration:none;color:var(--fg)}
+.sidebar-logo-link:visited{color:var(--fg)}
 .sidebar-close{display:none;background:none;border:none;cursor:pointer;color:var(--muted);padding:.25rem;line-height:1}
 .sidebar-nav{padding:.5rem 0;flex:1;display:flex;flex-direction:column}
 .sidebar-group{padding:.25rem 0}


### PR DESCRIPTION
## Summary

Closes **#958** (S9 + C6 — dark-mode sidebar brand link styling). The global `a:hover{text-decoration:underline}` rule was bleeding onto `.sidebar-logo-link`, producing an underline on hover that looked broken (especially in dark mode), and the default `:visited` color was overriding the brand link's intentional `--fg` value.

## Fix

Adds 3 lines after the existing `.sidebar-logo-link` rule:

```css
.sidebar-logo-link:hover,
.sidebar-logo-link:focus { text-decoration: none; color: var(--fg); }
.sidebar-logo-link:visited { color: var(--fg); }
```

Selector verified against current markup (`lib/presentation.php:491` — `.sidebar-logo-link` on the brand link). The original issue body cited an `aside .logo a` selector that no longer exists; the body was refreshed during pre-flight to the current `.sidebar-logo-link`.

## Test plan

- [x] PHPUnit unit suite — 686/686 pass (no PHP touched)
- [x] PHPStan L9 — 0 errors
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **835 / 835 passed** (excluding pre-existing #1311 via grep-invert). Zero visual regression on the at-rest brand link; the `:hover` / `:visited` overrides are interaction-state.
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time
- [ ] VR regression guard for hover + visited dark-mode states tracked separately under #1035

## Stream A progress

7 of 11 done (#1256 #1257 #957 #961 #959 #960 #958); 4 remaining (#953 #954 #955 #956).

🤖 Generated with [Claude Code](https://claude.com/claude-code)