### PR TITLE
a11y: pair color signals with non-color counterparts for WCAG 1.4.1 (#956)

### DIFF
--- a/Simple-PHP-IPAM/assets/app.css
+++ b/Simple-PHP-IPAM/assets/app.css
@@ -147,6 +147,24 @@
 html[data-theme="light"]{color-scheme:light;}
 html[data-theme="dark"]{color-scheme:dark;}
 
+/* Screen-reader-only utility — C4 / #956.
+   Standard a11y pattern: visually hidden, accessible to assistive tech.
+   Used to pair color-only signals (util-bar severity, health-dot status)
+   with text equivalents for WCAG 1.4.1. Two existing consumers in
+   change_password.php were relying on this class without a definition;
+   defining it here fixes that latent bug too. */
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+
 /* Dark-mode calendar picker indicator: filter has no light-dark()
    equivalent, so this stays as a separate selector pair. */
 html[data-theme="dark"] ::-webkit-calendar-picker-indicator{filter:invert(1);}

--- a/Simple-PHP-IPAM/dashboard.php
+++ b/Simple-PHP-IPAM/dashboard.php
@@ -246,11 +246,18 @@ ipam_render('dashboard_kpi_card', ['label' => 'Crit Alerts', 'value' => $kpis['a
             <td class="muted"><?= e(to_str($s['description'])) ?></td>
             <td><?= e((string)$used) ?></td>
             <td><?= e((string)$cap) ?></td>
+            <?php
+              $barLevel = $pct >= $dashCrit ? 'critical' : ($pct >= $dashWarn ? 'warning' : 'normal');
+              $barAriaLabel = "Utilization {$pct}%, {$barLevel} level";
+            ?>
             <td class="mw-90">
-              <div class="util-bar-block">
+              <div class="util-bar-block" role="meter" aria-label="<?= e($barAriaLabel) ?>" aria-valuenow="<?= $pct ?>" aria-valuemin="0" aria-valuemax="100">
                 <div class="util-bar-fill <?= $barClass ?>" data-pct="<?= $pct ?>"></div>
               </div>
               <span class="muted font-xs"><?= $pct ?>%</span>
+              <?php if ($barLevel !== 'normal'): ?>
+                <span class="sr-only"><?= e(ucfirst($barLevel)) ?> level</span>
+              <?php endif; ?>
             </td>
             <td><?= render_sparkline($sparklines[to_int($s['id'])] ?? []) ?></td>
           </tr>

--- a/Simple-PHP-IPAM/health.php
+++ b/Simple-PHP-IPAM/health.php
@@ -271,8 +271,19 @@ if ($data === null) {
  * ---------------------------------------------------------------------- */
 function health_dot(string $level): string
 {
-    $cls = match ($level) { 'ok' => 'ok', 'warn' => 'warn', 'crit' => 'crit', default => 'warn' };
-    return '<span class="health-dot ' . $cls . '" aria-label="' . e($level) . '"></span>';
+    // C4 / #956: the colored dot is the visible signal; pair it with a
+    // visually-hidden text equivalent so the severity is announced by
+    // screen readers and survives a forced-monochrome rendering. The
+    // aria-label on the dot remains for AT that consume role-described
+    // graphics directly; the .sr-only span is the belt-and-suspenders
+    // text node that always announces.
+    [$cls, $word] = match ($level) {
+        'ok'   => ['ok',   'OK'],
+        'crit' => ['crit', 'Critical'],
+        default => ['warn', 'Warning'],  // 'warn' and any unknown level
+    };
+    return '<span class="health-dot ' . $cls . '" aria-label="' . e($level) . '"></span>'
+         . '<span class="sr-only">' . e($word) . '</span>';
 }
 
 function health_row(string $label, string $value, string $level = ''): void

--- a/Simple-PHP-IPAM/scan_history.php
+++ b/Simple-PHP-IPAM/scan_history.php
@@ -198,12 +198,19 @@ page_header('Scan History');
           <td class="success"><strong><?= $up ?></strong></td>
           <td class="<?= $down > 0 ? 'danger' : 'muted' ?>"><?= $down ?></td>
           <td><?= $tot ?></td>
+          <?php
+            $scanLevel = $pct < 50 ? 'critical' : ($pct < 80 ? 'warning' : 'normal');
+            $scanAria  = "Scan success rate {$pct}%, {$scanLevel} level";
+          ?>
           <td>
-            <div class="util-bar" style="width:120px">
+            <div class="util-bar" style="width:120px" role="meter" aria-label="<?= e($scanAria) ?>" aria-valuenow="<?= $pct ?>" aria-valuemin="0" aria-valuemax="100">
               <div class="util-bar-fill<?= $pct < 80 ? ' util-bar-fill--warn' : '' ?><?= $pct < 50 ? ' util-bar-fill--crit' : '' ?>"
                    data-pct="<?= $pct ?>" style="width:<?= $pct ?>%"></div>
             </div>
             <?= $pct ?>%
+            <?php if ($scanLevel !== 'normal'): ?>
+              <span class="sr-only"><?= e(ucfirst($scanLevel)) ?> level</span>
+            <?php endif; ?>
           </td>
         </tr>
         <?php endforeach ?>

--- a/docs/internal/design-guide.md
+++ b/docs/internal/design-guide.md
@@ -165,6 +165,12 @@ The codebase is largely WCAG 2.1 AA compliant; do not regress it. Concrete rules
 - Tap targets ≥ 44px on mobile (the sidebar overlay, command palette, and primary buttons all already comply).
 - Don't disable focus outlines; theme them via `:focus-visible` instead.
 - Use Heroicons + visible text together for nav items — icon-only nav fails screen readers.
+- **Color is never the sole signal** (WCAG 1.4.1). Every color-coded status must pair with a non-color counterpart — text, icon, bar width, percentage number, or `<span class="sr-only">` for screen-reader announcement. Examples in-tree (closed by #956):
+    - **`.util-bar-fill--warn` / `--crit`** — wrap the `.util-bar` (or `.util-bar-block`) in `role="meter"` with `aria-label` describing the level and `aria-valuenow/min/max`. Add `<span class="sr-only">{Warning|Critical} level</span>` adjacent to the percent number when above threshold.
+    - **`health_dot()` in `health.php`** — already emits `aria-label` on the dot; also emits a sibling `<span class="sr-only">{OK|Warning|Critical}</span>` so the level is announced in plain text.
+    - **`.status-used/reserved/free`** — the surrounding label (`<div class="label">Used</div>`) or column header is the non-color signal; no additional sr-only text needed.
+    - **`.status-badge.status-*`** — the visible text (`used`/`reserved`/`free`) is itself the non-color signal.
+- The `.sr-only` utility class in `app.css` is the standard "visually hidden, accessible to AT" helper. Use it for any screen-reader-only text that pairs with a visual signal.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **#956** (rolls up C4, C17, D5, L4, L10, A20 — color-not-only-signal sweep). After surveying the sites the audit called out, the visible signals (percent number, bar width, label/header text, status word) already satisfy WCAG 1.4.1 for sighted users — color is reinforcement, not the sole signal. The genuine gap was for screen-reader users: the color-coded severity (util-bar warn/crit, health-dot ok/warn/crit) wasn't announced.

## Changes

| File | What |
|---|---|
| `assets/app.css` | New `.sr-only` utility class (standard visually-hidden helper). Side benefit: closes a latent bug in `change_password.php` that referenced `.sr-only` without a definition — two strings intended to be screen-reader-only were visible to all users. |
| `dashboard.php` | Util-bar wrapper gets `role="meter"` + `aria-label` + `aria-valuenow/min/max`. `<span class="sr-only">{Warning|Critical} level</span>` adjacent to percent number when above threshold. Bar visual unchanged. |
| `scan_history.php` | Same treatment (note: scan success rate has inverted semantics — `pct < 80` is warn, `pct < 50` is crit). |
| `health.php` | `health_dot()` emits a sibling `<span class="sr-only">{OK|Warning|Critical}</span>` next to the dot. Belt-and-suspenders with the existing `aria-label`. Dot visual unchanged. |
| `docs/internal/design-guide.md` | "Accessibility" section gains a "color is never the sole signal" entry with worked examples and the `.sr-only` contract. |

## Deliberately NOT changed

- **Dashboard KPI metrics** (`.status-used/reserved/free` numbers under `Used/Reserved/Free` labels) — label text IS the non-color signal.
- **Dashboard subnet table cells** (same status classes, column headers provide the non-color signal).
- **Addresses status badge** (`.status-badge.status-{used,reserved,free}`) — visible text `used`/`reserved`/`free` IS the non-color signal.
- **`subnets.php` map-util bars** — percent populated by JS post-load; would need a JS update to set sr-only text. Out of scope for #956; folds cleanly into a future JS pass.
- **Visible icons on util-bar or health-dot** — would force baseline regen on every dashboard/health screenshot. The `aria`/`sr-only` path is fully WCAG 1.4.1 compliant for assistive tech.

## Test plan

- [x] PHPUnit unit suite — 686/686 pass
- [x] PHPStan L9 — 0 errors (had to flatten the original `match`-after-`match` pattern in `health_dot()` per `match.alwaysTrue` rule)
- [x] PHPCS — clean
- [x] Containerized Playwright against sqlite — **835 / 835 passed** (excluding pre-existing #1311 via grep-invert). Zero visual regression on covered pages.
- [x] `change_password.php`'s two pre-existing-visible `.sr-only` strings are now correctly hidden (page isn't in VR coverage, so no baseline impact).
- [ ] Full 3-driver Playwright gate at v3.36.0 release-PR time.

## Stream A progress

10 of 11 issues addressed (#1256 #1257 #962 #957 #961 #959 #960 #958 #954 #955 #956); 1 remaining (#953 6-step type scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)