### PR TITLE
chore(phpstan): drop dead === '' branches flagged by PHPStan 2.2

### DIFF
--- a/Simple-PHP-IPAM/api.php
+++ b/Simple-PHP-IPAM/api.php
@@ -94,7 +94,7 @@ if ($rawKey === '') {
         $cookiePath = to_str($config['session_cookie_path'] ?? '');
         if ($cookiePath === '') {
             $sn = to_str($_SERVER['SCRIPT_NAME'] ?? '');
-            if ($sn !== '') { $d = str_replace('\\', '/', dirname($sn)); $cookiePath = ($d === '' || $d === '.' || $d === '/') ? '/' : $d . '/'; } else { $cookiePath = '/'; }
+            if ($sn !== '') { $d = str_replace('\\', '/', dirname($sn)); $cookiePath = ($d === '.' || $d === '/') ? '/' : $d . '/'; } else { $cookiePath = '/'; }
         }
         session_set_cookie_params(['lifetime' => 0, 'path' => $cookiePath, 'domain' => '', 'secure' => true, 'httponly' => true, 'samesite' => 'Strict']);
         $sesDir = __DIR__ . '/data/sessions';

--- a/Simple-PHP-IPAM/lib/bootstrap_session.php
+++ b/Simple-PHP-IPAM/lib/bootstrap_session.php
@@ -68,7 +68,10 @@ function ipam_bootstrap_session(array $config): void
         $scriptName = to_str($_SERVER['SCRIPT_NAME'] ?? '');
         if ($scriptName !== '') {
             $dir = str_replace('\\', '/', dirname($scriptName));
-            $configuredCookiePath = ($dir === '' || $dir === '.' || $dir === '/') ? '/' : $dir . '/';
+            // PHPStan 2.2+ (identical.alwaysFalse): dirname() never returns '',
+            // and str_replace on a non-empty input is non-empty too — the only
+            // sentinels here are '.' (current dir) and '/' (root).
+            $configuredCookiePath = ($dir === '.' || $dir === '/') ? '/' : $dir . '/';
         } else {
             $configuredCookiePath = '/';
         }


### PR DESCRIPTION
## Summary

Pre-cursor for dependabot #1328 (phpstan/phpstan 2.1.54 → 2.2.1).

PHPStan 2.2.0 introduced `identical.alwaysFalse`, which catches two defensive-but-dead branches in the cookie-path derivation logic — both in code I did not touch as part of v3.36.1, but both blocking the phpstan bump:

- `Simple-PHP-IPAM/api.php:97`
- `Simple-PHP-IPAM/lib/bootstrap_session.php:71`

Both compute `$dir = str_replace('\\', '/', dirname($scriptName))` where `$scriptName` is already guarded as non-empty. `dirname()` never returns `''` on a non-empty input, and `str_replace` on a non-empty haystack is non-empty too — so the `$dir === ''` arm of the ternary is unreachable. The remaining sentinels (`'.'` for relative scripts, `'/'` for root) are kept; they're the real cases.

## Test plan

- [x] Local verification with phpstan **2.2.1** installed: full `phpstan analyse` clean across 171 files.
- [x] Local verification with current pinned phpstan **2.1.54**: still clean (no regression).
- [x] PHPCS clean on both touched files.
- [x] PHPUnit `Session|Api` filter: 64 passed / 0 failed.
- [x] No behaviour change at runtime — the removed arm was unreachable.
- [ ] Merge this first, then rebase #1328 onto `dev` to land the phpstan bump cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)